### PR TITLE
test(agentcontrol): close workers through shutdown protocol

### DIFF
--- a/internal/agentcontrol/agent_control_test.go
+++ b/internal/agentcontrol/agent_control_test.go
@@ -260,8 +260,12 @@ func TestPostParticipantMessagePublishesOncePerAgent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer c.Close()
-	defer close(client.release)
+	t.Cleanup(func() {
+		c.BeginShutdown()
+		c.StopAll()
+		c.YieldWorkerTerminalFinalizations()
+		c.Close()
+	})
 
 	events := make(chan ParticipantMessage, 1)
 	c.SubscribeParticipantMessages(events)

--- a/internal/appserver/participant_pin_model_test.go
+++ b/internal/appserver/participant_pin_model_test.go
@@ -161,7 +161,7 @@ func TestResidentDMHonorsModelPinOnConfiguredProvider(t *testing.T) {
 	})
 	out := &lockedBuffer{}
 	srv := New(rt, out)
-	t.Cleanup(func() { waitForResidentQuiesce(t, srv) })
+	t.Cleanup(srv.Close)
 	participantID := saveNamedParticipant(t, rt, "andy", "reviewer", "alt-provider:pinned-model")
 	threadID := startDMThreadForPinTest(t, srv, out, participantID)
 
@@ -190,7 +190,7 @@ func TestResidentDMBareModelPinOverridesCurrentProviderModel(t *testing.T) {
 	rt := buildParticipantPinRuntime(t, providers.AdaptStreamClient(currentClient), "fake-provider", nil)
 	out := &lockedBuffer{}
 	srv := New(rt, out)
-	t.Cleanup(func() { waitForResidentQuiesce(t, srv) })
+	t.Cleanup(srv.Close)
 	participantID := saveNamedParticipant(t, rt, "andy", "reviewer", "bare-pinned-model")
 	threadID := startDMThreadForPinTest(t, srv, out, participantID)
 
@@ -212,7 +212,7 @@ func TestResidentDMModelPinRejectsUnconfiguredProvider(t *testing.T) {
 	rt := buildParticipantPinRuntime(t, providers.AdaptStreamClient(currentClient), "fake-provider", nil)
 	out := &lockedBuffer{}
 	srv := New(rt, out)
-	t.Cleanup(func() { waitForResidentQuiesce(t, srv) })
+	t.Cleanup(srv.Close)
 	participantID := saveNamedParticipant(t, rt, "andy", "reviewer", "missing-provider:some-model")
 	threadID := startDMThreadForPinTest(t, srv, out, participantID)
 
@@ -277,7 +277,7 @@ func TestResidentDMModelPinAppliesPinnedModelContextBudget(t *testing.T) {
 	})
 	out := &lockedBuffer{}
 	srv := New(rt, out)
-	t.Cleanup(func() { waitForResidentQuiesce(t, srv) })
+	t.Cleanup(srv.Close)
 
 	// Precondition: the global runner has no window, so any non-zero window on
 	// the thread runner can only come from the pinned model's resolved budget.

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -136,6 +136,7 @@ type Manager struct {
 type processHandle struct {
 	mu    sync.Mutex
 	stdin io.WriteCloser
+	done  chan struct{}
 }
 
 func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
@@ -296,12 +297,19 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 	p.Status = StatusRunning
 	p.UpdatedAt = time.Now()
 	_ = m.save(p)
-	m.handles[id] = &processHandle{stdin: stdin}
+	handle := &processHandle{stdin: stdin, done: make(chan struct{})}
+	m.handles[id] = handle
 	m.publish(Event{Type: EventStarted, Process: *p})
 	if opt.TTY {
-		go m.waitPTY(id, cmd, logf, ptyFile)
+		go func() {
+			defer close(handle.done)
+			m.waitPTY(id, cmd, logf, ptyFile)
+		}()
 	} else {
-		go m.wait(id, cmd, logf)
+		go func() {
+			defer close(handle.done)
+			m.wait(id, cmd, logf)
+		}()
 	}
 	return p, nil
 }
@@ -621,8 +629,10 @@ func (m *Manager) Stop(id string) (*Process, error) {
 		m.mu.Unlock()
 		return nil, err
 	}
+	handle := m.handles[id]
 	if p.Status == StatusStopped || p.Status == StatusFailed {
 		m.mu.Unlock()
+		waitForProcessMonitor(handle)
 		return p, nil
 	}
 	running, err := processMatchesRecord(p)
@@ -648,6 +658,7 @@ func (m *Manager) Stop(id string) (*Process, error) {
 		}
 		m.mu.Unlock()
 		m.publish(Event{Type: EventStopped, Cause: EventCauseRequestedStop, Process: *p})
+		waitForProcessMonitor(handle)
 		return p, nil
 	}
 	p.Status = StatusStopping
@@ -662,6 +673,9 @@ func (m *Manager) Stop(id string) (*Process, error) {
 	}
 	cur, stopped, err := m.waitForStop(id, time.Now().Add(2*time.Second))
 	if err != nil || stopped {
+		if stopped {
+			waitForProcessMonitor(handle)
+		}
 		return cur, err
 	}
 
@@ -670,7 +684,11 @@ func (m *Manager) Stop(id string) (*Process, error) {
 		return cur, err
 	}
 	if !running {
-		return m.reconcileStopped(id)
+		cur, err := m.reconcileStopped(id)
+		if err == nil {
+			waitForProcessMonitor(handle)
+		}
+		return cur, err
 	}
 	if err := syscall.Kill(-cur.PGID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return cur, fmt.Errorf("kill process group %d: %w", cur.PGID, err)
@@ -682,7 +700,15 @@ func (m *Manager) Stop(id string) (*Process, error) {
 	if !stopped {
 		return cur, fmt.Errorf("process group %d did not stop after SIGKILL", cur.PGID)
 	}
+	waitForProcessMonitor(handle)
 	return cur, nil
+}
+
+func waitForProcessMonitor(handle *processHandle) {
+	if handle == nil || handle.done == nil {
+		return
+	}
+	<-handle.done
 }
 
 func (m *Manager) waitForStop(id string, deadline time.Time) (*Process, bool, error) {


### PR DESCRIPTION
## Summary

- close the participant-message test worker through the production shutdown protocol
- remove a scheduler-dependent terminal-transition cleanup race

## Validation

- targeted test passed 1000 consecutive runs
- agentcontrol package passed
- make check-go test-go build-go passed

This fixes the Go CI timeout observed on main run 29446106844.