### PR TITLE
Ship desktop, runtime, and automation updates

### DIFF
--- a/clients/core/package-lock.json
+++ b/clients/core/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.0",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
         "vitest": "^4.0.17"
       },
       "engines": {
@@ -445,6 +445,346 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1135,17 +1475,38 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/clients/core/package.json
+++ b/clients/core/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.0",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.0.17"
   }
 }

--- a/clients/mobile/package-lock.json
+++ b/clients/mobile/package-lock.json
@@ -25,7 +25,8 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
-        "typescript": "~6.0.3",
+        "@typescript/native": "npm:typescript@~7.0.2",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
         "vitest": "^4.0.17"
       },
       "engines": {
@@ -36,7 +37,7 @@
       "name": "@wuu/protocol",
       "version": "0.0.0",
       "devDependencies": {
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=22"
@@ -52,7 +53,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.0",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
         "vitest": "^4.0.17"
       },
       "engines": {
@@ -2229,6 +2230,397 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@typescript/native": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
@@ -6678,17 +7070,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/ua-parser-js": {

--- a/clients/mobile/package.json
+++ b/clients/mobile/package.json
@@ -32,8 +32,9 @@
     "react-native-web": "^0.21.2"
   },
   "devDependencies": {
+    "@typescript/native": "npm:typescript@~7.0.2",
     "@types/react": "~19.2.2",
-    "typescript": "~6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.0.17"
   }
 }

