### PR TITLE
fix(agentcontrol): deduplicate registered spawn reservations

### DIFF
--- a/internal/agentcontrol/agent_control.go
+++ b/internal/agentcontrol/agent_control.go
@@ -84,23 +84,23 @@ type AgentControl struct {
 	turnUltra atomic.Bool
 	// treeFrozen gates nested-result wakes between turn/interrupt's
 	// FreezeWorkerTree and the next user turn's ResolveFrozenWorkerTree.
-	treeFrozen    atomic.Bool
-	shutdownMu    sync.RWMutex
-	stopping      bool
-	spawnSlotMu   sync.Mutex
-	spawnSlots    int
-	queueStartMu  sync.Mutex
-	queueStarted  bool
-	queueStopped  bool
-	queueDrainMu  sync.Mutex
-	queueMu       sync.Mutex
-	queued        []preparedSpawn
-	queueRetryMu  sync.Mutex
-	queueRetrying bool
-	statusCh      chan subagent.Notification
-	statusStop    chan struct{}
-	statusDone    chan struct{}
-	closeOnce     sync.Once
+	treeFrozen        atomic.Bool
+	shutdownMu        sync.RWMutex
+	stopping          bool
+	spawnSlotMu       sync.Mutex
+	spawnReservations map[*spawnSlotReservation]struct{}
+	queueStartMu      sync.Mutex
+	queueStarted      bool
+	queueStopped      bool
+	queueDrainMu      sync.Mutex
+	queueMu           sync.Mutex
+	queued            []preparedSpawn
+	queueRetryMu      sync.Mutex
+	queueRetrying     bool
+	statusCh          chan subagent.Notification
+	statusStop        chan struct{}
+	statusDone        chan struct{}
+	closeOnce         sync.Once
 
 	workerTransitionMu                    sync.Mutex
 	workerTransitions                     map[string]*sync.Mutex
@@ -893,7 +893,7 @@ func (c *AgentControl) Spawn(ctx context.Context, req SpawnRequest) (spawnResult
 	// the capability its spawner had, not whatever the session says at launch.
 	ultra := c.effectiveSpawnUltra(req.ParentID)
 
-	spawnSlot, admitted := c.tryReserveSpawnSlot()
+	spawnSlot, admitted := c.tryReserveSpawnSlot(workerID)
 	if !admitted && req.Synchronous {
 		return nil, fmt.Errorf("max parallel sub-agents reached (%d). Wait for one to complete or use async spawn so the task can queue.", c.maxParallel)
 	}
@@ -1304,7 +1304,7 @@ func (c *AgentControl) Fork(ctx context.Context, req ForkRequest, parentHistory 
 	// fresh spawn (turn snapshot for the root, stored value for a worker).
 	ultra := c.effectiveSpawnUltra(req.ParentID)
 
-	spawnSlot, admitted := c.tryReserveSpawnSlot()
+	spawnSlot, admitted := c.tryReserveSpawnSlot(workerID)
 	if !admitted {
 		if req.Synchronous {
 			return nil, fmt.Errorf("max parallel sub-agents reached (%d). Wait for one to complete or use async spawn so the task can queue.", c.maxParallel)
@@ -2250,7 +2250,7 @@ func (c *AgentControl) maybeStartQueued(ctx context.Context) {
 		if !c.hasQueuedSpawns() {
 			return
 		}
-		spawnSlot, admitted := c.tryReserveSpawnSlot()
+		spawnSlot, admitted := c.tryReserveSpawnSlot("")
 		if !admitted {
 			return
 		}
@@ -2259,6 +2259,7 @@ func (c *AgentControl) maybeStartQueued(ctx context.Context) {
 			spawnSlot.release()
 			return
 		}
+		spawnSlot.bindWorker(prepared.WorkerID)
 		outcome, err := func() (queuedSpawnStartOutcome, error) {
 			defer spawnSlot.release()
 			return c.startQueuedSpawn(ctx, prepared)

--- a/internal/agentcontrol/spawn_slot.go
+++ b/internal/agentcontrol/spawn_slot.go
@@ -2,7 +2,10 @@ package agentcontrol
 
 import (
 	"context"
+	"strings"
 	"sync"
+
+	"github.com/blueberrycongee/wuu/internal/subagent"
 )
 
 // spawnSlotReservation bridges the process-local preparation window before
@@ -12,21 +15,61 @@ import (
 // durable worker ID. Without this reservation, concurrent callers on one
 // control can all observe the same free slot and oversubscribe maxParallel.
 type spawnSlotReservation struct {
-	control *AgentControl
-	once    sync.Once
+	control  *AgentControl
+	workerID string
+	once     sync.Once
 }
 
-func (c *AgentControl) tryReserveSpawnSlot() (*spawnSlotReservation, bool) {
+func (c *AgentControl) tryReserveSpawnSlot(workerID string) (*spawnSlotReservation, bool) {
 	if c == nil || c.manager == nil {
 		return nil, false
 	}
 	c.spawnSlotMu.Lock()
 	defer c.spawnSlotMu.Unlock()
-	if c.manager.CountRunning()+c.spawnSlots >= c.maxParallel {
+
+	// A reservation covers only the preparation window before Manager.Spawn
+	// registers the worker. Build one manager snapshot so a registered worker
+	// and its not-yet-released reservation are never counted twice.
+	registered := make(map[string]subagent.Status)
+	running := 0
+	for _, snap := range c.manager.List() {
+		registered[snap.ID] = snap.Status
+		if snap.Status == subagent.StatusRunning {
+			running++
+		}
+	}
+	pending := 0
+	for reservation := range c.spawnReservations {
+		id := strings.TrimSpace(reservation.workerID)
+		if id == "" {
+			pending++
+			continue
+		}
+		if _, exists := registered[id]; !exists {
+			pending++
+		}
+	}
+	if running+pending >= c.maxParallel {
 		return nil, false
 	}
-	c.spawnSlots++
-	return &spawnSlotReservation{control: c}, true
+	reservation := &spawnSlotReservation{control: c, workerID: strings.TrimSpace(workerID)}
+	if c.spawnReservations == nil {
+		c.spawnReservations = make(map[*spawnSlotReservation]struct{})
+	}
+	c.spawnReservations[reservation] = struct{}{}
+	return reservation, true
+}
+
+func (r *spawnSlotReservation) bindWorker(workerID string) {
+	if r == nil || r.control == nil {
+		return
+	}
+	c := r.control
+	c.spawnSlotMu.Lock()
+	if _, active := c.spawnReservations[r]; active {
+		r.workerID = strings.TrimSpace(workerID)
+	}
+	c.spawnSlotMu.Unlock()
 }
 
 func (r *spawnSlotReservation) release() {
@@ -44,9 +87,7 @@ func (r *spawnSlotReservation) releaseWithQueueKick(kickQueued bool) {
 	r.once.Do(func() {
 		c := r.control
 		c.spawnSlotMu.Lock()
-		if c.spawnSlots > 0 {
-			c.spawnSlots--
-		}
+		delete(c.spawnReservations, r)
 		c.spawnSlotMu.Unlock()
 
 		// Direct preparation uses kickQueued because a very short worker can


### PR DESCRIPTION
## Summary

- count one Manager snapshot when checking subagent capacity
- stop double-counting workers whose preparation reservation has already registered in Manager
- bind queued reservations to their durable worker id before launch

## Validation

- failing synchronous reservation test passed 500 consecutive runs
- agentcontrol package passed 10 consecutive runs
- make check-go test-go build-go passed

This fixes the Go CI failure observed on main run 29449206698.