--- a/cmd/wuu/main.go
+++ b/cmd/wuu/main.go
@@ -2068,10 +2068,6 @@ func runAppServer(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := rt.StartCronScheduler(); err != nil {
-		_, _ = rt.Cleanup()
-		return err
-	}
 	defer func() {
 		_, _ = rt.Cleanup()
 	}()

--- a/cmd/wuu/remote.go
+++ b/cmd/wuu/remote.go
@@ -203,10 +203,6 @@ func runRemoteHost(args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := rt.StartCronScheduler(); err != nil {
-		_, _ = rt.Cleanup()
-		return err
-	}
 	defer func() { _, _ = rt.Cleanup() }()
 
 	opts := host.Options{

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -37,7 +37,7 @@
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "jsdom": "^25.0.0",
-        "typescript": "^5.7.2",
+        "typescript": "^7.0.2",
         "vite": "^7.3.6",
         "vitest": "^3.2.7"
       },
@@ -2417,6 +2417,346 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -8748,17 +9088,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -98,7 +98,7 @@
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "jsdom": "^25.0.0",
-    "typescript": "^5.7.2",
+    "typescript": "^7.0.2",
     "vite": "^7.3.6",
     "vitest": "^3.2.7"
   }

--- a/desktop/src/renderer/ChatThreadView.test.tsx
+++ b/desktop/src/renderer/ChatThreadView.test.tsx
@@ -1107,6 +1107,7 @@ type IntersectionCallback = (
 class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null = null;
   readonly rootMargin: string = "";
+  readonly scrollMargin: string = "";
   readonly thresholds: ReadonlyArray<number> = [];
   observedNodes: Element[] = [];
   callback: IntersectionCallback;

--- a/desktop/src/renderer/EnvironmentPanel.tsx
+++ b/desktop/src/renderer/EnvironmentPanel.tsx
@@ -115,8 +115,6 @@ export function EnvironmentPanel({
   const hasChanges = Boolean(gitStatus?.is_repo && (gitStatus.dirty_count > 0 || diff.files > 0));
   const branchLabel = gitStatus?.is_repo ? gitStatus.branch ?? "detached" : "非 Git 仓库";
   const prDisabled = Boolean(pullRequestDisabledReason && !gitStatus?.pr_url);
-  const planTotal = planUpdate?.plan.length ?? 0;
-  const planCompleted = planUpdate?.plan.filter((item) => item.status === "completed").length ?? 0;
 
   function toggleMenu(menu: Exclude<EnvironmentPanelMenu, null>): void {
     onSetActiveMenu(activeMenu === menu ? null : menu);
@@ -130,21 +128,6 @@ export function EnvironmentPanel({
       aria-hidden={motionState === "closing" ? true : undefined}
     >
       <div className="environment-panel-header">
-        <div className="environment-panel-title">
-          {planUpdate ? (
-            <>
-              <h2>进度</h2>
-              <span
-                className="environment-panel-counter"
-                aria-label={`已完成 ${planCompleted} 项，共 ${planTotal} 项`}
-              >
-                {planCompleted}/{planTotal}
-              </span>
-            </>
-          ) : (
-            <h2>环境信息</h2>
-          )}
-        </div>
         <div className="environment-panel-actions">
           <button className="icon-button" type="button" aria-label="关闭环境信息" onClick={onClose}>
             <X className="icon" />
@@ -153,8 +136,6 @@ export function EnvironmentPanel({
       </div>
 
       {planUpdate ? <EnvironmentPlanSection planUpdate={planUpdate} /> : null}
-
-      {planUpdate ? <div className="environment-section-heading">环境信息</div> : null}
 
       <div className="environment-panel-body">
         <button

--- a/desktop/src/renderer/EnvironmentPanelLayout.test.ts
+++ b/desktop/src/renderer/EnvironmentPanelLayout.test.ts
@@ -19,6 +19,17 @@ function cssRule(selector: string): string {
 }
 
 describe("environment panel subagent rows", () => {
+  it("overlays the close button beside the first content row", () => {
+    const header = cssRule(".environment-panel-header");
+    expect(header).toMatch(/position:\s*absolute/);
+    expect(header).toMatch(/top:\s*15px/);
+    expect(header).toMatch(/right:\s*14px/);
+    expect(cssRule(".environment-plan-item:first-child")).toMatch(/padding-right:\s*34px/);
+    expect(
+      cssRule(".environment-panel-header + .environment-panel-body .environment-row:first-child"),
+    ).toMatch(/padding-right:\s*40px/);
+  });
+
   it("keeps the status label on a stable right-side axis", () => {
     expect(cssRule(".subagent-row")).toMatch(
       /grid-template-columns:\s*minmax\(0,\s*1fr\)/,

--- a/desktop/src/renderer/EnvironmentPanelLayout.test.ts
+++ b/desktop/src/renderer/EnvironmentPanelLayout.test.ts
@@ -29,12 +29,27 @@ describe("environment panel subagent rows", () => {
     expect(main).toMatch(
       /grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(42px,\s*auto\)/,
     );
-    expect(main).toMatch(/padding:\s*0 8px 0 12px/);
+    expect(main).toMatch(/padding:\s*0 8px/);
 
     const status = cssRule(".subagent-row-status");
     expect(status).toMatch(/justify-content:\s*end/);
     expect(status).toMatch(/min-width:\s*42px/);
     expect(status).toMatch(/background:\s*transparent/);
+  });
+
+  it("aligns a larger avatar with the regular environment row icons", () => {
+    const avatar = cssRule(".subagent-row .participant-chip-avatar");
+    expect(avatar).toMatch(/width:\s*20px/);
+    expect(avatar).toMatch(/height:\s*20px/);
+    expect(cssRule(".environment-row")).toMatch(/padding:\s*0 8px/);
+    expect(cssRule(".subagent-row-main")).toMatch(/padding:\s*0 8px/);
+  });
+
+  it("keeps the running status dot static", () => {
+    expect(cssRule(".subagent-row.running .subagent-row-status::before")).not.toMatch(
+      /animation/,
+    );
+    expect(environmentCSS).not.toMatch(/@keyframes\s+subagent-status-pulse/);
   });
 
   it("puts keyboard focus on the row instead of the inner button outline", () => {

--- a/desktop/src/renderer/JumpToLatestPill.test.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.test.tsx
@@ -152,10 +152,19 @@ function installMockResizeObserver(): MockResizeObserverRecord[] {
   return records;
 }
 
-function flushResizeObservers(records: MockResizeObserverRecord[]): void {
+function flushResizeObservers(
+  records: MockResizeObserverRecord[],
+  target?: Element,
+): void {
   for (const record of records) {
-    const entries = Array.from(record.observed).map((target) => ({
-      target,
+    const observedTargets = target
+      ? Array.from(record.observed).filter((observed) => observed === target)
+      : Array.from(record.observed);
+    if (observedTargets.length === 0) {
+      continue;
+    }
+    const entries = observedTargets.map((observed) => ({
+      target: observed,
       contentRect: {
         x: 0,
         y: 0,
@@ -227,6 +236,32 @@ describe("JumpToLatestPill", () => {
     act(() => {
       setScrollTop(560); // 40px from the bottom, inside the 80px threshold
       node.dispatchEvent(new Event("scroll"));
+    });
+    expect(host.querySelector(".jump-to-latest-pill")).toBeNull();
+  });
+
+  it("clears a transient scroll-away state when folded content settles", () => {
+    const resizeObservers = installMockResizeObserver();
+    const geometry = {
+      scrollHeight: 500,
+      clientHeight: 600,
+      scrollTop: 0,
+    };
+    const { node } = scrollContainer(geometry);
+    const content = document.createElement("div");
+    node.appendChild(content);
+    const host = mountPill(node);
+    expect(host.querySelector(".jump-to-latest-pill")).toBeNull();
+
+    act(() => {
+      geometry.scrollHeight = 900;
+      node.dispatchEvent(new Event("scroll"));
+    });
+    expect(host.querySelector(".jump-to-latest-pill")).not.toBeNull();
+
+    act(() => {
+      geometry.scrollHeight = 500;
+      flushResizeObservers(resizeObservers, content);
     });
     expect(host.querySelector(".jump-to-latest-pill")).toBeNull();
   });

--- a/desktop/src/renderer/JumpToLatestPill.test.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.test.tsx
@@ -266,7 +266,38 @@ describe("JumpToLatestPill", () => {
     expect(host.querySelector(".jump-to-latest-pill")).toBeNull();
   });
 
-  it("anchors above the composer via a body portal when bottomAnchor is given", () => {
+  it("observes content nodes inserted after the pill mounts", async () => {
+    const resizeObservers = installMockResizeObserver();
+    const geometry = {
+      scrollHeight: 500,
+      clientHeight: 600,
+      scrollTop: 0,
+    };
+    const { node } = scrollContainer(geometry);
+    const host = mountPill(node);
+    const lateContent = document.createElement("div");
+
+    await act(async () => {
+      node.appendChild(lateContent);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      geometry.scrollHeight = 900;
+      flushResizeObservers(resizeObservers, lateContent);
+    });
+    expect(host.querySelector(".jump-to-latest-pill")).not.toBeNull();
+
+    act(() => {
+      geometry.scrollHeight = 500;
+      flushResizeObservers(resizeObservers, lateContent);
+    });
+    expect(host.querySelector(".jump-to-latest-pill")).toBeNull();
+  });
+
+  it("tracks the visual composer frame and disappears when its anchor is removed", () => {
+    vi.useFakeTimers();
+    const resizeObservers = installMockResizeObserver();
     const { node } = scrollContainer({
       scrollHeight: 1000,
       clientHeight: 400,
@@ -280,6 +311,10 @@ describe("JumpToLatestPill", () => {
     document.body.appendChild(anchor);
     mountedContainers.push(anchor);
     stubRect(anchor, { left: 100, top: 700, bottom: 780, width: 600, height: 80 });
+    const frame = document.createElement("div");
+    frame.className = "composer-frame";
+    anchor.appendChild(frame);
+    stubRect(frame, { left: 100, top: 620, bottom: 780, width: 600, height: 160 });
     Object.defineProperty(window, "innerHeight", {
       configurable: true,
       value: 900,
@@ -288,10 +323,11 @@ describe("JumpToLatestPill", () => {
     const host = document.createElement("div");
     node.appendChild(host);
     const root = createRoot(host);
+    const containerRef = { current: node };
     act(() => {
       root.render(
         createElement(JumpToLatestPill, {
-          containerRef: { current: node },
+          containerRef,
           bottomAnchor: anchor,
         }),
       );
@@ -306,8 +342,31 @@ describe("JumpToLatestPill", () => {
     expect(pill).not.toBeNull();
     // left = container.left + container.width / 2 = 100 + 300
     expect(pill?.style.left).toBe("400px");
-    // bottom = innerHeight - anchor.top + gap(12) = 900 - 700 + 12
-    expect(pill?.style.bottom).toBe("212px");
+    // Expanded composers move their frame above the outer footer. Position
+    // from that visual top, not from the unchanged footer box.
+    expect(pill?.style.bottom).toBe("292px");
+    expect(
+      resizeObservers.some((observer) => observer.observed.has(frame)),
+    ).toBe(true);
+
+    act(() => {
+      stubRect(frame, { left: 100, top: 560, bottom: 780, width: 600, height: 220 });
+      flushResizeObservers(resizeObservers, frame);
+      vi.runAllTimers();
+    });
+    expect(pill?.style.bottom).toBe("352px");
+
+    act(() => {
+      root.render(
+        createElement(JumpToLatestPill, {
+          containerRef,
+          bottomAnchor: null,
+        }),
+      );
+    });
+    expect(
+      document.body.querySelector(".jump-to-latest-pill-anchored"),
+    ).toBeNull();
   });
 
   it("notifies parent via onScrolledAwayChange when the scroll-away boolean flips", () => {

--- a/desktop/src/renderer/JumpToLatestPill.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.tsx
@@ -76,6 +76,7 @@ type JumpToLatestPillProps = {
 
 const DEFAULT_THRESHOLD_PX = 80;
 const PILL_BOTTOM_GAP_PX = 12;
+const COMPOSER_FRAME_SELECTOR = ".composer-frame";
 
 type PillPosition = { left: number; bottom: number };
 
@@ -140,10 +141,21 @@ export function JumpToLatestPill({
     if (resizeObserver) {
       observeAutoFollowResizeTargets(node, resizeObserver);
     }
+    const childObserver =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(() => {
+            if (resizeObserver) {
+              observeAutoFollowResizeTargets(node, resizeObserver);
+            }
+            scheduleUpdate();
+          })
+        : undefined;
+    childObserver?.observe(node, { childList: true });
 
     return () => {
       resizeSettleUpdate.cancel();
       node.removeEventListener("scroll", scheduleUpdate);
+      childObserver?.disconnect();
       resizeObserver?.disconnect();
     };
   }, [containerRef, threshold]);
@@ -154,7 +166,9 @@ export function JumpToLatestPill({
       return;
     }
     const containerRect = container.getBoundingClientRect();
-    const anchorRect = bottomAnchor.getBoundingClientRect();
+    const visualAnchor =
+      bottomAnchor.querySelector<HTMLElement>(COMPOSER_FRAME_SELECTOR) ?? bottomAnchor;
+    const anchorRect = visualAnchor.getBoundingClientRect();
     setPosition({
       // Centered on the scroll container's visible width (issue #5 intent).
       left: containerRect.left + containerRect.width / 2,
@@ -169,9 +183,10 @@ export function JumpToLatestPill({
 
   // Measured positioning for the anchored (portaled) variant. Recomputes on
   // scroll, window resize, and container/composer resize (typing grows the
-  // composer, moving its top edge).
+  // composer, moving its top edge). The composer frame is observed separately
+  // because expanded mode moves it upward without growing the outer anchor.
   useEffect(() => {
-    if (!anchored || !scrolledAway) {
+    if (!anchored || !scrolledAway || !bottomAnchor) {
       return undefined;
     }
     const resizeSettleRecompute =
@@ -208,9 +223,23 @@ export function JumpToLatestPill({
     if (container) {
       resizeObserver?.observe(container);
     }
-    if (bottomAnchor) {
+    const observeAnchorTargets = (): void => {
       resizeObserver?.observe(bottomAnchor);
-    }
+      const visualAnchor =
+        bottomAnchor.querySelector<HTMLElement>(COMPOSER_FRAME_SELECTOR);
+      if (visualAnchor) {
+        resizeObserver?.observe(visualAnchor);
+      }
+    };
+    observeAnchorTargets();
+    const anchorChildObserver =
+      typeof MutationObserver !== "undefined"
+        ? new MutationObserver(() => {
+            observeAnchorTargets();
+            schedule();
+          })
+        : undefined;
+    anchorChildObserver?.observe(bottomAnchor, { childList: true, subtree: true });
     return () => {
       resizeSettleRecompute.cancel();
       if (frame) {
@@ -218,6 +247,7 @@ export function JumpToLatestPill({
       }
       container?.removeEventListener("scroll", schedule);
       window.removeEventListener("resize", schedule);
+      anchorChildObserver?.disconnect();
       resizeObserver?.disconnect();
     };
   }, [anchored, bottomAnchor, scrolledAway, recomputePosition, containerRef]);
@@ -256,7 +286,7 @@ export function JumpToLatestPill({
   );
 
   if (anchored) {
-    if (!position) {
+    if (!bottomAnchor || !position) {
       return null;
     }
     return createPortal(

--- a/desktop/src/renderer/JumpToLatestPill.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.tsx
@@ -5,6 +5,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { observeAutoFollowResizeTargets } from "./AutoFollowScroll";
 import {
   createWindowResizeSettleScheduler,
   isWindowResizing,
@@ -125,16 +126,20 @@ export function JumpToLatestPill({
     scheduleUpdate();
     node.addEventListener("scroll", scheduleUpdate, { passive: true });
 
-    // Re-evaluate on container resize. A thread-panel drag mutates the
-    // scroll container's `clientHeight`; without this listener the
-    // pill would stay hidden or shown based on the pre-resize distance.
+    // Re-evaluate on container and content resize. A thread-panel drag mutates
+    // the container's `clientHeight`, while expanding or collapsing a fold
+    // mutates its child's height and therefore the container's `scrollHeight`.
+    // Observing both prevents a transient fold layout from leaving the pill
+    // stuck in its pre-settle state.
     // Guarded: test environments (jsdom) have no ResizeObserver, and the
     // pill degrades gracefully to scroll-event-only updates without it.
     const resizeObserver =
       typeof ResizeObserver !== "undefined"
         ? new ResizeObserver(scheduleUpdate)
         : undefined;
-    resizeObserver?.observe(node);
+    if (resizeObserver) {
+      observeAutoFollowResizeTargets(node, resizeObserver);
+    }
 
     return () => {
       resizeSettleUpdate.cancel();

--- a/desktop/src/renderer/ProcessSurface.test.tsx
+++ b/desktop/src/renderer/ProcessSurface.test.tsx
@@ -358,6 +358,95 @@ describe("ProcessSurface", () => {
     expect(count?.textContent).toBe("3");
   });
 
+  it("condenses many mixed tool calls into one bounded summary sentence", () => {
+    const { container } = render({
+      processItems: [
+        {
+          id: "search-1",
+          type: "tool_call",
+          name: "grep",
+          status: "completed",
+          arguments: JSON.stringify({ pattern: "cache_read" }),
+        },
+        {
+          id: "search-2",
+          type: "tool_call",
+          name: "grep",
+          status: "completed",
+          arguments: JSON.stringify({ pattern: "cache_write" }),
+        },
+        makeReadFile("read-1", "session.ts"),
+        makeReadFile("read-2", "storage.ts"),
+        {
+          id: "command-1",
+          type: "tool_call",
+          name: "bash",
+          status: "completed",
+          arguments: JSON.stringify({ command: "sqlite3 sessions.db" }),
+        },
+        {
+          id: "schedule-1",
+          type: "tool_call",
+          name: "cron",
+          status: "completed",
+          arguments: JSON.stringify({ action: "list" }),
+        },
+      ],
+      streaming: false,
+    });
+
+    const summary = container.querySelector(".process-surface-summary-line");
+    expect(summary?.textContent).toBe(
+      "已完成 6 项操作，包括搜索、查看文件等",
+    );
+    expect(summary?.querySelectorAll(".process-surface-segment")).toHaveLength(0);
+  });
+
+  it("keeps a useful count when many calls are all the same kind", () => {
+    const { container } = render({
+      processItems: [
+        makeReadFile("tool-1", "a.ts"),
+        makeReadFile("tool-2", "b.ts"),
+        makeReadFile("tool-3", "c.ts"),
+        makeReadFile("tool-4", "d.ts"),
+      ],
+      streaming: false,
+    });
+
+    expect(
+      container.querySelector(".process-surface-summary-line")?.textContent,
+    ).toBe("查看 4 个文件");
+  });
+
+  it("reports the current phase instead of appending reasoning to a long summary", () => {
+    const { container } = render({
+      processItems: [
+        makeReadFile("read-1", "a.ts"),
+        makeReadFile("read-2", "b.ts"),
+        {
+          id: "search-1",
+          type: "tool_call",
+          name: "grep",
+          status: "completed",
+          arguments: JSON.stringify({ pattern: "cache" }),
+        },
+        {
+          id: "command-1",
+          type: "tool_call",
+          name: "bash",
+          status: "completed",
+          arguments: JSON.stringify({ command: "npm test" }),
+        },
+        makeReasoning("reason-1", "checking results", "in_progress"),
+      ],
+      streaming: true,
+    });
+
+    expect(
+      container.querySelector(".process-surface-summary-line")?.textContent,
+    ).toBe("完成 4 项操作后，正在思考");
+  });
+
   it("marks the count is-changing for ~180ms when the value changes", async () => {
     const { container } = render({
       processItems: [

--- a/desktop/src/renderer/ProcessSurface.tsx
+++ b/desktop/src/renderer/ProcessSurface.tsx
@@ -74,8 +74,55 @@ const TOOL_ACTIVITY_ITEM_TYPES = new Set<string>([
   "collab_agent_tool_call",
 ]);
 
+// Mixed activity becomes harder to scan than a sentence once a group reaches
+// this size. Same-kind groups keep their more useful count summary.
+const CONDENSED_SUMMARY_MIN_TOOL_COUNT = 4;
+
+const PROCESS_KIND_LABELS: Record<ToolActivityProcessSegment["kind"], string> = {
+  edit: "更新文件",
+  create: "创建文件",
+  search: "搜索",
+  read: "查看文件",
+  list: "查看目录",
+  command: "执行检查",
+  agent: "处理子任务",
+  plan: "更新计划",
+  interaction: "等待回复",
+  schedule: "管理定时任务",
+  browser: "操作页面",
+  skill: "加载技能",
+  context: "整理上下文",
+  unknown: "使用工具",
+};
+
 function isToolActivityItem(item: ThreadItem): boolean {
   return TOOL_ACTIVITY_ITEM_TYPES.has(item.type);
+}
+
+function condensedToolActivityText(
+  segments: ToolActivityProcessSegment[],
+  toolCount: number,
+  reasoningStreaming: boolean,
+): string {
+  const failed = segments.some((segment) => segment.status === "failed");
+  const running = segments.some((segment) => segment.status === "running");
+  if (reasoningStreaming && !failed && !running) {
+    return `完成 ${toolCount} 项操作后，正在思考`;
+  }
+  if (failed) {
+    return `共处理 ${toolCount} 项操作，其中有未完成项`;
+  }
+
+  const labels = Array.from(
+    new Set(segments.map((segment) => PROCESS_KIND_LABELS[segment.kind])),
+  );
+  const shownLabels = labels.slice(0, 2);
+  const categoryText =
+    labels.length > 2
+      ? `${shownLabels.join("、")}等`
+      : shownLabels.join("和");
+  const statusText = running ? "正在处理" : "已完成";
+  return `${statusText} ${toolCount} 项操作，包括${categoryText}`;
 }
 
 export function ProcessSurface({
@@ -97,6 +144,9 @@ export function ProcessSurface({
   const reasoningStreaming =
     streaming &&
     reasoningItems.some((item) => item.status === "in_progress");
+  const useCondensedSummary =
+    toolItems.length >= CONDENSED_SUMMARY_MIN_TOOL_COUNT &&
+    toolSegments.length > 1;
   const activeGrayText = active ?? streaming;
 
   // Details are opt-in. The running row itself should stay compact by
@@ -133,14 +183,25 @@ export function ProcessSurface({
 
   const summaryLine = (
     <span className="process-surface-summary-line">
-      {toolSegments.map((segment, index) => (
-        <ProcessSurfaceSegmentView
-          key={segment.id}
-          segment={segment}
-          separator={index > 0}
+      {useCondensedSummary ? (
+        <AnimatedProcessText
+          className="process-surface-condensed-summary"
+          text={condensedToolActivityText(
+            toolSegments,
+            toolItems.length,
+            reasoningStreaming,
+          )}
         />
-      ))}
-      {hasReasoning ? (
+      ) : (
+        toolSegments.map((segment, index) => (
+          <ProcessSurfaceSegmentView
+            key={segment.id}
+            segment={segment}
+            separator={index > 0}
+          />
+        ))
+      )}
+      {hasReasoning && !useCondensedSummary ? (
         <span className="process-surface-segment process-surface-reasoning-segment">
           {toolSegments.length > 0 ? (
             <span className="process-surface-separator">·</span>

--- a/desktop/src/renderer/ToolActivity.test.ts
+++ b/desktop/src/renderer/ToolActivity.test.ts
@@ -238,6 +238,77 @@ describe("buildToolActivityProcessSegments", () => {
       },
     ]);
   });
+
+  it("uses action-oriented copy for repeated searches and scheduled tasks", () => {
+    const segments = buildToolActivityProcessSegments([
+      {
+        id: "search-1",
+        type: "tool_call",
+        name: "grep",
+        status: "completed",
+        arguments: JSON.stringify({ pattern: "cache_read" }),
+      },
+      {
+        id: "search-2",
+        type: "tool_call",
+        name: "grep",
+        status: "completed",
+        arguments: JSON.stringify({ pattern: "cache_write" }),
+      },
+      {
+        id: "schedule-1",
+        type: "tool_call",
+        name: "cron",
+        status: "completed",
+        arguments: JSON.stringify({ action: "list" }),
+      },
+    ] satisfies ThreadItem[]);
+
+    expect(segments).toMatchObject([
+      {
+        kind: "search",
+        countPrefix: "搜索 ",
+        count: 2,
+        countSuffix: " 次",
+      },
+      {
+        kind: "schedule",
+        text: "查看定时任务",
+      },
+    ]);
+  });
+
+  it("describes recognizable data-check commands by their purpose", () => {
+    const [timeSegment] = buildToolActivityProcessSegments([
+      {
+        id: "time-1",
+        type: "tool_call",
+        name: "bash",
+        status: "completed",
+        arguments: JSON.stringify({ command: "date '+%H:%M'" }),
+      },
+    ] satisfies ThreadItem[]);
+    expect(timeSegment).toMatchObject({
+      kind: "command",
+      text: "查看本地时间",
+    });
+
+    const [databaseSegment] = buildToolActivityProcessSegments([
+      {
+        id: "database-1",
+        type: "tool_call",
+        name: "bash",
+        status: "completed",
+        arguments: JSON.stringify({
+          command: "python3 - <<'PY'\nimport sqlite3\nPY",
+        }),
+      },
+    ] satisfies ThreadItem[]);
+    expect(databaseSegment).toMatchObject({
+      kind: "command",
+      text: "查询本地数据",
+    });
+  });
 });
 
 

--- a/desktop/src/renderer/ToolActivityHelpers.ts
+++ b/desktop/src/renderer/ToolActivityHelpers.ts
@@ -525,7 +525,7 @@ function toolActivitySectionFromItems(
       return {
         id: key,
         kind: "schedule",
-        title: "定时任务",
+        title: readableScheduleSummary(items),
         status: combinedToolStatus(items),
         commands: toolCommands(items),
         error: firstToolError(items),
@@ -607,7 +607,7 @@ function toolActivityProcessSegmentFromItems(
             error,
             countPrefix: "搜索 ",
             count,
-            countSuffix: " 项",
+            countSuffix: " 次",
           }
         : {
             id: key,
@@ -679,6 +679,14 @@ function toolActivityProcessSegmentFromItems(
         status,
         error,
         text: "更新计划",
+      };
+    case "schedule":
+      return {
+        id: key,
+        kind: "schedule",
+        status,
+        error,
+        text: readableScheduleSummary(items),
       };
     case "browser":
       return {
@@ -880,6 +888,27 @@ function compactCommandLabels(items: ThreadItem[]): string[] {
   return uniqueStrings(items.map((item) => readableCommandLabel(item)));
 }
 
+function readableScheduleSummary(items: ThreadItem[]): string {
+  const actions = uniqueStrings(
+    items.map((item) => {
+      const args = parseJSONRecord(item.arguments);
+      switch (stringValue(args, "action")) {
+        case "add":
+          return "安排定时任务";
+        case "remove":
+          return "取消定时任务";
+        case "list":
+          return "查看定时任务";
+        default:
+          return "处理定时任务";
+      }
+    }),
+  );
+  return actions.length === 1
+    ? actions[0]
+    : `处理 ${items.length} 项定时任务`;
+}
+
 function compactAgentLabels(items: ThreadItem[]): string[] {
   return uniqueStrings(
     items.map((item) => {
@@ -993,6 +1022,12 @@ function readableCommandLabel(
       return "查看提交历史";
     }
     return "执行 Git 操作";
+  }
+  if (/(?:^|[;&|]\s*)date(?:\s|$)/.test(command)) {
+    return "查看本地时间";
+  }
+  if (/\bsqlite3\b|(?:import|from)\s+sqlite3\b/.test(command)) {
+    return "查询本地数据";
   }
   if (/npm\s+run\s+typecheck|tsc\s+--noEmit/.test(command)) {
     return "检查类型";

--- a/desktop/src/renderer/styles/composer.css
+++ b/desktop/src/renderer/styles/composer.css
@@ -2,7 +2,6 @@
   /* Component color tokens for composer.css.
      Light-theme values; the dark theme overrides these in base.css theme blocks. */
   --composer-frame-shadow: 0 8px 24px rgba(20, 24, 28, 0.06);
-  --composer-frame-hero-shadow: 0 14px 36px rgba(20, 24, 28, 0.07);
   --composer-image-attachment-button-shadow: 0 2px 8px rgba(20, 24, 28, 0.12);
   --composer-file-attachment-button-hover-bg: #eceee9;
   --composer-goal-strip-danger-hover-bg: rgba(220, 80, 80, 0.12);
@@ -346,7 +345,7 @@
 .hero-composer-wrap .composer-frame {
   border-radius: var(--session-composer-radius, var(--radius-sm));
   background: var(--paper);
-  box-shadow: var(--composer-frame-hero-shadow);
+  box-shadow: var(--composer-frame-shadow);
 }
 
 /* Force the hero composer to the dock composer's dialog width so the

--- a/desktop/src/renderer/styles/environment.css
+++ b/desktop/src/renderer/styles/environment.css
@@ -117,11 +117,14 @@
 }
 
 .environment-panel-header {
+  position: absolute;
+  top: 15px;
+  right: 14px;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 10px;
-  padding: 0 2px 8px;
+  padding: 0;
 }
 
 .environment-panel-actions {
@@ -139,6 +142,10 @@
 .environment-panel-body {
   display: grid;
   gap: 3px;
+}
+
+.environment-panel-header + .environment-panel-body .environment-row:first-child {
+  padding-right: 40px;
 }
 
 .environment-side-stack > .environment-panel .environment-panel-body {
@@ -453,6 +460,10 @@
   font-weight: var(--weight-semibold);
   line-height: 1.25;
   animation: environment-plan-item-in var(--motion-base) var(--ease-out) both;
+}
+
+.environment-plan-item:first-child {
+  padding-right: 34px;
 }
 
 .environment-plan-item:nth-child(1) { animation-delay: 0ms; }

--- a/desktop/src/renderer/styles/environment.css
+++ b/desktop/src/renderer/styles/environment.css
@@ -119,30 +119,9 @@
 .environment-panel-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 10px;
   padding: 0 2px 8px;
-}
-
-.environment-panel-header h2 {
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: var(--font-title);
-  font-weight: var(--weight-semibold);
-}
-
-.environment-panel-title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-.environment-panel-counter {
-  color: var(--ink-muted);
-  font-size: var(--font-title);
-  font-weight: var(--weight-semibold);
-  font-variant-numeric: tabular-nums;
 }
 
 .environment-panel-actions {
@@ -526,13 +505,6 @@
   }
 }
 
-.environment-section-heading {
-  color: var(--ink-muted);
-  font-size: var(--font-title);
-  font-weight: var(--weight-semibold);
-  padding: 0 8px 8px;
-}
-
 .environment-row,
 .environment-footer-row {
   display: grid;
@@ -714,12 +686,17 @@
   background: transparent;
   border: 0;
   border-radius: inherit;
-  padding: 0 8px 0 12px;
+  padding: 0 8px;
   text-align: left;
   cursor: pointer;
   color: inherit;
   font: inherit;
   transition: padding-right var(--motion-fast) var(--ease-out);
+}
+
+.subagent-row .participant-chip-avatar {
+  width: 20px;
+  height: 20px;
 }
 
 .subagent-row-main:focus-visible {
@@ -769,7 +746,6 @@
 
 .subagent-row.running .subagent-row-status::before {
   display: block;
-  animation: subagent-status-pulse 1600ms ease-in-out infinite;
 }
 
 .subagent-row.failed .subagent-row-status {
@@ -830,23 +806,6 @@
   .subagent-row-main,
   .subagent-row-actions {
     transition: none;
-  }
-
-  .subagent-row.running .subagent-row-status::before {
-    animation: none;
-  }
-}
-
-@keyframes subagent-status-pulse {
-  0%,
-  100% {
-    opacity: 0.45;
-    transform: scale(0.9);
-  }
-
-  50% {
-    opacity: 0.9;
-    transform: scale(1);
   }
 }
 

--- a/desktop/src/renderer/styles/theme.css
+++ b/desktop/src/renderer/styles/theme.css
@@ -162,7 +162,6 @@
 
   /* composer.css / composer-context-meter.css / chat.css */
   --composer-frame-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  --composer-frame-hero-shadow: 0 14px 36px rgba(0, 0, 0, 0.45);
   --composer-image-attachment-button-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
   --composer-file-attachment-button-hover-bg: #2b2f34;
   --composer-collapsed-prompt-card-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -11,7 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -99,7 +99,10 @@ type Runner struct {
 	// NativeDeferredToolDiscovery lets provider adapters use native
 	// deferred-tool declarations for tools marked DeferLoading.
 	NativeDeferredToolDiscovery bool
-	InferenceJournal            providers.InferenceJournal
+	// ProviderOptions carries provider-specific model compatibility and variant
+	// options into both agent requests and nested compaction requests.
+	ProviderOptions  map[string]any
+	InferenceJournal providers.InferenceJournal
 }
 
 // RunResult is the structured outcome of a Runner.RunWithUsage call.
@@ -160,16 +163,17 @@ func (r *Runner) RunWithUsage(ctx context.Context, prompt string, onUsage func(i
 		CompactThresholdPct:         r.CompactThresholdPct,
 		CompactKeepRecentTokens:     r.CompactKeepRecentTokens,
 		NativeDeferredToolDiscovery: r.NativeDeferredToolDiscovery,
+		ProviderOptions:             r.ProviderOptions,
 		SystemPromptSections:        cloneSystemPromptSections(r.SystemPromptSections),
 		OnUsage:                     onUsage,
 		PostToolRewrite:             compact.RewriteHistoryFromInternalToolMessagesWithContext,
 		Compact: func(ctx context.Context, messages []providers.ChatMessage) ([]providers.ChatMessage, error) {
-			return compact.CompactWithBudget(ctx, messages, r.Client, r.Model, compact.Budget{
+			return compact.CompactWithBudgetAndOptions(ctx, messages, r.Client, r.Model, compact.Budget{
 				ContextTokens:       maxCtx,
 				InputTokens:         r.MaxInputTokens,
 				OutputReserveTokens: r.OutputReserveTokens,
 				KeepRecentTokens:    r.CompactKeepRecentTokens,
-			})
+			}, r.ProviderOptions)
 		},
 	}
 

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -304,12 +304,12 @@ func (r *StreamRunner) RunWithCallback(ctx context.Context, history []providers.
 			})
 		},
 		Compact: func(ctx context.Context, messages []providers.ChatMessage) ([]providers.ChatMessage, error) {
-			return compact.CompactWithBudget(ctx, messages, r.Client, requestModel, compact.Budget{
+			return compact.CompactWithBudgetAndOptions(ctx, messages, r.Client, requestModel, compact.Budget{
 				ContextTokens:       compactContextTokens,
 				InputTokens:         r.MaxInputTokens,
 				OutputReserveTokens: r.OutputReserveTokens,
 				KeepRecentTokens:    r.CompactKeepRecentTokens,
-			})
+			}, r.ProviderOptions)
 		},
 		// Forward each tool result through the streaming callback so
 		// clients can render tool output live (the loop itself only

--- a/internal/appserver/automation_execution.go
+++ b/internal/appserver/automation_execution.go
@@ -81,6 +81,9 @@ func (s *Server) createAutomationThread() (*threadState, error) {
 	if _, err := session.CreateWithMetadata(s.rt.SessionDir, id, threadCWD); err != nil {
 		return nil, err
 	}
+	if _, err := session.SetSource(s.rt.SessionDir, id, "automation"); err != nil {
+		return nil, err
+	}
 	if workspaceID := strings.TrimSpace(s.rt.WorkspaceID); workspaceID != "" {
 		if _, err := session.SetWorkspaceID(s.rt.SessionDir, id, workspaceID); err != nil {
 			return nil, err
@@ -91,6 +94,7 @@ func (s *Server) createAutomationThread() (*threadState, error) {
 		history = append(history, providers.ChatMessage{Role: "system", Content: prompt})
 	}
 	th := newThreadState(id, history, s.rt.ProviderName, s.rt.Model, threadCWD, true, time.Now().UTC())
+	th.Source = "automation"
 	th.WorkspaceKind = workspaceKindForCWD(s.rt.WuuHome, threadCWD)
 	s.mu.Lock()
 	s.threads[id] = th

--- a/internal/appserver/automation_execution.go
+++ b/internal/appserver/automation_execution.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/automation"
-	wuucontext "github.com/blueberrycongee/wuu/internal/context"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/runtime"
 	"github.com/blueberrycongee/wuu/internal/session"
@@ -151,8 +150,8 @@ func automationRequestContext(task automation.Task, run automation.Run) []agent.
 		strings.TrimSpace(task.ID), strings.TrimSpace(run.ID), run.TriggeredAt.UTC().Format(time.RFC3339),
 		strings.TrimSpace(task.Cron), strings.TrimSpace(task.Timezone), strings.TrimSpace(task.Mode),
 	)
-	return agent.RequestOnlyContextBlocks([]wuucontext.Block{{
-		Kind: wuucontext.BlockAdditionalContext, Title: "Automation", Source: "automation", Content: content,
+	return agent.RequestOnlyContextMessages([]providers.ChatMessage{{
+		Role: "system", Name: "automation_info", Content: content,
 	}})
 }
 

--- a/internal/appserver/automation_execution.go
+++ b/internal/appserver/automation_execution.go
@@ -1,0 +1,155 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/agent"
+	"github.com/blueberrycongee/wuu/internal/automation"
+	wuucontext "github.com/blueberrycongee/wuu/internal/context"
+	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/runtime"
+	"github.com/blueberrycongee/wuu/internal/session"
+)
+
+func (s *Server) ExecuteAutomation(ctx context.Context, task automation.Task, run automation.Run) (automation.ExecutionResult, error) {
+	if s == nil || s.closed.Load() {
+		return automation.ExecutionResult{}, errServerClosed
+	}
+	prompt := strings.TrimSpace(task.Prompt)
+	if prompt == "" {
+		return automation.ExecutionResult{}, fmt.Errorf("automation task %q has an empty prompt", task.ID)
+	}
+
+	var th *threadState
+	var err error
+	switch automation.Mode(task.Mode) {
+	case automation.ModeNewThread, "":
+		th, err = s.createAutomationThread()
+	case automation.ModeThreadHeartbeat:
+		threadID := strings.TrimSpace(task.HeartbeatThreadID)
+		if threadID == "" {
+			return automation.ExecutionResult{}, fmt.Errorf("automation task %q has no heartbeat thread", task.ID)
+		}
+		th, err = s.ensureResidentThread(threadID)
+	default:
+		return automation.ExecutionResult{}, fmt.Errorf("automation task %q has invalid mode %q", task.ID, task.Mode)
+	}
+	if err != nil {
+		return automation.ExecutionResult{}, err
+	}
+
+	msg, err := userMessageFromPrompt(prompt, nil, nil, s.rt.ExperimentalHelpMe)
+	if err != nil {
+		return automation.ExecutionResult{}, err
+	}
+	snapshot := turnRuntimeSnapshot{}.withPermissions(normalizeTurnPermissions(s.rt.Permissions))
+	snapshot.Ultra = s.rt.UltraMode()
+	snapshot.AutomationRunID = run.ID
+	snapshot.RequestContext = automationRequestContext(task, run)
+
+	result, started, err := s.startAutomationTurn(ctx, th, msg, snapshot)
+	if err != nil {
+		return automation.ExecutionResult{}, err
+	}
+	if started {
+		return result, nil
+	}
+
+	queueID := strings.TrimSpace(run.ID)
+	if queueID == "" {
+		queueID = session.NewID()
+	}
+	msg.ClientID = queueID
+	entry := queuedTurn{id: queueID, msg: msg, snapshot: snapshot}
+	s.enqueueQueuedUserTurn(th.ID, entry)
+	queued := queuedTurnSummary(th.ID, entry)
+	_ = s.writeNotification(NotificationTurnQueued, TurnQueuedNotification{Queued: queued})
+	s.kickQueuedTurnDrain(th.ID)
+	return automation.ExecutionResult{Status: automation.RunStatusQueued, ThreadID: th.ID, QueueID: queueID}, nil
+}
+
+func (s *Server) createAutomationThread() (*threadState, error) {
+	if s.rt == nil || s.rt.StreamRunner == nil {
+		return nil, errors.New("runtime session is required")
+	}
+	id := session.NewID()
+	threadCWD := s.rt.RootDir
+	if _, err := session.CreateWithMetadata(s.rt.SessionDir, id, threadCWD); err != nil {
+		return nil, err
+	}
+	if workspaceID := strings.TrimSpace(s.rt.WorkspaceID); workspaceID != "" {
+		if _, err := session.SetWorkspaceID(s.rt.SessionDir, id, workspaceID); err != nil {
+			return nil, err
+		}
+	}
+	history := make([]providers.ChatMessage, 0, 1)
+	if prompt := strings.TrimSpace(s.rt.StreamRunner.SystemPrompt); prompt != "" {
+		history = append(history, providers.ChatMessage{Role: "system", Content: prompt})
+	}
+	th := newThreadState(id, history, s.rt.ProviderName, s.rt.Model, threadCWD, true, time.Now().UTC())
+	th.WorkspaceKind = workspaceKindForCWD(s.rt.WuuHome, threadCWD)
+	s.mu.Lock()
+	s.threads[id] = th
+	s.mu.Unlock()
+	th.mu.Lock()
+	thread := th.snapshotLocked()
+	th.mu.Unlock()
+	if err := s.notifyThreadStarted(thread); err != nil {
+		return nil, err
+	}
+	s.pruneResidentThreads(id)
+	return th, nil
+}
+
+func (s *Server) startAutomationTurn(ctx context.Context, th *threadState, msg providers.ChatMessage, snapshot turnRuntimeSnapshot) (automation.ExecutionResult, bool, error) {
+	var threadRuntime *runtime.ThreadRuntime
+	started, ok, err := s.startThreadUserTurnWithAdmission(
+		ctx, th, msg, snapshot, false, turnReadOnlyFail,
+		turnAdmissionHooks{afterLease: func(admitted *threadState, _ *providers.ChatMessage) error {
+			var runtimeErr error
+			threadRuntime, runtimeErr = s.ensureThreadRuntimeAfterAdmission(admitted)
+			if runtimeErr == nil {
+				s.foldFrozenWorkerTree(admitted, threadRuntime)
+			}
+			return runtimeErr
+		}},
+	)
+	if err != nil {
+		if errors.Is(err, errThreadExecutionBusy) {
+			return automation.ExecutionResult{}, false, nil
+		}
+		return automation.ExecutionResult{}, false, err
+	}
+	if !ok {
+		return automation.ExecutionResult{}, false, nil
+	}
+	launch, accepted := s.reserveBackground(func() {
+		s.runTurn(started.ctx, th, threadRuntime, started.turnID, started.runtime, started.history)
+	})
+	if !accepted {
+		return automation.ExecutionResult{}, false, errors.Join(errServerClosed, s.abortStartedThreadTurnDurably(th, started, errServerClosed))
+	}
+	defer launch.Cancel()
+	if err := s.writeNotification(NotificationTurnStarted, TurnStartedNotification{ThreadID: th.ID, Turn: started.turn}); err != nil {
+		return automation.ExecutionResult{}, false, errors.Join(err, s.abortStartedThreadTurnDurably(th, started, err))
+	}
+	launch.Commit()
+	return automation.ExecutionResult{Status: automation.RunStatusRunning, ThreadID: th.ID, TurnID: started.turnID}, true, nil
+}
+
+func automationRequestContext(task automation.Task, run automation.Run) []agent.ContextSegment {
+	content := fmt.Sprintf(
+		"Automation trigger\n- task_id: %s\n- run_id: %s\n- triggered_at: %s\n- schedule: %s\n- timezone: %s\n- mode: %s",
+		strings.TrimSpace(task.ID), strings.TrimSpace(run.ID), run.TriggeredAt.UTC().Format(time.RFC3339),
+		strings.TrimSpace(task.Cron), strings.TrimSpace(task.Timezone), strings.TrimSpace(task.Mode),
+	)
+	return agent.RequestOnlyContextBlocks([]wuucontext.Block{{
+		Kind: wuucontext.BlockAdditionalContext, Title: "Automation", Source: "automation", Content: content,
+	}})
+}
+
+var _ automation.Executor = (*Server)(nil)

--- a/internal/appserver/automation_execution_test.go
+++ b/internal/appserver/automation_execution_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/session"
+	"github.com/blueberrycongee/wuu/internal/statepath"
 )
 
 func TestAutomationRequestContextIsHiddenAndRequestOnly(t *testing.T) {
@@ -26,7 +27,7 @@ func TestAutomationRequestContextIsHiddenAndRequestOnly(t *testing.T) {
 	if segment.Lifecycle != agent.ContextSegmentRequestOnly || segment.Durable || segment.VisibleInUI {
 		t.Fatalf("automation context must be hidden and request-only: %#v", segment)
 	}
-	if len(segment.Messages) != 1 || !strings.Contains(segment.Messages[0].Content, "task_id: task-1") || !strings.Contains(segment.Messages[0].Content, "run_id: run-1") {
+	if len(segment.Messages) != 1 || segment.Messages[0].Role != "system" || !strings.Contains(segment.Messages[0].Content, "task_id: task-1") || !strings.Contains(segment.Messages[0].Content, "run_id: run-1") {
 		t.Fatalf("automation context message = %#v", segment.Messages)
 	}
 }
@@ -81,7 +82,7 @@ func TestAutomationNewThreadRunsAsPersistedAutomationThread(t *testing.T) {
 	var foundHiddenContext bool
 	for _, request := range requests {
 		for _, message := range request.Messages {
-			if message.Hidden && strings.Contains(message.Content, "task_id: "+task.ID) {
+			if message.Hidden && message.Role == "system" && strings.Contains(message.Content, "task_id: "+task.ID) {
 				foundHiddenContext = true
 			}
 		}
@@ -96,15 +97,22 @@ func TestAutomationNewThreadRunsAsPersistedAutomationThread(t *testing.T) {
 }
 
 func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var releaseOnce sync.Once
+	firstStarted := make(chan struct{})
+	firstRelease := make(chan struct{})
+	secondStarted := make(chan struct{})
+	secondRelease := make(chan struct{})
+	var firstReleaseOnce sync.Once
+	var secondReleaseOnce sync.Once
 	client := &fakeClient{
 		response: providersResponse("done"),
 		onChat: func(call int, _ providers.ChatRequest) {
-			if call == 1 {
-				close(started)
-				<-release
+			switch call {
+			case 1:
+				close(firstStarted)
+				<-firstRelease
+			case 2:
+				close(secondStarted)
+				<-secondRelease
 			}
 		},
 	}
@@ -114,7 +122,8 @@ func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
 	out := &lockedBuffer{}
 	srv := New(rt, out)
 	t.Cleanup(func() {
-		releaseOnce.Do(func() { close(release) })
+		firstReleaseOnce.Do(func() { close(firstRelease) })
+		secondReleaseOnce.Do(func() { close(secondRelease) })
 		srv.Close()
 	})
 
@@ -130,7 +139,7 @@ func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
 		t.Fatalf("first Fire: %v", err)
 	}
 	select {
-	case <-started:
+	case <-firstStarted:
 	case <-time.After(2 * time.Second):
 		t.Fatal("first heartbeat turn did not start")
 	}
@@ -154,7 +163,32 @@ func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
 		t.Fatalf("queued run count = %d, runs = %#v", queued, runs)
 	}
 
-	releaseOnce.Do(func() { close(release) })
+	firstReleaseOnce.Do(func() { close(firstRelease) })
+	select {
+	case <-secondStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued heartbeat turn did not start")
+	}
+	runs, err = rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 2 {
+		t.Fatalf("runs after dequeue = %#v, %v", runs, err)
+	}
+	var completed, running int
+	for _, run := range runs {
+		switch run.Status {
+		case automation.RunStatusCompleted:
+			completed++
+		case automation.RunStatusRunning:
+			running++
+			if run.TurnID == "" || run.QueueID != "" {
+				t.Fatalf("running dequeued run = %#v", run)
+			}
+		}
+	}
+	if completed != 1 || running != 1 {
+		t.Fatalf("dequeued run states = %#v", runs)
+	}
+	secondReleaseOnce.Do(func() { close(secondRelease) })
 	waitForTurnCompletedCountForThread(t, out, threadID, 2)
 	runs, err = rt.AutomationManager.ListRuns()
 	if err != nil || len(runs) != 2 {
@@ -164,5 +198,53 @@ func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
 		if run.Status != automation.RunStatusCompleted || run.ThreadID != threadID || run.TurnID == "" {
 			t.Fatalf("completed heartbeat run = %#v", run)
 		}
+	}
+}
+
+func TestAutomationManagerRecoversQueuedHeartbeatIntoPersistedThread(t *testing.T) {
+	client := &fakeClient{response: providersResponse("recovered")}
+	rt := newTestRuntime(t, client)
+	rt.StateDir = filepath.Dir(rt.SessionDir)
+	threadID := "recovered-heartbeat-thread"
+	if _, err := session.CreateWithMetadata(rt.SessionDir, threadID, rt.RootDir); err != nil {
+		t.Fatalf("CreateWithMetadata: %v", err)
+	}
+	task := automation.Task{
+		ID: "recovered-heartbeat-task", Prompt: "resume the scheduled check",
+		Mode: string(automation.ModeThreadHeartbeat), HeartbeatThreadID: threadID,
+		Cron: "*/5 * * * *", Timezone: "UTC",
+	}
+	runStore := automation.NewRunStore(statepath.AutomationRunsPath(rt.StateDir))
+	if err := runStore.Add(automation.Run{
+		ID: "recovered-heartbeat-run", TaskID: task.ID, Task: task,
+		Mode: task.Mode, Status: automation.RunStatusQueued,
+	}); err != nil {
+		t.Fatalf("add queued run: %v", err)
+	}
+	rt.AutomationManager = automation.NewManager(automation.Config{StateDir: rt.StateDir})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	t.Cleanup(srv.Close)
+
+	waitForTurnCompletedForThread(t, out, threadID)
+	runs, err := rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("recovered runs = %#v, %v", runs, err)
+	}
+	if run := runs[0]; run.Status != automation.RunStatusCompleted || run.ThreadID != threadID || run.TurnID == "" {
+		t.Fatalf("recovered run = %#v", run)
+	}
+	records, err := session.LoadHistoryRecords(rt.SessionDir, threadID, true)
+	if err != nil {
+		t.Fatalf("LoadHistoryRecords: %v", err)
+	}
+	var foundPrompt bool
+	for _, record := range records {
+		if record.Role == "user" && strings.Contains(record.Content, task.Prompt) {
+			foundPrompt = true
+		}
+	}
+	if !foundPrompt {
+		t.Fatalf("recovered prompt missing from history: %#v", records)
 	}
 }

--- a/internal/appserver/automation_execution_test.go
+++ b/internal/appserver/automation_execution_test.go
@@ -1,12 +1,17 @@
 package appserver
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/automation"
+	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/session"
 )
 
 func TestAutomationRequestContextIsHiddenAndRequestOnly(t *testing.T) {
@@ -23,5 +28,141 @@ func TestAutomationRequestContextIsHiddenAndRequestOnly(t *testing.T) {
 	}
 	if len(segment.Messages) != 1 || !strings.Contains(segment.Messages[0].Content, "task_id: task-1") || !strings.Contains(segment.Messages[0].Content, "run_id: run-1") {
 		t.Fatalf("automation context message = %#v", segment.Messages)
+	}
+}
+
+func TestAutomationNewThreadRunsAsPersistedAutomationThread(t *testing.T) {
+	client := &fakeClient{response: providersResponse("done")}
+	rt := newTestRuntime(t, client)
+	rt.StateDir = filepath.Dir(rt.SessionDir)
+	rt.AutomationManager = automation.NewManager(automation.Config{StateDir: rt.StateDir})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	t.Cleanup(srv.Close)
+
+	task := automation.Task{
+		ID: "new-thread-task", Prompt: "inspect the build", Mode: string(automation.ModeNewThread),
+		Cron: "*/5 * * * *", Timezone: "UTC",
+	}
+	if err := rt.AutomationManager.Fire(context.Background(), task); err != nil {
+		t.Fatalf("Fire: %v", err)
+	}
+	runs, err := rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 1 || runs[0].ThreadID == "" {
+		t.Fatalf("runs after admission = %#v, %v", runs, err)
+	}
+	threadID := runs[0].ThreadID
+	waitForTurnCompletedForThread(t, out, threadID)
+
+	persisted, ok, err := session.Find(rt.SessionDir, threadID)
+	if err != nil || !ok || persisted.Source != "automation" {
+		t.Fatalf("persisted thread = %#v, %t, %v", persisted, ok, err)
+	}
+	records, err := session.LoadHistoryRecords(rt.SessionDir, threadID, true)
+	if err != nil {
+		t.Fatalf("LoadHistoryRecords: %v", err)
+	}
+	var foundPrompt bool
+	for _, record := range records {
+		if record.Role == "user" && strings.Contains(record.Content, task.Prompt) {
+			foundPrompt = true
+		}
+		if strings.Contains(record.Content, "task_id: "+task.ID) {
+			t.Fatalf("automation metadata was persisted as conversation history: %#v", record)
+		}
+	}
+	if !foundPrompt {
+		t.Fatalf("automation prompt missing from persisted history: %#v", records)
+	}
+
+	client.mu.Lock()
+	requests := append([]providers.ChatRequest(nil), client.requests...)
+	client.mu.Unlock()
+	var foundHiddenContext bool
+	for _, request := range requests {
+		for _, message := range request.Messages {
+			if message.Hidden && strings.Contains(message.Content, "task_id: "+task.ID) {
+				foundHiddenContext = true
+			}
+		}
+	}
+	if !foundHiddenContext {
+		t.Fatalf("provider request missing hidden automation context: %#v", requests)
+	}
+	runs, err = rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 1 || runs[0].Status != automation.RunStatusCompleted || runs[0].TurnID == "" {
+		t.Fatalf("completed runs = %#v, %v", runs, err)
+	}
+}
+
+func TestAutomationHeartbeatQueuesTurnsOnExistingThread(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	client := &fakeClient{
+		response: providersResponse("done"),
+		onChat: func(call int, _ providers.ChatRequest) {
+			if call == 1 {
+				close(started)
+				<-release
+			}
+		},
+	}
+	rt := newTestRuntime(t, client)
+	rt.StateDir = filepath.Dir(rt.SessionDir)
+	rt.AutomationManager = automation.NewManager(automation.Config{StateDir: rt.StateDir})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		srv.Close()
+	})
+
+	if err := srv.handleLine(context.Background(), []byte(`{"id":"thread","method":"thread/start"}`)); err != nil {
+		t.Fatalf("thread/start: %v", err)
+	}
+	threadID := remarshal[ThreadStartResult](t, responseByID(t, parseOutput(t, out.String()), "thread")["result"]).Thread.ID
+	task := automation.Task{
+		ID: "heartbeat-task", Prompt: "check cache", Mode: string(automation.ModeThreadHeartbeat),
+		HeartbeatThreadID: threadID, Cron: "*/5 * * * *", Timezone: "UTC",
+	}
+	if err := rt.AutomationManager.Fire(context.Background(), task); err != nil {
+		t.Fatalf("first Fire: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first heartbeat turn did not start")
+	}
+	if err := rt.AutomationManager.Fire(context.Background(), task); err != nil {
+		t.Fatalf("second Fire: %v", err)
+	}
+	runs, err := rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 2 {
+		t.Fatalf("runs while busy = %#v, %v", runs, err)
+	}
+	var queued int
+	for _, run := range runs {
+		if run.ThreadID != threadID {
+			t.Fatalf("heartbeat run used thread %q, want %q", run.ThreadID, threadID)
+		}
+		if run.Status == automation.RunStatusQueued {
+			queued++
+		}
+	}
+	if queued != 1 {
+		t.Fatalf("queued run count = %d, runs = %#v", queued, runs)
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	waitForTurnCompletedCountForThread(t, out, threadID, 2)
+	runs, err = rt.AutomationManager.ListRuns()
+	if err != nil || len(runs) != 2 {
+		t.Fatalf("completed heartbeat runs = %#v, %v", runs, err)
+	}
+	for _, run := range runs {
+		if run.Status != automation.RunStatusCompleted || run.ThreadID != threadID || run.TurnID == "" {
+			t.Fatalf("completed heartbeat run = %#v", run)
+		}
 	}
 }

--- a/internal/appserver/automation_execution_test.go
+++ b/internal/appserver/automation_execution_test.go
@@ -1,0 +1,27 @@
+package appserver
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/agent"
+	"github.com/blueberrycongee/wuu/internal/automation"
+)
+
+func TestAutomationRequestContextIsHiddenAndRequestOnly(t *testing.T) {
+	segments := automationRequestContext(
+		automation.Task{ID: "task-1", Cron: "*/5 * * * *", Timezone: "UTC", Mode: string(automation.ModeThreadHeartbeat)},
+		automation.Run{ID: "run-1", TriggeredAt: time.Date(2026, 7, 16, 7, 0, 0, 0, time.UTC)},
+	)
+	if len(segments) != 1 {
+		t.Fatalf("segments = %#v", segments)
+	}
+	segment := segments[0]
+	if segment.Lifecycle != agent.ContextSegmentRequestOnly || segment.Durable || segment.VisibleInUI {
+		t.Fatalf("automation context must be hidden and request-only: %#v", segment)
+	}
+	if len(segment.Messages) != 1 || !strings.Contains(segment.Messages[0].Content, "task_id: task-1") || !strings.Contains(segment.Messages[0].Content, "run_id: run-1") {
+		t.Fatalf("automation context message = %#v", segment.Messages)
+	}
+}

--- a/internal/appserver/automation_handlers.go
+++ b/internal/appserver/automation_handlers.go
@@ -1,0 +1,61 @@
+package appserver
+
+import (
+	"errors"
+	"strings"
+)
+
+func (s *Server) handleAutomationList(req Request) error {
+	if s == nil || s.rt == nil || s.rt.AutomationManager == nil {
+		return s.writeResponse(req.ID, nil, errors.New("automation manager is unavailable"))
+	}
+	tasks, err := s.rt.AutomationManager.ListTasks()
+	if err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	return s.writeResponse(req.ID, AutomationListResult{Tasks: tasks}, nil)
+}
+
+func (s *Server) handleAutomationRuns(req Request) error {
+	if s == nil || s.rt == nil || s.rt.AutomationManager == nil {
+		return s.writeResponse(req.ID, nil, errors.New("automation manager is unavailable"))
+	}
+	runs, err := s.rt.AutomationManager.ListRuns()
+	if err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	return s.writeResponse(req.ID, AutomationRunsResult{Runs: runs}, nil)
+}
+
+func (s *Server) handleAutomationUpdate(req Request) error {
+	if s == nil || s.rt == nil || s.rt.AutomationManager == nil {
+		return s.writeResponse(req.ID, nil, errors.New("automation manager is unavailable"))
+	}
+	var params AutomationUpdateParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	params.ID = strings.TrimSpace(params.ID)
+	if params.ID == "" || params.Paused == nil {
+		return s.writeResponse(req.ID, nil, errors.New("id and paused are required"))
+	}
+	task, err := s.rt.AutomationManager.SetPaused(params.ID, *params.Paused)
+	if err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	return s.writeResponse(req.ID, AutomationUpdateResult{Task: task}, nil)
+}
+
+func (s *Server) handleAutomationRemove(req Request) error {
+	if s == nil || s.rt == nil || s.rt.AutomationManager == nil {
+		return s.writeResponse(req.ID, nil, errors.New("automation manager is unavailable"))
+	}
+	var params AutomationRemoveParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	if err := s.rt.AutomationManager.RemoveTask(strings.TrimSpace(params.ID)); err != nil {
+		return s.writeResponse(req.ID, nil, err)
+	}
+	return s.writeResponse(req.ID, OKResult{OK: true}, nil)
+}

--- a/internal/appserver/automation_handlers_test.go
+++ b/internal/appserver/automation_handlers_test.go
@@ -1,0 +1,43 @@
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/blueberrycongee/wuu/internal/automation"
+	"github.com/blueberrycongee/wuu/internal/runtime"
+)
+
+func TestAutomationListRPC(t *testing.T) {
+	stateDir := t.TempDir()
+	manager := automation.NewManager(automation.Config{StateDir: stateDir})
+	defer manager.Stop()
+	if _, err := manager.AddTask(automation.AddTaskParams{
+		Prompt: "inspect", Schedule: "*/5 * * * *", Timezone: "UTC", Durable: true,
+	}); err != nil {
+		t.Fatalf("AddTask() error = %v", err)
+	}
+	var out bytes.Buffer
+	server := New(&runtime.Session{
+		StateDir: stateDir, SessionDir: filepath.Join(stateDir, "sessions"), AutomationManager: manager,
+	}, &out)
+	defer server.Close()
+	if err := server.handleLine(context.Background(), []byte(`{"id":"list","method":"automation/list"}`)); err != nil {
+		t.Fatalf("automation/list error = %v", err)
+	}
+	result := remarshal[AutomationListResult](t, responseByID(t, parseOutput(t, out.String()), "list")["result"])
+	if len(result.Tasks) != 1 || result.Tasks[0].Prompt != "inspect" {
+		t.Fatalf("tasks = %#v", result.Tasks)
+	}
+	taskID := result.Tasks[0].ID
+	out.Reset()
+	if err := server.handleLine(context.Background(), []byte(`{"id":"pause","method":"automation/update","params":{"id":"`+taskID+`","paused":true}}`)); err != nil {
+		t.Fatalf("automation/update error = %v", err)
+	}
+	updated := remarshal[AutomationUpdateResult](t, responseByID(t, parseOutput(t, out.String()), "pause")["result"])
+	if !updated.Task.Paused {
+		t.Fatalf("updated task = %#v", updated.Task)
+	}
+}

--- a/internal/appserver/model.go
+++ b/internal/appserver/model.go
@@ -48,6 +48,7 @@ func (th *threadState) snapshotLocked() Thread {
 	}
 	return Thread{
 		ID:               th.ID,
+		Source:           th.Source,
 		ParentID:         th.ParentID,
 		AgentPath:        th.AgentPath,
 		Preview:          firstNonEmpty(th.Title, threadPreview(th.History)),

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/activity"
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/extensions"
 	"github.com/blueberrycongee/wuu/internal/insight"
@@ -27,6 +28,10 @@ const (
 	MethodConfigProviderRemove = "config/provider/remove"
 	MethodSkillList            = "skill/list"
 	MethodAgentTemplateList    = "agent-template/list"
+	MethodAutomationList       = "automation/list"
+	MethodAutomationRuns       = "automation/run/list"
+	MethodAutomationUpdate     = "automation/update"
+	MethodAutomationRemove     = "automation/remove"
 	// MethodGoalActiveSummary returns the lightweight composer-banner view
 	// of the most-recently-updated non-terminal goal in the requested thread
 	// scope. The mutation methods are user-owned controls for the active
@@ -1741,8 +1746,30 @@ const (
 	WorkspaceKindDM WorkspaceKind = "dm"
 )
 
+type AutomationListResult struct {
+	Tasks []automation.Task `json:"tasks"`
+}
+
+type AutomationRunsResult struct {
+	Runs []automation.Run `json:"runs"`
+}
+
+type AutomationUpdateParams struct {
+	ID     string `json:"id"`
+	Paused *bool  `json:"paused"`
+}
+
+type AutomationUpdateResult struct {
+	Task automation.Task `json:"task"`
+}
+
+type AutomationRemoveParams struct {
+	ID string `json:"id"`
+}
+
 type Thread struct {
 	ID               string        `json:"id"`
+	Source           string        `json:"source,omitempty"`
 	ParentID         string        `json:"parent_id,omitempty"`
 	AgentPath        string        `json:"agent_path,omitempty"`
 	Preview          string        `json:"preview"`

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -382,6 +382,12 @@ func NewWithCredentialStore(rt *runtime.Session, out io.Writer, store credential
 		}
 	}
 	s.startInferenceJournalMaintenance()
+	if rt != nil && rt.AutomationManager != nil {
+		if err := rt.AutomationManager.Start(s); err != nil {
+			s.startupErr = fmt.Errorf("start automation manager: %w", err)
+			return s
+		}
+	}
 	return s
 }
 

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -560,6 +560,9 @@ func (s *Server) Close() {
 	}
 	s.closeOnce.Do(func() {
 		s.closed.Store(true)
+		if s.rt != nil && s.rt.AutomationManager != nil {
+			s.rt.AutomationManager.Stop()
+		}
 		s.cancelSideThreads()
 		// Synchronize with startBackground so no new owned goroutine can be
 		// added after the shutdown waiter begins.

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -37,6 +37,7 @@ var (
 
 type threadState struct {
 	ID        string
+	Source    string
 	ParentID  string
 	AgentPath string
 	History   []providers.ChatMessage
@@ -807,6 +808,14 @@ func (s *Server) handleLine(ctx context.Context, raw []byte) error {
 		return s.handleSkillList(req)
 	case MethodAgentTemplateList:
 		return s.handleAgentTemplateList(req)
+	case MethodAutomationList:
+		return s.handleAutomationList(req)
+	case MethodAutomationRuns:
+		return s.handleAutomationRuns(req)
+	case MethodAutomationUpdate:
+		return s.handleAutomationUpdate(req)
+	case MethodAutomationRemove:
+		return s.handleAutomationRemove(req)
 	case MethodGoalActiveSummary:
 		return s.handleGoalActiveSummary(req)
 	case MethodGoalPause:

--- a/internal/appserver/thread_handlers.go
+++ b/internal/appserver/thread_handlers.go
@@ -989,6 +989,7 @@ func applySessionMetadata(th *threadState, metadata session.Session) {
 		th.CWD = metadata.CWD
 	}
 	th.Title = metadata.Title
+	th.Source = metadata.Source
 	th.ForkedFromID = metadata.ForkedFromID
 	th.ForkedFromTurnID = metadata.ForkedFromTurnID
 	th.ForkedFromItemID = metadata.ForkedFromItemID
@@ -1010,6 +1011,7 @@ func threadEntryFromSession(sess session.Session, provider, model string) thread
 	return threadListEntry{
 		thread: Thread{
 			ID:               sess.ID,
+			Source:           sess.Source,
 			Preview:          firstNonEmpty(sess.Title, sess.Summary),
 			Title:            sess.Title,
 			ModelProvider:    provider,

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -1921,6 +1921,11 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	awaitingAutoContinuation := err == nil && threadRuntime != nil &&
 		(threadRuntimeHasOutstandingAgentWork(threadRuntime) ||
 			threadHasOutstandingProcessCompletion(th.ID, threadRuntime.AgentControl, threadRuntime.ProcessManager))
+	if runID := strings.TrimSpace(turnRuntime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
+		if completeErr := s.rt.AutomationManager.CompleteRun(runID, th.ID, turnID, err); completeErr != nil {
+			providers.DebugLogf("complete automation run %q: %v", runID, completeErr)
+		}
+	}
 	if err != nil {
 		notify(NotificationTurnError, TurnErrorNotification{
 			ThreadID:   th.ID,
@@ -1948,11 +1953,6 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 			TracePath:                tracePath,
 			AwaitingAutoContinuation: awaitingAutoContinuation,
 		})
-	}
-	if runID := strings.TrimSpace(turnRuntime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
-		if completeErr := s.rt.AutomationManager.CompleteRun(runID, th.ID, turnID, err); completeErr != nil {
-			providers.DebugLogf("complete automation run %q: %v", runID, completeErr)
-		}
 	}
 	if residentTurn {
 		s.kickResidentAgent(residentParticipantID)
@@ -2602,6 +2602,8 @@ func (s *Server) startThreadUserTurnWithAdmission(ctx context.Context, th *threa
 		th.frozenTreeResultIDs = nil
 	}
 	turnRuntime.Ultra = snapshot.Ultra
+	turnRuntime.AutomationRunID = snapshot.AutomationRunID
+	turnRuntime.RequestContext = cloneContextSegments(snapshot.RequestContext)
 	th.mu.Unlock()
 
 	return startedThreadTurn{
@@ -2654,10 +2656,7 @@ func (s *Server) startQueuedTurn(ctx context.Context, threadID string, entry que
 		}
 	}
 
-	snapshot := turnRuntimeSnapshot{}.withPermissions(permissions)
-	snapshot.PermissionExplicit = entry.snapshot.PermissionExplicit
-	snapshot.ForceCompact = entry.snapshot.ForceCompact
-	snapshot.CompactOnly = entry.snapshot.CompactOnly
+	snapshot := entry.snapshot.withPermissions(permissions)
 	started, ok, err := s.startThreadUserTurnWithAdmission(
 		ctx,
 		th,

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -558,6 +558,7 @@ func (s *Server) handleTurnDequeue(req Request) error {
 		return err
 	}
 	if removed {
+		s.failQueuedAutomationRuns([]string{queueID}, "queued automation was removed")
 		_ = s.writeNotification(NotificationTurnDequeued, TurnDequeuedNotification{
 			ThreadID: threadID,
 			QueueID:  queueID,
@@ -1212,6 +1213,7 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 	control := threadAgentControlLocked(th)
 	th.mu.Unlock()
 	discardedQueueIDs := s.discardQueuedUserWork(threadID)
+	s.failQueuedAutomationRuns(discardedQueueIDs, "queued automation was interrupted")
 	cancel()
 	// turn/interrupt means "freeze this work", not "leave background workers
 	// running": cancel the whole anonymous-worker tree, clear its queued
@@ -2325,7 +2327,8 @@ func (s *Server) drainQueuedTurns(threadID string) {
 	}
 	th := s.thread(threadID)
 	if th == nil {
-		s.discardQueuedUserTurns(threadID)
+		discardedQueueIDs := s.discardQueuedUserTurns(threadID)
+		s.failQueuedAutomationRuns(discardedQueueIDs, "automation thread no longer exists")
 		s.clearQueuedTurnDrain(threadID)
 		return
 	}
@@ -2343,6 +2346,11 @@ func (s *Server) drainQueuedTurns(threadID string) {
 	executionBusy := errors.Is(err, errThreadExecutionBusy)
 	if err != nil && !executionBusy {
 		providers.DebugLogf("start queued turn for thread %q: %v", threadID, err)
+		if runID := strings.TrimSpace(entry.snapshot.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
+			if completeErr := s.rt.AutomationManager.CompleteRun(runID, threadID, "", err); completeErr != nil {
+				providers.DebugLogf("fail queued automation run %q: %v", runID, completeErr)
+			}
+		}
 	}
 	requeued := false
 	if !started && (err == nil || executionBusy) {
@@ -2673,6 +2681,11 @@ func (s *Server) startQueuedTurn(ctx context.Context, threadID string, entry que
 	if err != nil || !ok {
 		return ok, err
 	}
+	if runID := strings.TrimSpace(started.runtime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
+		if err := s.rt.AutomationManager.MarkRunRunning(runID, threadID, started.turnID); err != nil {
+			return false, errors.Join(err, s.abortStartedThreadTurnDurably(th, started, err))
+		}
+	}
 
 	if s.beforeQueuedTurnBackgroundForTest != nil {
 		s.beforeQueuedTurnBackgroundForTest()
@@ -2786,6 +2799,17 @@ func (s *Server) notifyQueuedTurnsDequeued(threadID string, queueIDs []string) {
 			ThreadID: threadID,
 			QueueID:  queueID,
 		})
+	}
+}
+
+func (s *Server) failQueuedAutomationRuns(queueIDs []string, reason string) {
+	if s == nil || s.rt == nil || s.rt.AutomationManager == nil {
+		return
+	}
+	for _, queueID := range queueIDs {
+		if err := s.rt.AutomationManager.FailRunIfPending(queueID, reason); err != nil {
+			providers.DebugLogf("fail queued automation run %q: %v", queueID, err)
+		}
 	}
 }
 

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -113,7 +113,9 @@ type turnRuntimeSnapshot struct {
 	// completing worker's inherited value instead of re-reading a session
 	// value that may have changed while the orchestration tree ran. Rides
 	// the snapshot so queueing and wakeups keep the admitted value.
-	Ultra bool
+	Ultra           bool
+	AutomationRunID string
+	RequestContext  []agent.ContextSegment
 }
 
 func (s *Server) handleTurnStart(ctx context.Context, req Request) error {
@@ -1352,7 +1354,7 @@ func frozenWorkerTreeBlock(pending []agentCompletionTurn, frozen []agentcontrol.
 }
 
 func (s *Server) runTurn(ctx context.Context, th *threadState, threadRuntime *runtime.ThreadRuntime, turnID string, turnRuntime turnRuntimeSnapshot, history []providers.ChatMessage) {
-	s.runTurnWithRequestContext(ctx, th, threadRuntime, turnID, turnRuntime, history, nil, nil)
+	s.runTurnWithRequestContext(ctx, th, threadRuntime, turnID, turnRuntime, history, turnRuntime.RequestContext, nil)
 }
 
 func turnRuntimeSnapshotLocked(th *threadState) turnRuntimeSnapshot {
@@ -1946,6 +1948,11 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 			TracePath:                tracePath,
 			AwaitingAutoContinuation: awaitingAutoContinuation,
 		})
+	}
+	if runID := strings.TrimSpace(turnRuntime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
+		if completeErr := s.rt.AutomationManager.CompleteRun(runID, th.ID, turnID, err); completeErr != nil {
+			providers.DebugLogf("complete automation run %q: %v", runID, completeErr)
+		}
 	}
 	if residentTurn {
 		s.kickResidentAgent(residentParticipantID)

--- a/internal/automation/manager.go
+++ b/internal/automation/manager.go
@@ -1,0 +1,335 @@
+package automation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/cron"
+	"github.com/blueberrycongee/wuu/internal/statepath"
+)
+
+type Mode string
+
+const (
+	ModeNewThread       Mode = "new_thread"
+	ModeThreadHeartbeat Mode = "thread_heartbeat"
+)
+
+type RunStatus string
+
+const (
+	RunStatusQueued    RunStatus = "queued"
+	RunStatusRunning   RunStatus = "running"
+	RunStatusCompleted RunStatus = "completed"
+	RunStatusFailed    RunStatus = "failed"
+)
+
+type Task = cron.Task
+
+type AddTaskParams struct {
+	Title             string
+	Prompt            string
+	Schedule          string
+	Timezone          string
+	Mode              Mode
+	CreatorThreadID   string
+	HeartbeatThreadID string
+	Recurring         bool
+	Durable           bool
+}
+
+type ExecutionResult struct {
+	Status   RunStatus
+	ThreadID string
+	TurnID   string
+	QueueID  string
+}
+
+type Executor interface {
+	ExecuteAutomation(context.Context, Task, Run) (ExecutionResult, error)
+}
+
+type Config struct {
+	StateDir string
+	OnError  func(error)
+}
+
+type Manager struct {
+	stateDir     string
+	durableStore *cron.TaskStore
+	sessionStore *cron.SessionTaskStore
+	runStore     *RunStore
+	lock         *cron.Lock
+	onError      func(error)
+
+	mu        sync.Mutex
+	executor  Executor
+	scheduler *cron.Scheduler
+	owner     bool
+}
+
+func NewManager(cfg Config) *Manager {
+	stateDir := strings.TrimSpace(cfg.StateDir)
+	return &Manager{
+		stateDir:     stateDir,
+		durableStore: cron.NewTaskStore(statepath.ScheduledTasksPath(stateDir)),
+		sessionStore: cron.NewSessionTaskStore(stateDir),
+		runStore:     NewRunStore(statepath.AutomationRunsPath(stateDir)),
+		lock:         cron.NewLock(statepath.ScheduledTasksLockPath(stateDir)),
+		onError:      cfg.OnError,
+	}
+}
+
+func (m *Manager) Start(executor Executor) error {
+	if m == nil {
+		return errors.New("automation manager is required")
+	}
+	if strings.TrimSpace(m.stateDir) == "" {
+		return errors.New("workspace state directory is required")
+	}
+	if executor == nil {
+		return errors.New("automation executor is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.scheduler != nil {
+		m.executor = executor
+		return nil
+	}
+	m.executor = executor
+	m.scheduler = cron.NewScheduler(cron.SchedulerConfig{
+		Store:        m.durableStore,
+		SessionStore: m.sessionStore,
+		OnFire:       m.Fire,
+		OnError:      m.reportError,
+		IsOwner:      m.ownsDurableTasks,
+	})
+	m.scheduler.Start()
+	return nil
+}
+
+func (m *Manager) Stop() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	scheduler := m.scheduler
+	m.scheduler = nil
+	m.executor = nil
+	m.mu.Unlock()
+	if scheduler != nil {
+		scheduler.Stop()
+	}
+	if m.lock != nil {
+		m.lock.Release()
+	}
+	m.mu.Lock()
+	m.owner = false
+	m.mu.Unlock()
+}
+
+func (m *Manager) AddTask(params AddTaskParams) (Task, error) {
+	if m == nil {
+		return Task{}, errors.New("automation manager is required")
+	}
+	prompt := strings.TrimSpace(params.Prompt)
+	if prompt == "" {
+		return Task{}, errors.New("automation prompt is required")
+	}
+	schedule := strings.TrimSpace(params.Schedule)
+	if schedule == "" {
+		return Task{}, errors.New("automation schedule is required")
+	}
+	if _, err := cron.ParseCronExpression(schedule); err != nil {
+		return Task{}, fmt.Errorf("invalid automation schedule: %w", err)
+	}
+	timezone := strings.TrimSpace(params.Timezone)
+	if timezone == "" {
+		timezone = time.Local.String()
+	}
+	if _, err := time.LoadLocation(timezone); err != nil {
+		return Task{}, fmt.Errorf("invalid automation timezone %q: %w", timezone, err)
+	}
+	mode := params.Mode
+	if mode == "" {
+		mode = ModeNewThread
+	}
+	if mode != ModeNewThread && mode != ModeThreadHeartbeat {
+		return Task{}, fmt.Errorf("invalid automation mode %q", mode)
+	}
+	creatorThreadID := strings.TrimSpace(params.CreatorThreadID)
+	heartbeatThreadID := strings.TrimSpace(params.HeartbeatThreadID)
+	if mode == ModeThreadHeartbeat {
+		if heartbeatThreadID == "" {
+			heartbeatThreadID = creatorThreadID
+		}
+		if heartbeatThreadID == "" {
+			return Task{}, errors.New("thread heartbeat automation requires a thread id")
+		}
+	}
+	task := Task{
+		ID:                cron.GenerateTaskID(),
+		Title:             strings.TrimSpace(params.Title),
+		Cron:              schedule,
+		Timezone:          timezone,
+		Prompt:            prompt,
+		Mode:              string(mode),
+		CreatorThreadID:   creatorThreadID,
+		HeartbeatThreadID: heartbeatThreadID,
+		CreatedAt:         time.Now().UnixMilli(),
+		Recurring:         params.Recurring,
+	}
+	if task.Title == "" {
+		task.Title = prompt
+	}
+	if _, err := task.NextFireAt(); err != nil {
+		return Task{}, fmt.Errorf("automation has no valid future run: %w", err)
+	}
+	if err := m.ensureCapacity(); err != nil {
+		return Task{}, err
+	}
+	var store taskAdder = m.sessionStore
+	if params.Durable {
+		store = m.durableStore
+	}
+	if err := store.Add(task); err != nil {
+		return Task{}, err
+	}
+	return task, nil
+}
+
+func (m *Manager) ListTasks() ([]Task, error) {
+	if m == nil {
+		return nil, errors.New("automation manager is required")
+	}
+	durable, err := m.durableStore.List()
+	if err != nil {
+		return nil, err
+	}
+	sessionOnly, err := m.sessionStore.List()
+	if err != nil {
+		return nil, err
+	}
+	return append(durable, sessionOnly...), nil
+}
+
+func (m *Manager) RemoveTask(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("automation task id is required")
+	}
+	if err := m.durableStore.Remove(id); err != nil {
+		return err
+	}
+	return m.sessionStore.Remove(id)
+}
+
+func (m *Manager) ListRuns() ([]Run, error) {
+	if m == nil {
+		return nil, errors.New("automation manager is required")
+	}
+	return m.runStore.List()
+}
+
+func (m *Manager) Fire(ctx context.Context, task Task) error {
+	if m == nil {
+		return errors.New("automation manager is required")
+	}
+	task = normalizeTask(task)
+	m.mu.Lock()
+	executor := m.executor
+	m.mu.Unlock()
+	if executor == nil {
+		return errors.New("automation executor is not attached")
+	}
+	run := Run{
+		ID:          newRunID(),
+		TaskID:      task.ID,
+		Mode:        task.Mode,
+		Status:      RunStatusRunning,
+		TriggeredAt: time.Now().UTC(),
+	}
+	if err := m.runStore.Add(run); err != nil {
+		return fmt.Errorf("record automation run: %w", err)
+	}
+	result, err := executor.ExecuteAutomation(ctx, task, run)
+	if err != nil {
+		_ = m.runStore.Finish(run.ID, RunStatusFailed, "", "", err.Error())
+		return err
+	}
+	status := result.Status
+	if status != RunStatusQueued && status != RunStatusRunning {
+		status = RunStatusRunning
+	}
+	return m.runStore.UpdateAdmission(run.ID, status, result.ThreadID, result.TurnID, result.QueueID)
+}
+
+func (m *Manager) CompleteRun(runID, threadID, turnID string, runErr error) error {
+	status := RunStatusCompleted
+	errorText := ""
+	if runErr != nil {
+		status = RunStatusFailed
+		errorText = runErr.Error()
+	}
+	return m.runStore.Finish(strings.TrimSpace(runID), status, strings.TrimSpace(threadID), strings.TrimSpace(turnID), errorText)
+}
+
+func (m *Manager) ensureCapacity() error {
+	durable, err := m.durableStore.List()
+	if err != nil {
+		return err
+	}
+	sessionOnly, err := m.sessionStore.List()
+	if err != nil {
+		return err
+	}
+	if len(durable)+len(sessionOnly) >= cron.MaxJobs {
+		return fmt.Errorf("maximum number of automation tasks reached (%d)", cron.MaxJobs)
+	}
+	return nil
+}
+
+func (m *Manager) ownsDurableTasks() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.owner {
+		return true
+	}
+	if m.lock == nil {
+		return false
+	}
+	owner, err := m.lock.TryAcquire()
+	if err != nil {
+		if m.onError != nil {
+			m.onError(fmt.Errorf("acquire automation scheduler lock: %w", err))
+		}
+		return false
+	}
+	m.owner = owner
+	return owner
+}
+
+func (m *Manager) reportError(err error) {
+	if err != nil && m.onError != nil {
+		m.onError(err)
+	}
+}
+
+func normalizeTask(task Task) Task {
+	if strings.TrimSpace(task.Mode) == "" {
+		task.Mode = string(ModeNewThread)
+	}
+	if strings.TrimSpace(task.Timezone) == "" {
+		task.Timezone = time.Local.String()
+	}
+	return task
+}
+
+type taskAdder interface {
+	Add(Task) error
+}

--- a/internal/automation/manager.go
+++ b/internal/automation/manager.go
@@ -236,6 +236,24 @@ func (m *Manager) ListRuns() ([]Run, error) {
 	return m.runStore.List()
 }
 
+func (m *Manager) SetPaused(id string, paused bool) (Task, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Task{}, errors.New("automation task id is required")
+	}
+	if task, found, err := m.durableStore.SetPaused(id, paused); err != nil {
+		return Task{}, err
+	} else if found {
+		return normalizeTask(task), nil
+	}
+	if task, found, err := m.sessionStore.SetPaused(id, paused); err != nil {
+		return Task{}, err
+	} else if found {
+		return normalizeTask(task), nil
+	}
+	return Task{}, fmt.Errorf("automation task %q not found", id)
+}
+
 func (m *Manager) Fire(ctx context.Context, task Task) error {
 	if m == nil {
 		return errors.New("automation manager is required")

--- a/internal/automation/manager.go
+++ b/internal/automation/manager.go
@@ -181,8 +181,14 @@ func (m *Manager) AddTask(params AddTaskParams) (Task, error) {
 		Mode:              string(mode),
 		CreatorThreadID:   creatorThreadID,
 		HeartbeatThreadID: heartbeatThreadID,
+		Metadata:          map[string]string{"kind": "prompt"},
 		CreatedAt:         time.Now().UnixMilli(),
 		Recurring:         params.Recurring,
+	}
+	if params.Durable {
+		task.Metadata["durability"] = "durable"
+	} else {
+		task.Metadata["durability"] = "session-only"
 	}
 	if task.Title == "" {
 		task.Title = prompt
@@ -215,6 +221,12 @@ func (m *Manager) ListTasks() ([]Task, error) {
 	if err != nil {
 		return nil, err
 	}
+	for index := range durable {
+		durable[index] = withTaskDurability(durable[index], "durable")
+	}
+	for index := range sessionOnly {
+		sessionOnly[index] = withTaskDurability(sessionOnly[index], "session-only")
+	}
 	return append(durable, sessionOnly...), nil
 }
 
@@ -244,12 +256,12 @@ func (m *Manager) SetPaused(id string, paused bool) (Task, error) {
 	if task, found, err := m.durableStore.SetPaused(id, paused); err != nil {
 		return Task{}, err
 	} else if found {
-		return normalizeTask(task), nil
+		return withTaskDurability(task, "durable"), nil
 	}
 	if task, found, err := m.sessionStore.SetPaused(id, paused); err != nil {
 		return Task{}, err
 	} else if found {
-		return normalizeTask(task), nil
+		return withTaskDurability(task, "session-only"), nil
 	}
 	return Task{}, fmt.Errorf("automation task %q not found", id)
 }
@@ -346,6 +358,16 @@ func normalizeTask(task Task) Task {
 		task.Timezone = time.Local.String()
 	}
 	return task
+}
+
+func withTaskDurability(task Task, durability string) Task {
+	metadata := make(map[string]string, len(task.Metadata)+1)
+	for key, value := range task.Metadata {
+		metadata[key] = value
+	}
+	metadata["durability"] = durability
+	task.Metadata = metadata
+	return normalizeTask(task)
 }
 
 type taskAdder interface {

--- a/internal/automation/manager.go
+++ b/internal/automation/manager.go
@@ -96,20 +96,29 @@ func (m *Manager) Start(executor Executor) error {
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.scheduler != nil {
 		m.executor = executor
+		m.mu.Unlock()
 		return nil
 	}
 	m.executor = executor
-	m.scheduler = cron.NewScheduler(cron.SchedulerConfig{
+	scheduler := cron.NewScheduler(cron.SchedulerConfig{
 		Store:        m.durableStore,
 		SessionStore: m.sessionStore,
 		OnFire:       m.Fire,
 		OnError:      m.reportError,
 		IsOwner:      m.ownsDurableTasks,
 	})
-	m.scheduler.Start()
+	m.scheduler = scheduler
+	m.mu.Unlock()
+
+	if m.ownsDurableTasks() {
+		if err := m.recoverRuns(context.Background(), executor); err != nil {
+			m.Stop()
+			return err
+		}
+	}
+	scheduler.Start()
 	return nil
 }
 
@@ -280,6 +289,7 @@ func (m *Manager) Fire(ctx context.Context, task Task) error {
 	run := Run{
 		ID:          newRunID(),
 		TaskID:      task.ID,
+		Task:        task,
 		Mode:        task.Mode,
 		Status:      RunStatusRunning,
 		TriggeredAt: time.Now().UTC(),
@@ -307,6 +317,64 @@ func (m *Manager) CompleteRun(runID, threadID, turnID string, runErr error) erro
 		errorText = runErr.Error()
 	}
 	return m.runStore.Finish(strings.TrimSpace(runID), status, strings.TrimSpace(threadID), strings.TrimSpace(turnID), errorText)
+}
+
+func (m *Manager) MarkRunRunning(runID, threadID, turnID string) error {
+	if m == nil {
+		return errors.New("automation manager is required")
+	}
+	return m.runStore.UpdateAdmission(
+		strings.TrimSpace(runID), RunStatusRunning,
+		strings.TrimSpace(threadID), strings.TrimSpace(turnID), "",
+	)
+}
+
+func (m *Manager) FailRunIfPending(runID, reason string) error {
+	if m == nil {
+		return errors.New("automation manager is required")
+	}
+	return m.runStore.FailIfPending(runID, reason)
+}
+
+func (m *Manager) recoverRuns(ctx context.Context, executor Executor) error {
+	runs, err := m.runStore.List()
+	if err != nil {
+		return fmt.Errorf("load automation runs for recovery: %w", err)
+	}
+	for _, run := range runs {
+		switch run.Status {
+		case RunStatusRunning:
+			if err := m.runStore.Finish(run.ID, RunStatusFailed, run.ThreadID, run.TurnID, "automation stopped before the turn completed"); err != nil {
+				return err
+			}
+		case RunStatusQueued:
+			task := normalizeTask(run.Task)
+			if strings.TrimSpace(task.ID) == "" {
+				task.ID = run.TaskID
+			}
+			if strings.TrimSpace(task.Prompt) == "" {
+				if err := m.runStore.Finish(run.ID, RunStatusFailed, run.ThreadID, run.TurnID, "queued automation payload is unavailable"); err != nil {
+					return err
+				}
+				continue
+			}
+			result, executeErr := executor.ExecuteAutomation(ctx, task, run)
+			if executeErr != nil {
+				if err := m.runStore.Finish(run.ID, RunStatusFailed, run.ThreadID, run.TurnID, executeErr.Error()); err != nil {
+					return err
+				}
+				continue
+			}
+			status := result.Status
+			if status != RunStatusQueued && status != RunStatusRunning {
+				status = RunStatusRunning
+			}
+			if err := m.runStore.UpdateAdmission(run.ID, status, result.ThreadID, result.TurnID, result.QueueID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (m *Manager) ensureCapacity() error {

--- a/internal/automation/manager_test.go
+++ b/internal/automation/manager_test.go
@@ -39,7 +39,7 @@ func TestManagerAddsHeartbeatTaskWithCreatorThread(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTasks() error = %v", err)
 	}
-	if len(tasks) != 1 || tasks[0].ID != task.ID {
+	if len(tasks) != 1 || tasks[0].ID != task.ID || tasks[0].Metadata["durability"] != "durable" {
 		t.Fatalf("ListTasks() = %#v", tasks)
 	}
 }

--- a/internal/automation/manager_test.go
+++ b/internal/automation/manager_test.go
@@ -98,3 +98,42 @@ func TestManagerRecordsExecutionFailure(t *testing.T) {
 		t.Fatalf("runs = %#v", runs)
 	}
 }
+
+func TestManagerPausesDurableTask(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	task, err := manager.AddTask(AddTaskParams{
+		Prompt: "inspect", Schedule: "*/5 * * * *", Timezone: "UTC", Durable: true,
+	})
+	if err != nil {
+		t.Fatalf("AddTask() error = %v", err)
+	}
+	paused, err := manager.SetPaused(task.ID, true)
+	if err != nil {
+		t.Fatalf("SetPaused() error = %v", err)
+	}
+	if !paused.Paused {
+		t.Fatalf("paused task = %#v", paused)
+	}
+	tasks, err := manager.ListTasks()
+	if err != nil || len(tasks) != 1 || !tasks[0].Paused {
+		t.Fatalf("ListTasks() = %#v, %v", tasks, err)
+	}
+}
+
+func TestRunAdmissionDoesNotOverwriteTerminalStatus(t *testing.T) {
+	store := NewRunStore(t.TempDir() + "/runs.json")
+	run := Run{ID: "run-1", Status: RunStatusRunning}
+	if err := store.Add(run); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if err := store.Finish(run.ID, RunStatusCompleted, "thread-1", "turn-1", ""); err != nil {
+		t.Fatalf("Finish() error = %v", err)
+	}
+	if err := store.UpdateAdmission(run.ID, RunStatusRunning, "thread-1", "turn-1", ""); err != nil {
+		t.Fatalf("UpdateAdmission() error = %v", err)
+	}
+	runs, err := store.List()
+	if err != nil || len(runs) != 1 || runs[0].Status != RunStatusCompleted {
+		t.Fatalf("runs = %#v, %v", runs, err)
+	}
+}

--- a/internal/automation/manager_test.go
+++ b/internal/automation/manager_test.go
@@ -9,9 +9,13 @@ import (
 type recordingExecutor struct {
 	result ExecutionResult
 	err    error
+	tasks  []Task
+	runs   []Run
 }
 
-func (e *recordingExecutor) ExecuteAutomation(_ context.Context, _ Task, _ Run) (ExecutionResult, error) {
+func (e *recordingExecutor) ExecuteAutomation(_ context.Context, task Task, run Run) (ExecutionResult, error) {
+	e.tasks = append(e.tasks, task)
+	e.runs = append(e.runs, run)
 	return e.result, e.err
 }
 
@@ -135,5 +139,49 @@ func TestRunAdmissionDoesNotOverwriteTerminalStatus(t *testing.T) {
 	runs, err := store.List()
 	if err != nil || len(runs) != 1 || runs[0].Status != RunStatusCompleted {
 		t.Fatalf("runs = %#v, %v", runs, err)
+	}
+}
+
+func TestManagerRecoversQueuedRunAndFailsInterruptedRun(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	queuedTask := Task{
+		ID: "queued-task", Prompt: "resume queued work", Mode: string(ModeThreadHeartbeat),
+		HeartbeatThreadID: "thread-1", Cron: "*/5 * * * *", Timezone: "UTC",
+	}
+	if err := manager.runStore.Add(Run{
+		ID: "queued-run", TaskID: queuedTask.ID, Task: queuedTask,
+		Mode: queuedTask.Mode, Status: RunStatusQueued,
+	}); err != nil {
+		t.Fatalf("add queued run: %v", err)
+	}
+	if err := manager.runStore.Add(Run{
+		ID: "running-run", TaskID: "running-task", Status: RunStatusRunning,
+		ThreadID: "thread-2", TurnID: "turn-1",
+	}); err != nil {
+		t.Fatalf("add running run: %v", err)
+	}
+	executor := &recordingExecutor{result: ExecutionResult{
+		Status: RunStatusRunning, ThreadID: "thread-1", TurnID: "turn-2",
+	}}
+	if err := manager.Start(executor); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer manager.Stop()
+	if len(executor.tasks) != 1 || executor.tasks[0].Prompt != queuedTask.Prompt || len(executor.runs) != 1 || executor.runs[0].ID != "queued-run" {
+		t.Fatalf("recovered execution = tasks %#v, runs %#v", executor.tasks, executor.runs)
+	}
+	runs, err := manager.ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	byID := make(map[string]Run, len(runs))
+	for _, run := range runs {
+		byID[run.ID] = run
+	}
+	if recovered := byID["queued-run"]; recovered.Status != RunStatusRunning || recovered.ThreadID != "thread-1" || recovered.TurnID != "turn-2" {
+		t.Fatalf("recovered queued run = %#v", recovered)
+	}
+	if interrupted := byID["running-run"]; interrupted.Status != RunStatusFailed || interrupted.CompletedAt.IsZero() || interrupted.Error == "" {
+		t.Fatalf("interrupted running run = %#v", interrupted)
 	}
 }

--- a/internal/automation/manager_test.go
+++ b/internal/automation/manager_test.go
@@ -1,0 +1,100 @@
+package automation
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type recordingExecutor struct {
+	result ExecutionResult
+	err    error
+}
+
+func (e *recordingExecutor) ExecuteAutomation(_ context.Context, _ Task, _ Run) (ExecutionResult, error) {
+	return e.result, e.err
+}
+
+func TestManagerAddsHeartbeatTaskWithCreatorThread(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	task, err := manager.AddTask(AddTaskParams{
+		Prompt:          "check cache health",
+		Schedule:        "*/5 * * * *",
+		Timezone:        "UTC",
+		Mode:            ModeThreadHeartbeat,
+		CreatorThreadID: "thread-1",
+		Recurring:       true,
+		Durable:         true,
+	})
+	if err != nil {
+		t.Fatalf("AddTask() error = %v", err)
+	}
+	if task.HeartbeatThreadID != "thread-1" {
+		t.Fatalf("HeartbeatThreadID = %q, want thread-1", task.HeartbeatThreadID)
+	}
+	if task.Mode != string(ModeThreadHeartbeat) {
+		t.Fatalf("Mode = %q", task.Mode)
+	}
+	tasks, err := manager.ListTasks()
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != task.ID {
+		t.Fatalf("ListTasks() = %#v", tasks)
+	}
+}
+
+func TestManagerRejectsHeartbeatWithoutThread(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	_, err := manager.AddTask(AddTaskParams{
+		Prompt:   "check cache health",
+		Schedule: "*/5 * * * *",
+		Timezone: "UTC",
+		Mode:     ModeThreadHeartbeat,
+	})
+	if err == nil {
+		t.Fatal("AddTask() error = nil")
+	}
+}
+
+func TestManagerRecordsAdmissionAndCompletion(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	manager.executor = &recordingExecutor{result: ExecutionResult{
+		Status:   RunStatusRunning,
+		ThreadID: "thread-2",
+		TurnID:   "turn-1",
+	}}
+	if err := manager.Fire(context.Background(), Task{ID: "task-1", Prompt: "inspect", Mode: string(ModeNewThread)}); err != nil {
+		t.Fatalf("Fire() error = %v", err)
+	}
+	runs, err := manager.ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns() error = %v", err)
+	}
+	if len(runs) != 1 || runs[0].Status != RunStatusRunning || runs[0].ThreadID != "thread-2" {
+		t.Fatalf("runs = %#v", runs)
+	}
+	if err := manager.CompleteRun(runs[0].ID, "thread-2", "turn-1", nil); err != nil {
+		t.Fatalf("CompleteRun() error = %v", err)
+	}
+	runs, _ = manager.ListRuns()
+	if runs[0].Status != RunStatusCompleted || runs[0].CompletedAt.IsZero() {
+		t.Fatalf("completed run = %#v", runs[0])
+	}
+}
+
+func TestManagerRecordsExecutionFailure(t *testing.T) {
+	manager := NewManager(Config{StateDir: t.TempDir()})
+	manager.executor = &recordingExecutor{err: errors.New("start failed")}
+	err := manager.Fire(context.Background(), Task{ID: "task-1", Prompt: "inspect"})
+	if err == nil {
+		t.Fatal("Fire() error = nil")
+	}
+	runs, listErr := manager.ListRuns()
+	if listErr != nil {
+		t.Fatalf("ListRuns() error = %v", listErr)
+	}
+	if len(runs) != 1 || runs[0].Status != RunStatusFailed || runs[0].Error != "start failed" {
+		t.Fatalf("runs = %#v", runs)
+	}
+}

--- a/internal/automation/runs.go
+++ b/internal/automation/runs.go
@@ -16,6 +16,7 @@ import (
 type Run struct {
 	ID          string    `json:"id"`
 	TaskID      string    `json:"task_id"`
+	Task        Task      `json:"task"`
 	Mode        string    `json:"mode"`
 	Status      RunStatus `json:"status"`
 	TriggeredAt time.Time `json:"triggered_at"`
@@ -78,6 +79,25 @@ func (s *RunStore) Finish(id string, status RunStatus, threadID, turnID, errorTe
 			run.TurnID = turnID
 		}
 		run.Error = strings.TrimSpace(errorText)
+	})
+}
+
+func (s *RunStore) FailIfPending(id, errorText string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	return s.update(func(runs []Run) ([]Run, error) {
+		for index := range runs {
+			if runs[index].ID != id || runs[index].Status == RunStatusCompleted || runs[index].Status == RunStatusFailed {
+				continue
+			}
+			runs[index].Status = RunStatusFailed
+			runs[index].CompletedAt = time.Now().UTC()
+			runs[index].Error = strings.TrimSpace(errorText)
+			break
+		}
+		return runs, nil
 	})
 }
 

--- a/internal/automation/runs.go
+++ b/internal/automation/runs.go
@@ -57,6 +57,9 @@ func (s *RunStore) Add(run Run) error {
 
 func (s *RunStore) UpdateAdmission(id string, status RunStatus, threadID, turnID, queueID string) error {
 	return s.mutate(id, func(run *Run) {
+		if run.Status == RunStatusCompleted || run.Status == RunStatusFailed {
+			return
+		}
 		run.Status = status
 		run.ThreadID = strings.TrimSpace(threadID)
 		run.TurnID = strings.TrimSpace(turnID)

--- a/internal/automation/runs.go
+++ b/internal/automation/runs.go
@@ -1,0 +1,168 @@
+package automation
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Run struct {
+	ID          string    `json:"id"`
+	TaskID      string    `json:"task_id"`
+	Mode        string    `json:"mode"`
+	Status      RunStatus `json:"status"`
+	TriggeredAt time.Time `json:"triggered_at"`
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	ThreadID    string    `json:"thread_id,omitempty"`
+	TurnID      string    `json:"turn_id,omitempty"`
+	QueueID     string    `json:"queue_id,omitempty"`
+	Error       string    `json:"error,omitempty"`
+}
+
+type RunStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewRunStore(path string) *RunStore {
+	return &RunStore{path: strings.TrimSpace(path)}
+}
+
+func (s *RunStore) List() ([]Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.load()
+}
+
+func (s *RunStore) Add(run Run) error {
+	if strings.TrimSpace(run.ID) == "" {
+		return errors.New("automation run id is required")
+	}
+	return s.update(func(runs []Run) ([]Run, error) {
+		for _, existing := range runs {
+			if existing.ID == run.ID {
+				return nil, fmt.Errorf("automation run %q already exists", run.ID)
+			}
+		}
+		return append(runs, run), nil
+	})
+}
+
+func (s *RunStore) UpdateAdmission(id string, status RunStatus, threadID, turnID, queueID string) error {
+	return s.mutate(id, func(run *Run) {
+		run.Status = status
+		run.ThreadID = strings.TrimSpace(threadID)
+		run.TurnID = strings.TrimSpace(turnID)
+		run.QueueID = strings.TrimSpace(queueID)
+	})
+}
+
+func (s *RunStore) Finish(id string, status RunStatus, threadID, turnID, errorText string) error {
+	return s.mutate(id, func(run *Run) {
+		run.Status = status
+		run.CompletedAt = time.Now().UTC()
+		if threadID != "" {
+			run.ThreadID = threadID
+		}
+		if turnID != "" {
+			run.TurnID = turnID
+		}
+		run.Error = strings.TrimSpace(errorText)
+	})
+}
+
+func (s *RunStore) mutate(id string, mutation func(*Run)) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("automation run id is required")
+	}
+	return s.update(func(runs []Run) ([]Run, error) {
+		for index := range runs {
+			if runs[index].ID == id {
+				mutation(&runs[index])
+				return runs, nil
+			}
+		}
+		return nil, fmt.Errorf("automation run %q not found", id)
+	})
+}
+
+func (s *RunStore) update(change func([]Run) ([]Run, error)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	runs, err := s.load()
+	if err != nil {
+		return err
+	}
+	runs, err = change(runs)
+	if err != nil {
+		return err
+	}
+	return s.save(runs)
+}
+
+func (s *RunStore) load() ([]Run, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var wrapper struct {
+		Runs []Run `json:"runs"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("parse automation runs: %w", err)
+	}
+	return wrapper.Runs, nil
+}
+
+func (s *RunStore) save(runs []Run) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(struct {
+		Runs []Run `json:"runs"`
+	}{Runs: runs}, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".automation-runs-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, s.path)
+}
+
+func newRunID() string {
+	bytes := make([]byte, 8)
+	if _, err := rand.Read(bytes); err != nil {
+		return fmt.Sprintf("run-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(bytes)
+}

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/contextbudget"
+	"github.com/blueberrycongee/wuu/internal/provideroptions"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/stringutil"
 	"github.com/blueberrycongee/wuu/internal/toolresult"
@@ -151,6 +152,10 @@ func CanCompactWithBudget(messages []providers.ChatMessage, model string, budget
 }
 
 func CompactWithBudget(ctx context.Context, messages []providers.ChatMessage, client providers.Client, model string, budget Budget) ([]providers.ChatMessage, error) {
+	return CompactWithBudgetAndOptions(ctx, messages, client, model, budget, nil)
+}
+
+func CompactWithBudgetAndOptions(ctx context.Context, messages []providers.ChatMessage, client providers.Client, model string, budget Budget, options map[string]any) ([]providers.ChatMessage, error) {
 	plan, ok := planCompaction(messages, model, budget)
 	if !ok {
 		return messages, nil
@@ -161,7 +166,7 @@ func CompactWithBudget(ctx context.Context, messages []providers.ChatMessage, cl
 	toSummarize := plan.conversation[:plan.keepStart]
 	toKeep := plan.conversation[plan.keepStart:]
 
-	summary, err := summarizeCompactHistory(ctx, client, model, budget, toSummarize, plan.previousSummary)
+	summary, err := summarizeCompactHistory(ctx, client, model, budget, options, toSummarize, plan.previousSummary)
 	if err != nil {
 		return messages, err
 	}
@@ -215,7 +220,7 @@ func planCompaction(messages []providers.ChatMessage, model string, budget Budge
 	}, true
 }
 
-func summarizeCompactHistory(ctx context.Context, client providers.Client, model string, budget Budget, messages []providers.ChatMessage, previousSummary string) (string, error) {
+func summarizeCompactHistory(ctx context.Context, client providers.Client, model string, budget Budget, options map[string]any, messages []providers.ChatMessage, previousSummary string) (string, error) {
 	if len(messages) == 0 {
 		return strings.TrimSpace(previousSummary), nil
 	}
@@ -228,7 +233,7 @@ func summarizeCompactHistory(ctx context.Context, client providers.Client, model
 			n = 1
 		}
 		chunk := remaining[:n]
-		next, err := summarizeCompactChunk(ctx, client, model, chunk, summary)
+		next, err := summarizeCompactChunk(ctx, client, model, options, chunk, summary)
 		if err != nil {
 			return "", err
 		}
@@ -249,10 +254,10 @@ func limitSummaryOutput(summary string) string {
 	return summary[:cut]
 }
 
-func summarizeCompactChunk(ctx context.Context, client providers.Client, model string, messages []providers.ChatMessage, previousSummary string) (string, error) {
+func summarizeCompactChunk(ctx context.Context, client providers.Client, model string, options map[string]any, messages []providers.ChatMessage, previousSummary string) (string, error) {
 	toSummarize := messages
 	for attempt := 0; ; attempt++ {
-		summaryReq := compactSummaryRequest(model, buildSummaryPrompt(toSummarize, previousSummary))
+		summaryReq := compactSummaryRequest(model, buildSummaryPrompt(toSummarize, previousSummary), options)
 		resp, err := summarizeCompact(ctx, client, summaryReq)
 		if err != nil {
 			// If the summary request itself overflowed the model's
@@ -269,7 +274,7 @@ func summarizeCompactChunk(ctx context.Context, client providers.Client, model s
 	}
 }
 
-func compactSummaryRequest(model, prompt string) providers.ChatRequest {
+func compactSummaryRequest(model, prompt string, options map[string]any) providers.ChatRequest {
 	return providers.ChatRequest{
 		Model:     model,
 		Operation: providers.NewInferenceOperation(providers.InferenceOperationCompaction, providers.InferenceProfileContinuationCritical),
@@ -277,12 +282,19 @@ func compactSummaryRequest(model, prompt string) providers.ChatRequest {
 			{Role: "system", Content: "You summarize coding-agent conversations for context compaction. Follow the user's required format exactly. Do not call tools."},
 			{Role: "user", Content: prompt},
 		},
-		Temperature: 0.3,
-		MaxTokens:   compactSummaryMaxTokens,
-		ProviderOptions: map[string]any{
-			"textVerbosity": "low",
-		},
+		Temperature:     0.3,
+		MaxTokens:       compactSummaryMaxTokens,
+		ProviderOptions: compactSummaryProviderOptions(options),
 	}
+}
+
+func compactSummaryProviderOptions(options map[string]any) map[string]any {
+	out := provideroptions.Clone(options)
+	if out == nil {
+		out = make(map[string]any, 1)
+	}
+	out["textVerbosity"] = "low"
+	return out
 }
 
 func summarizeCompact(ctx context.Context, client providers.Client, req providers.ChatRequest) (providers.ChatResponse, error) {

--- a/internal/compact/compact_test.go
+++ b/internal/compact/compact_test.go
@@ -371,7 +371,8 @@ func TestCompact_SetsSummaryOutputControls(t *testing.T) {
 	}
 
 	client := &mockCompactClient{response: "summary of older turns"}
-	_, err := Compact(context.Background(), messages, client, "gpt-5.5")
+	options := map[string]any{"temperatureSupported": false, "textVerbosity": "high"}
+	_, err := CompactWithBudgetAndOptions(context.Background(), messages, client, "gpt-5.5", Budget{}, options)
 	if err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
@@ -380,6 +381,12 @@ func TestCompact_SetsSummaryOutputControls(t *testing.T) {
 	}
 	if got := client.lastRequest.ProviderOptions["textVerbosity"]; got != "low" {
 		t.Fatalf("expected low text verbosity, got %#v", got)
+	}
+	if got := client.lastRequest.ProviderOptions["temperatureSupported"]; got != false {
+		t.Fatalf("expected model temperature compatibility option, got %#v", got)
+	}
+	if got := options["textVerbosity"]; got != "high" {
+		t.Fatalf("compact request mutated caller options, got %#v", got)
 	}
 }
 

--- a/internal/compact/helpme_extract.go
+++ b/internal/compact/helpme_extract.go
@@ -52,6 +52,10 @@ Where things stand now: files changed, verification results, and what remains un
 // the extraction never needs the whole history in one window. The journal is
 // bounded to helpMeCompactMaxSectionBytes.
 func BuildHelpMeParentJournal(ctx context.Context, client providers.Client, model string, budget Budget, history []providers.ChatMessage) (string, error) {
+	return BuildHelpMeParentJournalWithOptions(ctx, client, model, budget, nil, history)
+}
+
+func BuildHelpMeParentJournalWithOptions(ctx context.Context, client providers.Client, model string, budget Budget, options map[string]any, history []providers.ChatMessage) (string, error) {
 	if client == nil {
 		return "", nil
 	}
@@ -71,7 +75,7 @@ func BuildHelpMeParentJournal(ctx context.Context, client providers.Client, mode
 		if n <= 0 {
 			n = 1
 		}
-		next, err := extractHelpMeJournalChunk(ctx, client, model, remaining[:n], journal)
+		next, err := extractHelpMeJournalChunk(ctx, client, model, options, remaining[:n], journal)
 		if err != nil {
 			return "", err
 		}
@@ -124,10 +128,10 @@ func buildHelpMeJournalPrompt(chunk []providers.ChatMessage, previousJournal str
 	return b.String()
 }
 
-func extractHelpMeJournalChunk(ctx context.Context, client providers.Client, model string, chunk []providers.ChatMessage, previousJournal string) (string, error) {
+func extractHelpMeJournalChunk(ctx context.Context, client providers.Client, model string, options map[string]any, chunk []providers.ChatMessage, previousJournal string) (string, error) {
 	toExtract := chunk
 	for attempt := 0; ; attempt++ {
-		req := helpMeJournalRequest(model, buildHelpMeJournalPrompt(toExtract, previousJournal))
+		req := helpMeJournalRequest(model, buildHelpMeJournalPrompt(toExtract, previousJournal), options)
 		resp, err := summarizeCompact(ctx, client, req)
 		if err != nil {
 			// Same backstop as summarizeCompactChunk: if the extraction
@@ -143,7 +147,7 @@ func extractHelpMeJournalChunk(ctx context.Context, client providers.Client, mod
 	}
 }
 
-func helpMeJournalRequest(model, prompt string) providers.ChatRequest {
+func helpMeJournalRequest(model, prompt string, options map[string]any) providers.ChatRequest {
 	return providers.ChatRequest{
 		Model:     model,
 		Operation: providers.NewInferenceOperation(providers.InferenceOperationReview, providers.InferenceProfileContinuationCritical),
@@ -151,11 +155,9 @@ func helpMeJournalRequest(model, prompt string) providers.ChatRequest {
 			{Role: "system", Content: helpMeJournalSystemPrompt},
 			{Role: "user", Content: prompt},
 		},
-		Temperature: 0.2,
-		MaxTokens:   helpMeJournalMaxTokens,
-		ProviderOptions: map[string]any{
-			"textVerbosity": "low",
-		},
+		Temperature:     0.2,
+		MaxTokens:       helpMeJournalMaxTokens,
+		ProviderOptions: compactSummaryProviderOptions(options),
 	}
 }
 

--- a/internal/compact/helpme_extract_test.go
+++ b/internal/compact/helpme_extract_test.go
@@ -15,6 +15,7 @@ import (
 type journalRecordingClient struct {
 	mu        sync.Mutex
 	prompts   []string
+	requests  []providers.ChatRequest
 	responses []string
 }
 
@@ -26,6 +27,7 @@ func (c *journalRecordingClient) Chat(_ context.Context, req providers.ChatReque
 		prompt = req.Messages[len(req.Messages)-1].Content
 	}
 	c.prompts = append(c.prompts, prompt)
+	c.requests = append(c.requests, req)
 	idx := len(c.prompts) - 1
 	if idx >= len(c.responses) {
 		idx = len(c.responses) - 1
@@ -37,6 +39,12 @@ func (c *journalRecordingClient) recorded() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]string(nil), c.prompts...)
+}
+
+func (c *journalRecordingClient) recordedRequests() []providers.ChatRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]providers.ChatRequest(nil), c.requests...)
 }
 
 func TestBuildHelpMeParentJournalSingleChunk(t *testing.T) {
@@ -69,6 +77,32 @@ func TestBuildHelpMeParentJournalSingleChunk(t *testing.T) {
 	// The extraction prompt is not the continuation-style compact prompt.
 	if strings.Contains(prompts[0], "context compaction") || strings.Contains(prompts[0], "## External State") {
 		t.Fatalf("extraction must not reuse the continuation summary prompt:\n%s", prompts[0])
+	}
+}
+
+func TestBuildHelpMeParentJournalPropagatesProviderOptions(t *testing.T) {
+	client := &journalRecordingClient{responses: []string{"### User goal\nkeep model compatibility"}}
+	history := []providers.ChatMessage{
+		{Role: "user", Content: "investigate the failure"},
+		{Role: "assistant", Content: "working on it"},
+	}
+	options := map[string]any{"temperatureSupported": false, "textVerbosity": "high"}
+
+	if _, err := BuildHelpMeParentJournalWithOptions(context.Background(), client, "fake-model", Budget{}, options, history); err != nil {
+		t.Fatal(err)
+	}
+	requests := client.recordedRequests()
+	if len(requests) != 1 {
+		t.Fatalf("expected one extraction request, got %d", len(requests))
+	}
+	if got := requests[0].ProviderOptions["temperatureSupported"]; got != false {
+		t.Fatalf("expected model temperature compatibility option, got %#v", got)
+	}
+	if got := requests[0].ProviderOptions["textVerbosity"]; got != "low" {
+		t.Fatalf("expected low extraction verbosity, got %#v", got)
+	}
+	if got := options["textVerbosity"]; got != "high" {
+		t.Fatalf("journal extraction mutated caller options, got %#v", got)
 	}
 }
 

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -182,6 +182,9 @@ func (s *Scheduler) checkStore(kind string, store schedulerStore, sessionOnly bo
 		if s.shouldStopWork() {
 			return
 		}
+		if task.Paused {
+			continue
+		}
 		if task.Recurring && IsExpired(task, now.UnixMilli()) {
 			if _, err := store.RemoveIfUnchanged(task); err != nil {
 				s.reportError(fmt.Errorf("remove expired %s scheduled task %q: %w", kind, task.ID, err))

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -118,6 +118,9 @@ func (s *Scheduler) catchUpStore(kind string, store schedulerStore, sessionOnly 
 		return
 	}
 	for _, task := range FindMissedOneShots(tasks, now) {
+		if task.Paused {
+			continue
+		}
 		if s.shouldStopWork() {
 			return
 		}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -241,6 +241,16 @@ func TestScheduler_StartCatchesUpMissedOneShots(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("fileStore.Add recurring: %v", err)
 	}
+	if err := fileStore.Add(Task{
+		ID:        "paused-missed",
+		Cron:      missedCronFor(missedAt),
+		Prompt:    "paused missed",
+		CreatedAt: missedAt.Add(-time.Hour).UnixMilli(),
+		Recurring: false,
+		Paused:    true,
+	}); err != nil {
+		t.Fatalf("fileStore.Add paused: %v", err)
+	}
 
 	firedCh := make(chan string, 4)
 	s := NewScheduler(SchedulerConfig{
@@ -270,8 +280,12 @@ func TestScheduler_StartCatchesUpMissedOneShots(t *testing.T) {
 	}
 
 	fileTasks, _ := fileStore.List()
-	if len(fileTasks) != 1 || fileTasks[0].ID != "recurring-untouched" {
-		t.Fatalf("expected only the recurring task to remain, got %#v", fileTasks)
+	remaining := map[string]bool{}
+	for _, task := range fileTasks {
+		remaining[task.ID] = true
+	}
+	if len(fileTasks) != 2 || !remaining["recurring-untouched"] || !remaining["paused-missed"] {
+		t.Fatalf("expected recurring and paused tasks to remain, got %#v", fileTasks)
 	}
 	sessionTasks, _ := sessionStore.List()
 	if len(sessionTasks) != 0 {

--- a/internal/cron/tasks.go
+++ b/internal/cron/tasks.go
@@ -20,13 +20,19 @@ const (
 )
 
 type Task struct {
-	ID          string            `json:"id"`
-	Cron        string            `json:"cron"`
-	Prompt      string            `json:"prompt,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	CreatedAt   int64             `json:"createdAt"`
-	LastFiredAt int64             `json:"lastFiredAt,omitempty"`
-	Recurring   bool              `json:"recurring"`
+	ID                string            `json:"id"`
+	Title             string            `json:"title,omitempty"`
+	Cron              string            `json:"cron"`
+	Timezone          string            `json:"timezone,omitempty"`
+	Prompt            string            `json:"prompt,omitempty"`
+	Mode              string            `json:"mode,omitempty"`
+	CreatorThreadID   string            `json:"creatorThreadId,omitempty"`
+	HeartbeatThreadID string            `json:"heartbeatThreadId,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+	CreatedAt         int64             `json:"createdAt"`
+	LastFiredAt       int64             `json:"lastFiredAt,omitempty"`
+	Recurring         bool              `json:"recurring"`
+	Paused            bool              `json:"paused,omitempty"`
 }
 
 func (t Task) NextFireAt() (time.Time, error) {
@@ -34,11 +40,18 @@ func (t Task) NextFireAt() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	anchor := time.Now()
+	location := time.Local
+	if timezone := strings.TrimSpace(t.Timezone); timezone != "" {
+		location, err = time.LoadLocation(timezone)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("load timezone %q: %w", timezone, err)
+		}
+	}
+	anchor := time.Now().In(location)
 	if t.LastFiredAt > 0 {
-		anchor = time.UnixMilli(t.LastFiredAt)
+		anchor = time.UnixMilli(t.LastFiredAt).In(location)
 	} else if t.CreatedAt > 0 {
-		anchor = time.UnixMilli(t.CreatedAt)
+		anchor = time.UnixMilli(t.CreatedAt).In(location)
 	}
 	return JitteredNextRun(ce, t.ID, anchor, t.Recurring)
 }
@@ -353,12 +366,18 @@ func matchingTaskIndex(tasks []Task, expected Task) (int, error) {
 
 func sameTask(left, right Task) bool {
 	return left.ID == right.ID &&
+		left.Title == right.Title &&
 		left.Cron == right.Cron &&
+		left.Timezone == right.Timezone &&
 		left.Prompt == right.Prompt &&
+		left.Mode == right.Mode &&
+		left.CreatorThreadID == right.CreatorThreadID &&
+		left.HeartbeatThreadID == right.HeartbeatThreadID &&
 		maps.Equal(left.Metadata, right.Metadata) &&
 		left.CreatedAt == right.CreatedAt &&
 		left.LastFiredAt == right.LastFiredAt &&
-		left.Recurring == right.Recurring
+		left.Recurring == right.Recurring &&
+		left.Paused == right.Paused
 }
 
 func GenerateTaskID() string {

--- a/internal/cron/tasks.go
+++ b/internal/cron/tasks.go
@@ -171,6 +171,28 @@ func (s *TaskStore) Remove(ids ...string) error {
 	})
 }
 
+func (s *TaskStore) SetPaused(id string, paused bool) (Task, bool, error) {
+	var updated Task
+	found := false
+	err := s.updateIfChanged(func(tasks []Task) ([]Task, bool, error) {
+		for index := range tasks {
+			if tasks[index].ID != id {
+				continue
+			}
+			found = true
+			if tasks[index].Paused == paused {
+				updated = tasks[index]
+				return tasks, false, nil
+			}
+			tasks[index].Paused = paused
+			updated = tasks[index]
+			return tasks, true, nil
+		}
+		return tasks, false, nil
+	})
+	return updated, found, err
+}
+
 // ClaimForDispatch atomically consumes one due task occurrence if the stored
 // task still matches the scheduler snapshot. Recurring tasks advance their
 // LastFiredAt timestamp; one-shot tasks are removed. A successful claim is an
@@ -304,6 +326,22 @@ func (s *SessionTaskStore) Remove(ids ...string) error {
 	}
 	sessionTaskState.tasks[s.namespace] = filtered
 	return nil
+}
+
+func (s *SessionTaskStore) SetPaused(id string, paused bool) (Task, bool, error) {
+	sessionTaskState.mu.Lock()
+	defer sessionTaskState.mu.Unlock()
+
+	tasks := sessionTaskState.tasks[s.namespace]
+	for index := range tasks {
+		if tasks[index].ID != id {
+			continue
+		}
+		tasks[index].Paused = paused
+		sessionTaskState.tasks[s.namespace] = tasks
+		return tasks[index], true, nil
+	}
+	return Task{}, false, nil
 }
 
 func (s *SessionTaskStore) ClaimForDispatch(expected Task, firedAt int64) (bool, error) {

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -23,8 +23,6 @@ import (
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/config"
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
-	"github.com/blueberrycongee/wuu/internal/cron"
-	goalrunner "github.com/blueberrycongee/wuu/internal/goal"
 	"github.com/blueberrycongee/wuu/internal/goalruntime"
 	"github.com/blueberrycongee/wuu/internal/hooks"
 	"github.com/blueberrycongee/wuu/internal/mcp"
@@ -145,8 +143,6 @@ type Session struct {
 	ExperimentalHelpMe          bool
 	DeferredToolCatalogPrompt   string
 	AutomationManager           *automation.Manager
-	CronScheduler               *cron.Scheduler
-	CronLock                    *cron.Lock
 	ReadinessIssues             []ReadinessIssue
 	InferenceJournalRuntime     *session.InferenceJournalRuntime
 }
@@ -702,166 +698,6 @@ func resolveToolLoadingModeForProvider(mode config.ToolLoadingMode, providerCfg 
 		}
 		return config.ToolLoadingFlat, false, false
 	}
-}
-
-func (s *Session) StartCronScheduler() error {
-	if s == nil || s.StreamRunner == nil {
-		return nil
-	}
-	if s.CronScheduler != nil {
-		return nil
-	}
-	stateDir := strings.TrimSpace(s.StateDir)
-	if stateDir == "" {
-		return fmt.Errorf("workspace state directory is required for cron scheduler")
-	}
-
-	lock := cron.NewLock(statepath.ScheduledTasksLockPath(stateDir))
-	ownsDurableTasks := false
-	scheduler := cron.NewScheduler(cron.SchedulerConfig{
-		Store:        cron.NewTaskStore(statepath.ScheduledTasksPath(stateDir)),
-		SessionStore: cron.NewSessionTaskStore(stateDir),
-		OnFire: func(ctx context.Context, task cron.Task) error {
-			return s.runScheduledPrompt(ctx, task)
-		},
-		OnError: func(err error) {
-			providers.DebugLogf("cron scheduler: %v", err)
-		},
-		IsOwner: func() bool {
-			if ownsDurableTasks {
-				return true
-			}
-			ok, err := lock.TryAcquire()
-			if err != nil {
-				providers.DebugLogf("cron scheduler lock acquire failed: %v", err)
-				return false
-			}
-			ownsDurableTasks = ok
-			return ok
-		},
-	})
-	s.CronLock = lock
-	s.CronScheduler = scheduler
-	scheduler.Start()
-	return nil
-}
-
-func (s *Session) runScheduledPrompt(ctx context.Context, task cron.Task) error {
-	prompt := strings.TrimSpace(task.Prompt)
-	if prompt == "" {
-		return fmt.Errorf("scheduled prompt task %q has an empty prompt", task.ID)
-	}
-	goalStore := s.startScheduledGoal(ctx, task, prompt)
-	threadRT, err := s.NewThreadRuntime(scheduledCronSessionID("cron-task", task.ID))
-	if err != nil {
-		err = fmt.Errorf("create isolated runtime: %w", err)
-		s.recordScheduledFailure(goalStore, task.ID, err)
-		return err
-	}
-	if threadRT.StreamRunner == nil {
-		err = errors.New("isolated runtime has no stream runner")
-		s.recordScheduledFailure(goalStore, task.ID, err)
-		return err
-	}
-	if threadRT.AgentControl != nil {
-		defer func() {
-			if shutdownErr := shutdownAndCleanupAgentControl(threadRT.AgentControl); shutdownErr != nil {
-				providers.DebugLogf("scheduled runtime shutdown: %v", shutdownErr)
-			}
-		}()
-		// Scheduled runtimes do not pass through app-server's runtime
-		// installation path. Their worker dependencies are complete once
-		// NewThreadRuntime returns, so enable queued work explicitly here.
-		threadRT.AgentControl.StartWorkerTerminalRecovery()
-		threadRT.AgentControl.StartQueuedWork()
-	}
-	if _, err := threadRT.StreamRunner.Run(ctx, prompt); err != nil {
-		s.recordScheduledFailure(goalStore, task.ID, err)
-		return err
-	}
-	if goalStore != nil {
-		_, _ = goalStore.MarkStepCompleted(goalrunner.StepExecution)
-		_, _ = goalStore.AddProgress(goalrunner.StepSummary, "Scheduled task execution completed.")
-		_, _ = goalStore.SetStatus(goalrunner.StatusCompleted, goalrunner.StepSummary, "scheduled task execution completed")
-	}
-	return nil
-}
-
-func (s *Session) recordScheduledFailure(goalStore *goalrunner.Store, taskID string, err error) {
-	if goalStore == nil || err == nil {
-		return
-	}
-	_, _ = goalStore.AddFailure(goalrunner.Failure{
-		Step:     goalrunner.StepExecution,
-		Kind:     "scheduled_task_failed",
-		Source:   "cron",
-		SourceID: taskID,
-		Message:  err.Error(),
-	})
-}
-
-func (s *Session) startScheduledGoal(ctx context.Context, task cron.Task, prompt string) *goalrunner.Store {
-	stateDir := strings.TrimSpace(s.StateDir)
-	if stateDir == "" {
-		return nil
-	}
-	goalID := scheduledCronSessionID("cron-goal", task.ID)
-	store := goalrunner.NewStore(filepath.Join(stateDir, "goals", goalID))
-	triggerPayload := map[string]string{
-		"task_id":   strings.TrimSpace(task.ID),
-		"cron":      strings.TrimSpace(task.Cron),
-		"kind":      "prompt",
-		"recurring": fmt.Sprintf("%t", task.Recurring),
-	}
-	runner := goalrunner.Runner{Store: store}
-	if _, err := runner.Init(ctx, goalrunner.Spec{
-		ID:            goalID,
-		Goal:          "Scheduled prompt task",
-		Task:          strings.TrimSpace(prompt),
-		AssignedAgent: "cron-scheduler",
-		Trigger: goalrunner.Trigger{
-			Type:    "scheduled",
-			Source:  "cron",
-			Payload: triggerPayload,
-		},
-	}); err != nil {
-		providers.DebugLogf("cron prompt task %q failed to initialize goal: %v", task.ID, err)
-		return nil
-	}
-	if _, err := store.SetStatus(goalrunner.StatusRunning, goalrunner.StepExecution, "scheduled task fired"); err != nil {
-		providers.DebugLogf("cron prompt task %q failed to mark goal running: %v", task.ID, err)
-		return store
-	}
-	if _, _, err := store.AddArtifact("trigger.md", "trigger", renderScheduledGoalTrigger(task, prompt)); err != nil {
-		providers.DebugLogf("cron prompt task %q failed to write goal trigger artifact: %v", task.ID, err)
-	}
-	return store
-}
-
-func renderScheduledGoalTrigger(task cron.Task, prompt string) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "# Scheduled Trigger\n\n")
-	fmt.Fprintf(&b, "- Task: %s\n", strings.TrimSpace(task.ID))
-	fmt.Fprintf(&b, "- Cron: %s\n", strings.TrimSpace(task.Cron))
-	fmt.Fprintf(&b, "- Recurring: %t\n", task.Recurring)
-	fmt.Fprintf(&b, "- Kind: prompt\n")
-	fmt.Fprintf(&b, "\n## Prompt\n\n%s\n", strings.TrimSpace(prompt))
-	return b.String()
-}
-
-func scheduledCronSessionID(prefix, taskID string) string {
-	id := strings.TrimSpace(taskID)
-	var safe strings.Builder
-	for i := 0; i < len(id); i++ {
-		ch := id[i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' {
-			safe.WriteByte(ch)
-		}
-	}
-	if safe.Len() == 0 {
-		safe.WriteString("task")
-	}
-	return fmt.Sprintf("%s-%s-%d", prefix, safe.String(), time.Now().UnixNano())
 }
 
 // NewThreadRuntime creates a per-conversation execution runtime from the

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
 	"github.com/blueberrycongee/wuu/internal/agenttemplate"
 	"github.com/blueberrycongee/wuu/internal/agentthread"
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/config"
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
@@ -143,6 +144,7 @@ type Session struct {
 	ExperimentalDeferredBundles bool
 	ExperimentalHelpMe          bool
 	DeferredToolCatalogPrompt   string
+	AutomationManager           *automation.Manager
 	CronScheduler               *cron.Scheduler
 	CronLock                    *cron.Lock
 	ReadinessIssues             []ReadinessIssue
@@ -289,6 +291,12 @@ func NewSession(opts Options) (*Session, error) {
 		return nil, err
 	}
 	activityRegistry := activity.NewRegistry()
+	automationManager := automation.NewManager(automation.Config{
+		StateDir: workspaceStateDir,
+		OnError: func(err error) {
+			providers.DebugLogf("automation manager: %v", err)
+		},
+	})
 
 	// File-directory memory (memory-redesign M1): the user notebook index is
 	// read once here — session creation is one of the two allowed
@@ -329,6 +337,7 @@ func NewSession(opts Options) (*Session, error) {
 			return nil, newErr
 		}
 		kit.SetStateDir(workspaceStateDir)
+		kit.SetAutomationManager(automationManager)
 		kit.SetProcessManager(processMgr)
 		kit.SetSkills(discoveredSkills)
 		ConfigureToolkitPermissions(kit, permissions)
@@ -598,6 +607,7 @@ func NewSession(opts Options) (*Session, error) {
 		DeferredToolCatalogPrompt:   deferredToolCatalogPrompt,
 		ReadinessIssues:             readinessIssues,
 		InferenceJournalRuntime:     journalRuntime,
+		AutomationManager:           automationManager,
 	}
 	// The legacy/root control remains dormant until SetSessionID binds its real
 	// artifact directories. Per-thread controls created by NewThreadRuntime are
@@ -1362,13 +1372,8 @@ func (s *Session) Cleanup() (process.CleanupResult, error) {
 		return process.CleanupResult{}, nil
 	}
 	var cleanupErr error
-	if s.CronScheduler != nil {
-		s.CronScheduler.Stop()
-		s.CronScheduler = nil
-	}
-	if s.CronLock != nil {
-		s.CronLock.Release()
-		s.CronLock = nil
+	if s.AutomationManager != nil {
+		s.AutomationManager.Stop()
 	}
 	if s.AgentControl != nil {
 		// Terminal intents are the durable recovery authority. Yield local retry

--- a/internal/runtime/session_test.go
+++ b/internal/runtime/session_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/config"
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
-	"github.com/blueberrycongee/wuu/internal/cron"
-	goalrunner "github.com/blueberrycongee/wuu/internal/goal"
 	"github.com/blueberrycongee/wuu/internal/harness"
 	"github.com/blueberrycongee/wuu/internal/hooks"
 	"github.com/blueberrycongee/wuu/internal/mcp"
@@ -597,121 +595,6 @@ func writeSessionTestFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
-func waitForScheduledGoalState(t *testing.T, stateDir, taskID string) goalrunner.State {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		entries, err := os.ReadDir(filepath.Join(stateDir, "goals"))
-		if err != nil {
-			lastErr = err
-			time.Sleep(20 * time.Millisecond)
-			continue
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "cron-goal-"+taskID+"-") {
-				continue
-			}
-			state, err := goalrunner.NewStore(filepath.Join(stateDir, "goals", entry.Name())).LoadState()
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			if state.Status == goalrunner.StatusCompleted {
-				return state
-			}
-			lastErr = nil
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if lastErr != nil {
-		t.Fatalf("scheduled goal state not found: %v", lastErr)
-	}
-	t.Fatalf("scheduled goal state for task %q not completed", taskID)
-	return goalrunner.State{}
-}
-
-func TestCronSchedulerRunsScheduledPrompt(t *testing.T) {
-	root := t.TempDir()
-	stateDir := filepath.Join(t.TempDir(), "state")
-	t.Setenv("WUU_HOME", filepath.Join(t.TempDir(), "wuu-home"))
-
-	taskStore := cron.NewTaskStore(statepath.ScheduledTasksPath(stateDir))
-	prompt := "Run weekly QA with arguments: settings search"
-	if err := taskStore.Add(cron.Task{
-		ID:        "prompt-1",
-		Cron:      "* * * * *",
-		Prompt:    prompt,
-		Metadata:  map[string]string{"kind": "workflow", "workflow_name": "weekly-qa", "workflow_arguments": "settings search"},
-		CreatedAt: time.Now().Add(-2 * time.Minute).UnixMilli(),
-		Recurring: false,
-	}); err != nil {
-		t.Fatalf("taskStore.Add: %v", err)
-	}
-
-	client := &sessionRecordingClient{}
-	rt := &Session{
-		RootDir:    root,
-		StateDir:   stateDir,
-		SessionDir: filepath.Join(stateDir, "sessions"),
-		StreamRunner: &agent.StreamRunner{
-			Client: client,
-			Model:  "test-model",
-		},
-	}
-	if err := rt.StartCronScheduler(); err != nil {
-		t.Fatalf("StartCronScheduler: %v", err)
-	}
-	t.Cleanup(func() { _, _ = rt.Cleanup() })
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		req := client.LastRequest()
-		if len(req.Messages) > 0 {
-			foundPrompt := false
-			for _, msg := range req.Messages {
-				if msg.Role == "user" && msg.Content == prompt {
-					foundPrompt = true
-					break
-				}
-			}
-			if !foundPrompt {
-				t.Fatalf("unexpected scheduled prompt request: %+v", req.Messages)
-			}
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if len(client.LastRequest().Messages) == 0 {
-		t.Fatal("expected scheduled prompt to run")
-	}
-
-	tasks, err := taskStore.List()
-	if err != nil {
-		t.Fatalf("taskStore.List: %v", err)
-	}
-	if len(tasks) != 0 {
-		t.Fatalf("one-shot prompt task should be removed after firing, got %+v", tasks)
-	}
-
-	goalState := waitForScheduledGoalState(t, stateDir, "prompt-1")
-	if goalState.Status != goalrunner.StatusCompleted {
-		t.Fatalf("scheduled goal status = %s, want completed: %+v", goalState.Status, goalState)
-	}
-	if goalState.Trigger.Type != "scheduled" || goalState.Trigger.Source != "cron" {
-		t.Fatalf("scheduled goal trigger not recorded: %+v", goalState.Trigger)
-	}
-	if goalState.Trigger.Payload["kind"] != "prompt" {
-		t.Fatalf("scheduled goal should record prompt kind, got metadata: %+v", goalState.Trigger.Payload)
-	}
-	if _, ok := goalState.Trigger.Payload["workflow_name"]; ok {
-		t.Fatalf("scheduled goal should ignore legacy workflow metadata: %+v", goalState.Trigger.Payload)
-	}
-	if goalState.AssignedAgent != "cron-scheduler" {
-		t.Fatalf("scheduled goal assigned agent = %q", goalState.AssignedAgent)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -41,6 +41,7 @@ type Session struct {
 	Summary   string    `json:"summary,omitempty"`
 	Entries   int       `json:"entries"`
 	CWD       string    `json:"cwd,omitempty"`
+	Source    string    `json:"source,omitempty"`
 	// WorkspaceID is the stable, location-independent identity of the workspace
 	// this session belongs to (the desktop's registered-project id). Sessions
 	// of a workspace with an id are listed by that id, so they follow the
@@ -239,7 +240,7 @@ SELECT id, created_at, updated_at, title, summary, entries, cwd,
        forked_from_id, forked_from_turn_id, forked_from_item_id,
        pinned_at, archived_at,
        worktree_path, worktree_base_head, worktree_base_repo,
-       dm_participant_id, is_group, focus_workspace, workspace_id
+       dm_participant_id, is_group, focus_workspace, workspace_id, source
 FROM sessions`)
 	if err != nil {
 		return nil, fmt.Errorf("list sessions: %w", err)
@@ -431,6 +432,12 @@ func SetFocusWorkspace(sessDir, id, focus string) (Session, error) {
 func SetWorkspaceID(sessDir, id, workspaceID string) (Session, error) {
 	return updateMetadata(sessDir, id, false, func(s *Session) {
 		s.WorkspaceID = strings.TrimSpace(workspaceID)
+	})
+}
+
+func SetSource(sessDir, id, source string) (Session, error) {
+	return updateMetadata(sessDir, id, false, func(s *Session) {
+		s.Source = strings.TrimSpace(source)
 	})
 }
 
@@ -1423,6 +1430,9 @@ WHERE workflow_id = ''`); err != nil {
 	if err := addColumnIfMissing(db, "sessions", "workspace_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
+	if err := addColumnIfMissing(db, "sessions", "source", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions(workspace_id)`); err != nil {
 		return fmt.Errorf("migrate sessions database: %w", err)
 	}
@@ -1987,8 +1997,8 @@ func insertSessionSQL() string {
 		id, created_at, updated_at, title, summary, entries, cwd,
 		forked_from_id, forked_from_turn_id, forked_from_item_id,
 		pinned_at, archived_at, worktree_path, worktree_base_head, worktree_base_repo,
-		dm_participant_id, is_group, focus_workspace, workspace_id
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		dm_participant_id, is_group, focus_workspace, workspace_id, source
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 }
 
 func updateSessionTx(tx *sql.Tx, sess Session) error {
@@ -1997,13 +2007,13 @@ UPDATE sessions
 SET created_at = ?, updated_at = ?, title = ?, summary = ?, entries = ?, cwd = ?,
     forked_from_id = ?, forked_from_turn_id = ?, forked_from_item_id = ?,
     pinned_at = ?, archived_at = ?, worktree_path = ?, worktree_base_head = ?, worktree_base_repo = ?,
-    dm_participant_id = ?, is_group = ?, focus_workspace = ?, workspace_id = ?
+    dm_participant_id = ?, is_group = ?, focus_workspace = ?, workspace_id = ?, source = ?
 WHERE id = ?`,
 		timeText(sess.CreatedAt), timeText(sess.UpdatedAt), sess.Title, sess.Summary, sess.Entries, normalizeCWD(sess.CWD),
 		sess.ForkedFromID, sess.ForkedFromTurnID, sess.ForkedFromItemID,
 		nullableTimeText(sess.PinnedAt), nullableTimeText(sess.ArchivedAt),
 		normalizeCWD(sess.WorktreePath), sess.WorktreeBaseHEAD, normalizeCWD(sess.WorktreeBaseRepo),
-		strings.TrimSpace(sess.DMParticipantID), boolToInt(sess.Group), strings.TrimSpace(sess.FocusWorkspace), strings.TrimSpace(sess.WorkspaceID),
+		strings.TrimSpace(sess.DMParticipantID), boolToInt(sess.Group), strings.TrimSpace(sess.FocusWorkspace), strings.TrimSpace(sess.WorkspaceID), strings.TrimSpace(sess.Source),
 		sess.ID,
 	)
 	if err != nil {
@@ -2033,6 +2043,7 @@ func sessionArgs(sess Session) []any {
 		boolToInt(sess.Group),
 		strings.TrimSpace(sess.FocusWorkspace),
 		strings.TrimSpace(sess.WorkspaceID),
+		strings.TrimSpace(sess.Source),
 	}
 }
 
@@ -2049,7 +2060,7 @@ SELECT id, created_at, updated_at, title, summary, entries, cwd,
        forked_from_id, forked_from_turn_id, forked_from_item_id,
        pinned_at, archived_at,
        worktree_path, worktree_base_head, worktree_base_repo,
-       dm_participant_id, is_group, focus_workspace, workspace_id
+       dm_participant_id, is_group, focus_workspace, workspace_id, source
 FROM sessions
 WHERE id = ?`, id)
 	return scanSessionRow(row)
@@ -2061,7 +2072,7 @@ SELECT id, created_at, updated_at, title, summary, entries, cwd,
        forked_from_id, forked_from_turn_id, forked_from_item_id,
        pinned_at, archived_at,
        worktree_path, worktree_base_head, worktree_base_repo,
-       dm_participant_id, is_group, focus_workspace, workspace_id
+       dm_participant_id, is_group, focus_workspace, workspace_id, source
 FROM sessions
 WHERE id = ?`, id)
 	return scanSessionRow(row)
@@ -2092,7 +2103,7 @@ func scanSession(scanner interface {
 		&s.ForkedFromID, &s.ForkedFromTurnID, &s.ForkedFromItemID,
 		&pinnedAt, &archivedAt,
 		&s.WorktreePath, &s.WorktreeBaseHEAD, &s.WorktreeBaseRepo,
-		&s.DMParticipantID, &isGroup, &s.FocusWorkspace, &s.WorkspaceID,
+		&s.DMParticipantID, &isGroup, &s.FocusWorkspace, &s.WorkspaceID, &s.Source,
 	); err != nil {
 		return Session{}, err
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -248,6 +248,27 @@ func TestSetGroupThreadPersistsAndSurfacesRegardlessOfCWD(t *testing.T) {
 	}
 }
 
+func TestSetSourcePersistsAndLists(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := CreateWithMetadata(dir, "automation-thread", "/tmp/project"); err != nil {
+		t.Fatalf("CreateWithMetadata: %v", err)
+	}
+	if _, err := SetSource(dir, "automation-thread", "automation"); err != nil {
+		t.Fatalf("SetSource: %v", err)
+	}
+	found, ok, err := Find(dir, "automation-thread")
+	if err != nil || !ok || found.Source != "automation" {
+		t.Fatalf("Find() = %+v, %t, %v", found, ok, err)
+	}
+	sessions, err := List(dir, 10)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Source != "automation" {
+		t.Fatalf("sessions = %+v", sessions)
+	}
+}
+
 func TestSetFocusWorkspacePersistsAndIsResettable(t *testing.T) {
 	dir := t.TempDir()
 	cwd := filepath.Join(t.TempDir(), "agent-home")

--- a/internal/statepath/statepath.go
+++ b/internal/statepath/statepath.go
@@ -253,6 +253,11 @@ func ScheduledTasksLockPath(workspaceStateDir string) string {
 	return filepath.Join(workspaceStateDir, "scheduled_tasks.lock")
 }
 
+// AutomationRunsPath returns the workspace-scoped automation run history file.
+func AutomationRunsPath(workspaceStateDir string) string {
+	return filepath.Join(workspaceStateDir, "automation_runs.json")
+}
+
 func sanitizeSlug(input string) string {
 	var b strings.Builder
 	lastDash := false

--- a/internal/subagent/manager.go
+++ b/internal/subagent/manager.go
@@ -171,6 +171,7 @@ func (m *Manager) defaultsSnapshot() managerDefaults {
 type RuntimeDefaults struct {
 	Client              providers.StreamClient
 	Model               string
+	ProviderOptions     map[string]any
 	ContextWindow       int
 	MaxInputTokens      int
 	OutputReserveTokens int
@@ -187,6 +188,7 @@ func (m *Manager) RuntimeDefaults() RuntimeDefaults {
 	return RuntimeDefaults{
 		Client:              d.client,
 		Model:               d.model,
+		ProviderOptions:     provideroptions.Clone(d.options),
 		ContextWindow:       d.contextWindow,
 		MaxInputTokens:      d.maxInputTokens,
 		OutputReserveTokens: d.outputReserve,

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -48,6 +48,15 @@ func (t *CronTool) Definition() providers.ToolDefinition {
 					"type":        "string",
 					"description": "Used by action=add. The prompt to execute each time the task fires.",
 				},
+				"mode": map[string]any{
+					"type":        "string",
+					"enum":        []string{"new_thread", "thread_heartbeat"},
+					"description": "Used by action=add. new_thread creates a visible thread per run; thread_heartbeat queues runs in the current thread.",
+				},
+				"heartbeat_thread_id": map[string]any{
+					"type":        "string",
+					"description": "Used with thread_heartbeat. Defaults to the current thread.",
+				},
 				"recurring": map[string]any{
 					"type":        "boolean",
 					"description": "Used by action=add. If true, the task repeats until removed or it expires (7 days). If false, it runs once.",
@@ -68,12 +77,14 @@ func (t *CronTool) Definition() providers.ToolDefinition {
 
 func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error) {
 	var args struct {
-		Action    string `json:"action"`
-		Cron      string `json:"cron"`
-		Prompt    string `json:"prompt"`
-		Recurring bool   `json:"recurring"`
-		Durable   bool   `json:"durable"`
-		ID        string `json:"id"`
+		Action            string `json:"action"`
+		Cron              string `json:"cron"`
+		Prompt            string `json:"prompt"`
+		Recurring         bool   `json:"recurring"`
+		Durable           bool   `json:"durable"`
+		ID                string `json:"id"`
+		Mode              string `json:"mode"`
+		HeartbeatThreadID string `json:"heartbeat_thread_id"`
 	}
 	if err := decodeArgs(argsJSON, &args); err != nil {
 		return "", err
@@ -82,7 +93,7 @@ func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error)
 	case "list":
 		return t.executeList()
 	case "add":
-		return t.executeAdd(args.Cron, args.Prompt, args.Recurring, args.Durable)
+		return t.executeAdd(args.Cron, args.Prompt, args.Mode, args.HeartbeatThreadID, args.Recurring, args.Durable)
 	case "remove":
 		return t.executeRemove(args.ID)
 	default:
@@ -90,7 +101,7 @@ func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error)
 	}
 }
 
-func (t *CronTool) executeAdd(cronExpr, prompt string, recurring, durable bool) (string, error) {
+func (t *CronTool) executeAdd(cronExpr, prompt, mode, heartbeatThreadID string, recurring, durable bool) (string, error) {
 	var args struct {
 		Cron      string
 		Prompt    string
@@ -101,6 +112,20 @@ func (t *CronTool) executeAdd(cronExpr, prompt string, recurring, durable bool) 
 	args.Prompt = strings.TrimSpace(prompt)
 	args.Recurring = recurring
 	args.Durable = durable
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		mode = "new_thread"
+	}
+	if mode != "new_thread" && mode != "thread_heartbeat" {
+		return "", fmt.Errorf("cron action=add has invalid mode %q", mode)
+	}
+	heartbeatThreadID = strings.TrimSpace(heartbeatThreadID)
+	if mode == "thread_heartbeat" && heartbeatThreadID == "" {
+		heartbeatThreadID = strings.TrimSpace(t.env.SessionID)
+	}
+	if mode == "thread_heartbeat" && heartbeatThreadID == "" {
+		return "", fmt.Errorf("cron action=add thread_heartbeat requires a thread id")
+	}
 	if args.Cron == "" {
 		return "", fmt.Errorf("cron action=add requires cron")
 	}
@@ -134,12 +159,16 @@ func (t *CronTool) executeAdd(cronExpr, prompt string, recurring, durable bool) 
 	}
 
 	task := cron.Task{
-		ID:        cron.GenerateTaskID(),
-		Cron:      args.Cron,
-		Prompt:    args.Prompt,
-		Metadata:  map[string]string{"kind": "prompt"},
-		CreatedAt: time.Now().UnixMilli(),
-		Recurring: args.Recurring,
+		ID:                cron.GenerateTaskID(),
+		Cron:              args.Cron,
+		Prompt:            args.Prompt,
+		Mode:              mode,
+		Timezone:          time.Local.String(),
+		CreatorThreadID:   strings.TrimSpace(t.env.SessionID),
+		HeartbeatThreadID: heartbeatThreadID,
+		Metadata:          map[string]string{"kind": "prompt"},
+		CreatedAt:         time.Now().UnixMilli(),
+		Recurring:         args.Recurring,
 	}
 
 	storeLabel := "session-only"
@@ -159,6 +188,7 @@ func (t *CronTool) executeAdd(cronExpr, prompt string, recurring, durable bool) 
 		"id":         task.ID,
 		"schedule":   args.Cron,
 		"prompt":     args.Prompt,
+		"mode":       mode,
 		"kind":       taskKind(task),
 		"type":       map[bool]string{true: "recurring", false: "one-shot"}[args.Recurring],
 		"durability": storeLabel,

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/cron"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/statepath"
@@ -31,6 +32,7 @@ func (t *CronTool) Definition() providers.ToolDefinition {
 		Description: "Manage scheduled tasks that run a prompt at cron intervals. " +
 			"action=list returns all scheduled tasks with their IDs, schedules, and prompts. " +
 			"action=add creates a task and requires cron plus prompt. A task can be recurring (runs repeatedly until removed or expired) or one-shot (runs once). " +
+			"Use new_thread when each run should be a separate visible conversation. Use thread_heartbeat when continuity in the current conversation matters. " +
 			"action=remove deletes a task and requires id.",
 		InputSchema: map[string]any{
 			"type": "object",
@@ -48,10 +50,18 @@ func (t *CronTool) Definition() providers.ToolDefinition {
 					"type":        "string",
 					"description": "Used by action=add. The prompt to execute each time the task fires.",
 				},
+				"title": map[string]any{
+					"type":        "string",
+					"description": "Used by action=add. Optional name shown for the automation.",
+				},
+				"timezone": map[string]any{
+					"type":        "string",
+					"description": "Used by action=add. IANA timezone for the schedule. Defaults to local time.",
+				},
 				"mode": map[string]any{
 					"type":        "string",
 					"enum":        []string{"new_thread", "thread_heartbeat"},
-					"description": "Used by action=add. new_thread creates a visible thread per run; thread_heartbeat queues runs in the current thread.",
+					"description": "Used by action=add. Defaults to new_thread. Choose new_thread for an independent visible thread per run; choose thread_heartbeat when each run must continue with the current thread's latest context.",
 				},
 				"heartbeat_thread_id": map[string]any{
 					"type":        "string",
@@ -85,6 +95,8 @@ func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error)
 		ID                string `json:"id"`
 		Mode              string `json:"mode"`
 		HeartbeatThreadID string `json:"heartbeat_thread_id"`
+		Title             string `json:"title"`
+		Timezone          string `json:"timezone"`
 	}
 	if err := decodeArgs(argsJSON, &args); err != nil {
 		return "", err
@@ -93,7 +105,7 @@ func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error)
 	case "list":
 		return t.executeList()
 	case "add":
-		return t.executeAdd(args.Cron, args.Prompt, args.Mode, args.HeartbeatThreadID, args.Recurring, args.Durable)
+		return t.executeAdd(args.Title, args.Cron, args.Timezone, args.Prompt, args.Mode, args.HeartbeatThreadID, args.Recurring, args.Durable)
 	case "remove":
 		return t.executeRemove(args.ID)
 	default:
@@ -101,97 +113,36 @@ func (t *CronTool) Execute(ctx context.Context, argsJSON string) (string, error)
 	}
 }
 
-func (t *CronTool) executeAdd(cronExpr, prompt, mode, heartbeatThreadID string, recurring, durable bool) (string, error) {
-	var args struct {
-		Cron      string
-		Prompt    string
-		Recurring bool
-		Durable   bool
-	}
-	args.Cron = strings.TrimSpace(cronExpr)
-	args.Prompt = strings.TrimSpace(prompt)
-	args.Recurring = recurring
-	args.Durable = durable
-	mode = strings.TrimSpace(mode)
-	if mode == "" {
-		mode = "new_thread"
-	}
-	if mode != "new_thread" && mode != "thread_heartbeat" {
-		return "", fmt.Errorf("cron action=add has invalid mode %q", mode)
-	}
-	heartbeatThreadID = strings.TrimSpace(heartbeatThreadID)
-	if mode == "thread_heartbeat" && heartbeatThreadID == "" {
-		heartbeatThreadID = strings.TrimSpace(t.env.SessionID)
-	}
-	if mode == "thread_heartbeat" && heartbeatThreadID == "" {
-		return "", fmt.Errorf("cron action=add thread_heartbeat requires a thread id")
-	}
-	if args.Cron == "" {
-		return "", fmt.Errorf("cron action=add requires cron")
-	}
-	if args.Prompt == "" {
-		return "", fmt.Errorf("cron action=add requires prompt")
-	}
-
-	ce, err := cron.ParseCronExpression(args.Cron)
-	if err != nil {
-		return "", fmt.Errorf("invalid cron expression: %w", err)
-	}
-
-	next, err := ce.NextRun(time.Now())
-	if err != nil {
-		return "", fmt.Errorf("cron has no valid future run: %w", err)
-	}
-	if next.After(time.Now().AddDate(1, 0, 0)) {
-		return "", fmt.Errorf("cron next run is more than 1 year away")
-	}
-
-	stateDir, err := t.env.WorkspaceStateDir()
+func (t *CronTool) executeAdd(title, cronExpr, timezone, prompt, mode, heartbeatThreadID string, recurring, durable bool) (string, error) {
+	manager, err := t.automationManager()
 	if err != nil {
 		return "", err
 	}
-	fileStore := cron.NewTaskStore(taskStorePath(stateDir))
-	sessionStore := cron.NewSessionTaskStore(stateDir)
-	fileTasks, _ := fileStore.List()
-	sessionTasks, _ := sessionStore.List()
-	if len(fileTasks)+len(sessionTasks) >= cron.MaxJobs {
-		return "", fmt.Errorf("maximum number of scheduled tasks reached (%d)", cron.MaxJobs)
-	}
-
-	task := cron.Task{
-		ID:                cron.GenerateTaskID(),
-		Cron:              args.Cron,
-		Prompt:            args.Prompt,
-		Mode:              mode,
-		Timezone:          time.Local.String(),
+	task, err := manager.AddTask(automation.AddTaskParams{
+		Title:             title,
+		Prompt:            prompt,
+		Schedule:          cronExpr,
+		Timezone:          timezone,
+		Mode:              automation.Mode(strings.TrimSpace(mode)),
 		CreatorThreadID:   strings.TrimSpace(t.env.SessionID),
 		HeartbeatThreadID: heartbeatThreadID,
-		Metadata:          map[string]string{"kind": "prompt"},
-		CreatedAt:         time.Now().UnixMilli(),
-		Recurring:         args.Recurring,
+		Recurring:         recurring,
+		Durable:           durable,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to save task: %w", err)
 	}
-
-	storeLabel := "session-only"
-	var storeErr error
-	if args.Durable {
-		storeLabel = "durable"
-		storeErr = fileStore.Add(task)
-	} else {
-		storeErr = sessionStore.Add(task)
-	}
-	if storeErr != nil {
-		return "", fmt.Errorf("failed to save task: %w", storeErr)
-	}
-
 	result := map[string]any{
 		"action":     "cron",
 		"id":         task.ID,
-		"schedule":   args.Cron,
-		"prompt":     args.Prompt,
-		"mode":       mode,
+		"title":      task.Title,
+		"schedule":   task.Cron,
+		"timezone":   task.Timezone,
+		"prompt":     task.Prompt,
+		"mode":       task.Mode,
 		"kind":       taskKind(task),
-		"type":       map[bool]string{true: "recurring", false: "one-shot"}[args.Recurring],
-		"durability": storeLabel,
+		"type":       map[bool]string{true: "recurring", false: "one-shot"}[task.Recurring],
+		"durability": task.Metadata["durability"],
 	}
 	return mustJSON(result)
 }
@@ -206,16 +157,11 @@ func (t *CronTool) executeRemove(id string) (string, error) {
 		return "", fmt.Errorf("cron action=remove requires id")
 	}
 
-	stateDir, err := t.env.WorkspaceStateDir()
+	manager, err := t.automationManager()
 	if err != nil {
 		return "", err
 	}
-	fileStore := cron.NewTaskStore(taskStorePath(stateDir))
-	sessionStore := cron.NewSessionTaskStore(stateDir)
-	if err := fileStore.Remove(id); err != nil {
-		return "", fmt.Errorf("failed to remove task: %w", err)
-	}
-	if err := sessionStore.Remove(id); err != nil {
+	if err := manager.RemoveTask(id); err != nil {
 		return "", fmt.Errorf("failed to remove task: %w", err)
 	}
 
@@ -224,24 +170,18 @@ func (t *CronTool) executeRemove(id string) (string, error) {
 }
 
 func (t *CronTool) executeList() (string, error) {
-	stateDir, err := t.env.WorkspaceStateDir()
+	manager, err := t.automationManager()
 	if err != nil {
 		return "", err
 	}
-	fileStore := cron.NewTaskStore(taskStorePath(stateDir))
-	sessionStore := cron.NewSessionTaskStore(stateDir)
-	fileTasks, err := fileStore.List()
-	if err != nil {
-		return "", fmt.Errorf("failed to list tasks: %w", err)
-	}
-	sessionTasks, err := sessionStore.List()
+	tasks, err := manager.ListTasks()
 	if err != nil {
 		return "", fmt.Errorf("failed to list tasks: %w", err)
 	}
 
 	now := time.Now().UnixMilli()
 	var items []map[string]any
-	appendTask := func(task cron.Task, sessionOnly bool) {
+	for _, task := range tasks {
 		typeLabel := "one-shot"
 		if task.Recurring {
 			typeLabel = "recurring"
@@ -249,23 +189,30 @@ func (t *CronTool) executeList() (string, error) {
 		if cron.IsExpired(task, now) {
 			typeLabel += " [expired]"
 		}
-		if sessionOnly {
+		if task.Metadata["durability"] != "durable" {
 			typeLabel += " [session-only]"
 		}
 		items = append(items, map[string]any{
-			"id":       task.ID,
-			"schedule": task.Cron,
-			"type":     typeLabel,
-			"kind":     taskKind(task),
-			"prompt":   task.Prompt,
+			"id":                  task.ID,
+			"title":               task.Title,
+			"schedule":            task.Cron,
+			"timezone":            task.Timezone,
+			"type":                typeLabel,
+			"kind":                taskKind(task),
+			"prompt":              task.Prompt,
+			"mode":                task.Mode,
+			"creator_thread_id":   task.CreatorThreadID,
+			"heartbeat_thread_id": task.HeartbeatThreadID,
+			"paused":              task.Paused,
 		})
-	}
-	for _, task := range fileTasks {
-		appendTask(task, false)
-	}
-	for _, task := range sessionTasks {
-		appendTask(task, true)
 	}
 
 	return mustJSON(map[string]any{"action": "cron", "tasks": items, "count": len(items)})
+}
+
+func (t *CronTool) automationManager() (*automation.Manager, error) {
+	if t == nil || t.env == nil || t.env.AutomationManager == nil {
+		return nil, fmt.Errorf("automation manager is unavailable")
+	}
+	return t.env.AutomationManager, nil
 }

--- a/internal/tools/cron_test.go
+++ b/internal/tools/cron_test.go
@@ -79,6 +79,28 @@ func TestScheduleCronTool_DurablePersistsToDisk(t *testing.T) {
 	}
 }
 
+func TestScheduleCronToolCreatesThreadHeartbeat(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	env := &Env{RootDir: dir, StateDir: stateDir, SessionID: "thread-1"}
+	tool := NewCronTool(env)
+
+	result, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check cache","mode":"thread_heartbeat","recurring":true}`)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !strings.Contains(result, `"mode":"thread_heartbeat"`) {
+		t.Fatalf("expected heartbeat mode, got %s", result)
+	}
+	tasks, err := cron.NewSessionTaskStore(stateDir).List()
+	if err != nil {
+		t.Fatalf("session store list: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].HeartbeatThreadID != "thread-1" || tasks[0].CreatorThreadID != "thread-1" {
+		t.Fatalf("heartbeat task = %#v", tasks)
+	}
+}
+
 func TestScheduleCronTool_DurableWriteFailureDoesNotCreateSessionTask(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")

--- a/internal/tools/cron_test.go
+++ b/internal/tools/cron_test.go
@@ -7,13 +7,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/cron"
 )
+
+func newCronToolTestEnv(rootDir, stateDir, sessionID string) *Env {
+	return &Env{
+		RootDir: rootDir, StateDir: stateDir, SessionID: sessionID,
+		AutomationManager: automation.NewManager(automation.Config{StateDir: stateDir}),
+	}
+}
 
 func TestScheduleCronTool_DefaultsToSessionOnly(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")
-	env := &Env{RootDir: dir, StateDir: stateDir}
+	env := newCronToolTestEnv(dir, stateDir, "")
 	tool := NewCronTool(env)
 
 	result, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check deploy","recurring":true}`)
@@ -49,7 +57,7 @@ func TestScheduleCronTool_DefaultsToSessionOnly(t *testing.T) {
 func TestScheduleCronTool_DurablePersistsToDisk(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")
-	env := &Env{RootDir: dir, StateDir: stateDir}
+	env := newCronToolTestEnv(dir, stateDir, "")
 	tool := NewCronTool(env)
 
 	result, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check deploy","recurring":true,"durable":true}`)
@@ -82,7 +90,7 @@ func TestScheduleCronTool_DurablePersistsToDisk(t *testing.T) {
 func TestScheduleCronToolCreatesThreadHeartbeat(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")
-	env := &Env{RootDir: dir, StateDir: stateDir, SessionID: "thread-1"}
+	env := newCronToolTestEnv(dir, stateDir, "thread-1")
 	tool := NewCronTool(env)
 
 	result, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check cache","mode":"thread_heartbeat","recurring":true}`)
@@ -107,7 +115,7 @@ func TestScheduleCronTool_DurableWriteFailureDoesNotCreateSessionTask(t *testing
 	if err := os.MkdirAll(taskStorePath(stateDir)+".lock", 0o755); err != nil {
 		t.Fatalf("create invalid durable lock path: %v", err)
 	}
-	env := &Env{RootDir: dir, StateDir: stateDir}
+	env := newCronToolTestEnv(dir, stateDir, "")
 	tool := NewCronTool(env)
 
 	_, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check deploy","recurring":true,"durable":true}`)
@@ -130,7 +138,7 @@ func TestScheduleCronTool_DurableWriteFailureDoesNotCreateSessionTask(t *testing
 func TestCancelCronTool(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")
-	env := &Env{RootDir: dir, StateDir: stateDir}
+	env := newCronToolTestEnv(dir, stateDir, "")
 	fileStore := cron.NewTaskStore(taskStorePath(stateDir))
 	if err := fileStore.Add(cron.Task{ID: "abc123", Cron: "* * * * *", Prompt: "x"}); err != nil {
 		t.Fatalf("fileStore.Add: %v", err)
@@ -164,7 +172,7 @@ func TestCancelCronTool(t *testing.T) {
 func TestListCronTool(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")
-	env := &Env{RootDir: dir, StateDir: stateDir}
+	env := newCronToolTestEnv(dir, stateDir, "")
 	fileStore := cron.NewTaskStore(taskStorePath(stateDir))
 	if err := fileStore.Add(cron.Task{ID: "abc", Cron: "*/5 * * * *", Prompt: "check"}); err != nil {
 		t.Fatalf("fileStore.Add: %v", err)

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/goalruntime"
 	proc "github.com/blueberrycongee/wuu/internal/process"
@@ -237,6 +238,7 @@ type Env struct {
 	NativeDeferredToolDiscovery bool
 	ProcessMgr                  *proc.Manager
 	AgentControl                *agentcontrol.AgentControl
+	AutomationManager           *automation.Manager
 	ParticipantSpeech           ParticipantSpeech
 	// GroupManager backs the resident-only create_group / add_member actions
 	// of manage_participant. Nil means group management is unavailable in this

--- a/internal/tools/tool_agents.go
+++ b/internal/tools/tool_agents.go
@@ -505,11 +505,11 @@ func extractHelpMeParentJournal(ctx context.Context, env *Env, history []provide
 	}
 	jctx, cancel := context.WithTimeout(ctx, helpMeJournalTimeout)
 	defer cancel()
-	journal, err := compact.BuildHelpMeParentJournal(jctx, defaults.Client, defaults.Model, compact.Budget{
+	journal, err := compact.BuildHelpMeParentJournalWithOptions(jctx, defaults.Client, defaults.Model, compact.Budget{
 		ContextTokens:       defaults.ContextWindow,
 		InputTokens:         defaults.MaxInputTokens,
 		OutputReserveTokens: defaults.OutputReserveTokens,
-	}, history)
+	}, defaults.ProviderOptions, history)
 	if err != nil {
 		providers.DebugLogf("helpme: parent journal extraction degraded to self-reported brief: %v", err)
 		return ""

--- a/internal/tools/toolkit.go
+++ b/internal/tools/toolkit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/activity"
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
+	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/capability"
 	"github.com/blueberrycongee/wuu/internal/goalruntime"
 	"github.com/blueberrycongee/wuu/internal/mcp"
@@ -169,6 +170,7 @@ func (t *Toolkit) CloneForRoot(rootDir string) (*Toolkit, error) {
 		NativeDeferredToolDiscovery: t.env.NativeDeferredToolDiscovery,
 		ProcessMgr:                  t.env.ProcessMgr,
 		AgentControl:                t.env.AgentControl,
+		AutomationManager:           t.env.AutomationManager,
 		ParticipantSpeech:           t.env.ParticipantSpeech,
 		GroupManager:                t.env.GroupManager,
 		TaskManager:                 t.env.TaskManager,
@@ -352,6 +354,11 @@ func (t *Toolkit) Skills() []skills.Skill {
 // SetSessionID sets the current session ID.
 func (t *Toolkit) SetSessionID(id string) {
 	t.env.SessionID = id
+}
+
+// SetAutomationManager attaches the workspace automation service.
+func (t *Toolkit) SetAutomationManager(manager *automation.Manager) {
+	t.env.AutomationManager = manager
 }
 
 // SessionID returns the session currently bound to this toolkit.

--- a/packages/protocol/package-lock.json
+++ b/packages/protocol/package-lock.json
@@ -8,24 +8,385 @@
       "name": "@wuu/protocol",
       "version": "0.0.0",
       "devDependencies": {
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       },
       "engines": {
         "node": ">=22"
       }
     },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     }
   }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1003,6 +1003,7 @@ export type Thread = {
   agent_path?: string;
   preview: string;
   title?: string;
+  source?: string;
   model_provider: string;
   model: string;
   cwd: string;


### PR DESCRIPTION
## Summary
- ship the accumulated desktop layout and activity improvements
- update TypeScript compiler integration and preserve runtime model options
- move scheduled automation onto persisted Thread/Turn execution with new-thread and heartbeat modes
- centralize task management, run records, hidden trigger context, and automation RPCs

## Verification
- `go test ./internal/appserver ./internal/automation ./internal/cron ./internal/runtime ./internal/session ./internal/tools`
- formatting and whitespace checks passed
- full `go test ./...` reaches one reproducible failure in unchanged `internal/agentcontrol`: `TestNewRestoresQueuedSpawnPayload`