### PR TITLE
Hide internal process notifications from conversations

### DIFF
--- a/desktop/src/renderer/AppState.test.ts
+++ b/desktop/src/renderer/AppState.test.ts
@@ -62,6 +62,7 @@ import {
   type SessionTab,
   type ThreadSummary,
 } from "./AppState";
+import { PROCESS_NOTIFICATION_NAME } from "./InternalUserNotification";
 import { streamTextKey, streamTextStore } from "./StreamText";
 
 function installManualRAF(): {
@@ -148,6 +149,10 @@ function handoffText(): string {
     })}\n</subagent_notification>`,
     trigger_turn: true
   });
+}
+
+function processNotificationText(): string {
+  return '<process_notification>{"process_id":"proc-1","status":"completed"}</process_notification>';
 }
 
 function threadWithUserTexts(texts: string[]): Thread {
@@ -305,6 +310,17 @@ describe("AppState server requests", () => {
 describe("queryTextsForThread", () => {
   it("skips internal agent handoff messages", () => {
     const thread = threadWithUserTexts([handoffText(), "真正的用户问题"]);
+
+    expect(queryTextsForThread(thread)).toEqual(["真正的用户问题"]);
+  });
+
+  it("skips named and legacy process notifications", () => {
+    const thread = threadWithUserTexts([
+      "unparseable process payload",
+      processNotificationText(),
+      "真正的用户问题",
+    ]);
+    thread.turns[0].items[0].name = PROCESS_NOTIFICATION_NAME;
 
     expect(queryTextsForThread(thread)).toEqual(["真正的用户问题"]);
   });
@@ -2861,6 +2877,31 @@ describe("chatMessagesFromTurns", () => {
         item: notification,
       },
       { kind: "user", id: "turn-1:item-2", turnID: "turn-1", item: realMessage },
+    ]);
+  });
+
+  it("hides named and legacy process notifications from chat rows", () => {
+    const named: ThreadItem = {
+      id: "process-named",
+      type: "user_message",
+      name: PROCESS_NOTIFICATION_NAME,
+      text: handoffText(),
+    };
+    const legacy: ThreadItem = {
+      id: "process-legacy",
+      type: "user_message",
+      text: processNotificationText(),
+    };
+    const realMessage: ThreadItem = {
+      id: "user-1",
+      type: "user_message",
+      text: "继续检查",
+    };
+
+    expect(
+      chatMessagesFromTurns([turn("turn-1", [named, legacy, realMessage])]),
+    ).toEqual([
+      { kind: "user", id: "turn-1:user-1", turnID: "turn-1", item: realMessage },
     ]);
   });
 

--- a/desktop/src/renderer/AppState.ts
+++ b/desktop/src/renderer/AppState.ts
@@ -16,7 +16,11 @@ import type {
   Turn,
 } from "../shared/protocol";
 import type { ComposerFile, ComposerImage } from "./ComposerMessages";
-import { agentHandoffDisplayItem, isAgentHandoffItem } from "./AgentHandoff";
+import { agentHandoffDisplayItem } from "./AgentHandoff";
+import {
+  isInternalUserNotificationItem,
+  isProcessNotificationItem,
+} from "./InternalUserNotification";
 import { threadDisplayTitle } from "./ThreadTitles";
 import { sortChildAgents } from "./ThreadAgents";
 import {
@@ -2126,9 +2130,9 @@ export function applySubthreadUpdatedNotification(
  * becomes a "focus" row regardless of what type the backend tags it
  * with.
  *
- * Subagent completion handoffs are internal user_message envelopes. The raw
- * JSON never reaches the chat DOM; trigger-turn handoffs become system event
- * divider rows and non-trigger mailbox records stay hidden.
+ * Internal user-role notifications never render as user-authored chat.
+ * Trigger-turn agent handoffs become system event divider rows; non-trigger
+ * handoffs and process completion notifications stay hidden.
  */
 export function chatMessagesFromTurns(
   turns: ReadonlyArray<Pick<Turn, "id"> & Partial<Pick<Turn, "items">>>,
@@ -2140,6 +2144,9 @@ export function chatMessagesFromTurns(
       if (item.focus_meta) {
         rows.push({ kind: "focus", id, turnID: turn.id, item });
       } else if (item.type === "user_message") {
+        if (isProcessNotificationItem(item)) {
+          continue;
+        }
         // Subagent notifications / inter-agent handoffs are delivered to the
         // resident as a self-addressed user_message (a JSON envelope wrapping
         // a <subagent_notification> payload). They are working-transcript
@@ -2158,7 +2165,7 @@ export function chatMessagesFromTurns(
           });
           continue;
         }
-        if (isAgentHandoffItem(item)) {
+        if (isInternalUserNotificationItem(item)) {
           continue;
         }
         if (item.envelope_meta && item.envelope_meta.length > 0) {
@@ -2791,7 +2798,7 @@ function queryTextForUserItem(item: ThreadItem): string | undefined {
   // Gate first on the item-level signal so corrupted payload text
   // (combined envelopes with \n\n joins, <changed_file_overlap> tails)
   // never reaches the text trim/return path.
-  if (isAgentHandoffItem(item)) {
+  if (isInternalUserNotificationItem(item)) {
     return undefined;
   }
   const text = (item.text ?? "").trim();

--- a/desktop/src/renderer/InternalUserNotification.test.ts
+++ b/desktop/src/renderer/InternalUserNotification.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROCESS_NOTIFICATION_NAME,
+  isInternalUserNotificationItem,
+  isProcessNotificationItem,
+  isProcessNotificationText,
+} from "./InternalUserNotification";
+
+const processNotificationText =
+  '<process_notification>{"process_id":"proc-1"}</process_notification>';
+
+describe("process notification classification", () => {
+  it("uses the protocol name as the primary signal", () => {
+    expect(
+      isProcessNotificationItem({
+        name: PROCESS_NOTIFICATION_NAME,
+        text: "unparseable historical payload",
+      }),
+    ).toBe(true);
+  });
+
+  it("recognizes complete legacy text envelopes without a name", () => {
+    expect(isProcessNotificationText(`  ${processNotificationText}\n`)).toBe(true);
+    expect(isProcessNotificationItem({ text: processNotificationText })).toBe(true);
+  });
+
+  it("does not classify incomplete envelopes or normal user text", () => {
+    expect(
+      isProcessNotificationText('<process_notification>{"process_id":"proc-1"}'),
+    ).toBe(false);
+    expect(isProcessNotificationItem({ text: "后台命令完成了吗？" })).toBe(false);
+    expect(isProcessNotificationItem(undefined)).toBe(false);
+  });
+
+  it("classifies both process notifications and agent handoffs as internal", () => {
+    expect(isInternalUserNotificationItem({ name: PROCESS_NOTIFICATION_NAME })).toBe(true);
+    expect(isInternalUserNotificationItem({ name: "wuu_agent_notification" })).toBe(true);
+    expect(isInternalUserNotificationItem({ text: "真实用户消息" })).toBe(false);
+  });
+});

--- a/desktop/src/renderer/InternalUserNotification.ts
+++ b/desktop/src/renderer/InternalUserNotification.ts
@@ -1,0 +1,34 @@
+import { isAgentHandoffItem } from "./AgentHandoff";
+
+export const PROCESS_NOTIFICATION_NAME = "wuu_process_notification";
+
+type InternalUserNotificationItem = {
+  name?: string;
+  text?: string;
+};
+
+export function isProcessNotificationText(text: string | undefined): boolean {
+  const trimmed = text?.trim();
+  return Boolean(
+    trimmed?.startsWith("<process_notification>") &&
+      trimmed.endsWith("</process_notification>"),
+  );
+}
+
+export function isProcessNotificationItem(
+  item: InternalUserNotificationItem | undefined,
+): boolean {
+  if (!item) {
+    return false;
+  }
+  if (item.name === PROCESS_NOTIFICATION_NAME) {
+    return true;
+  }
+  return isProcessNotificationText(item.text);
+}
+
+export function isInternalUserNotificationItem(
+  item: InternalUserNotificationItem | undefined,
+): boolean {
+  return isAgentHandoffItem(item) || isProcessNotificationItem(item);
+}

--- a/desktop/src/renderer/ThreadItemView.tsx
+++ b/desktop/src/renderer/ThreadItemView.tsx
@@ -19,6 +19,10 @@ import {
 } from "./ComposerMessages";
 import { EnvelopeNotice } from "./EnvelopeNotice";
 import {
+  isInternalUserNotificationItem,
+  isProcessNotificationItem,
+} from "./InternalUserNotification";
+import {
   collapsedLongTextPreview,
   useLongTextCollapse,
 } from "./LongTextCollapse";
@@ -93,6 +97,9 @@ export function ThreadItemView({
   switch (item.type) {
     case "user_message": {
       const text = item.text ?? "";
+      if (isProcessNotificationItem(item)) {
+        return null;
+      }
       // Envelope-routed messages (group chat → resident DM) render as a
       // collapsed meta row, never as a user bubble — a bubble would read
       // as if the user typed the forwarded content themselves.
@@ -112,6 +119,9 @@ export function ThreadItemView({
             className="agent-handoff-divider"
           />
         );
+      }
+      if (isInternalUserNotificationItem(item)) {
+        return null;
       }
       const copyable = text.trim() !== "";
       const editable = Boolean(

--- a/desktop/src/renderer/TurnView.test.tsx
+++ b/desktop/src/renderer/TurnView.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadItem, Turn } from "../shared/protocol";
 import { ASSISTANT_TURN_PRESENTATION_STABILIZE_MS } from "./AssistantTurnPresentation";
+import { PROCESS_NOTIFICATION_NAME } from "./InternalUserNotification";
 import { TurnView } from "./TurnView";
 
 let root: Root | undefined;
@@ -107,6 +108,36 @@ describe("TurnView", () => {
 
     const turn = view.querySelector<HTMLElement>(".turn");
     expect(turn?.dataset.turnStatus).toBe("in_progress");
+  });
+
+  it("hides named and legacy process notifications from the direct turn renderer", () => {
+    const processText =
+      '<process_notification>{"process_id":"proc-legacy"}</process_notification>';
+    const view = render(
+      makeTurn("completed", [
+        {
+          id: "process-named",
+          type: "user_message",
+          name: PROCESS_NOTIFICATION_NAME,
+          text: '<process_notification>{"process_id":"proc-named"}</process_notification>',
+        },
+        {
+          id: "process-legacy",
+          type: "user_message",
+          text: processText,
+        },
+        {
+          id: "user-1",
+          type: "user_message",
+          text: "真正的用户消息",
+        },
+      ]),
+    );
+
+    expect(view.textContent).not.toContain("proc-named");
+    expect(view.textContent).not.toContain("proc-legacy");
+    expect(view.textContent).toContain("真正的用户消息");
+    expect(view.querySelectorAll(".user-message-block")).toHaveLength(1);
   });
 
   it("keeps completed turn outputs visible after the turn is no longer latest", () => {

--- a/desktop/src/renderer/TurnViewHelpers.test.ts
+++ b/desktop/src/renderer/TurnViewHelpers.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Thread, Turn } from "../shared/protocol";
+import { PROCESS_NOTIFICATION_NAME } from "./InternalUserNotification";
 import {
   firstUserMessageAnchor,
   lastUserMessageAnchor,
@@ -28,6 +29,10 @@ function handoffText(): string {
     })}\n</subagent_notification>`,
     trigger_turn: true
   });
+}
+
+function processNotificationText(): string {
+  return '<process_notification>{"process_id":"proc-1"}</process_notification>';
 }
 
 /**
@@ -261,7 +266,7 @@ describe("anchor ID helpers", () => {
 function buildThread(
   turns: Array<{
     id: string;
-    items: Array<{ id: string; type: string; text?: string }>;
+    items: Array<{ id: string; type: string; text?: string; name?: string }>;
   }>,
 ): Thread {
   return {
@@ -351,6 +356,22 @@ describe("firstUserMessageAnchor", () => {
   it("skips internal agent handoff anchors", () => {
     const turn = buildTurn([
       { id: "handoff", type: "user_message", text: handoffText() },
+      { id: "u-1", type: "user_message", text: "hello" },
+    ]);
+    expect(firstUserMessageAnchor(turn)).toEqual({
+      turnID: "turn-1",
+      itemID: "u-1",
+    });
+  });
+
+  it("skips named process notification anchors", () => {
+    const turn = buildTurn([
+      {
+        id: "process",
+        type: "user_message",
+        name: PROCESS_NOTIFICATION_NAME,
+        text: "unparseable process payload",
+      },
       { id: "u-1", type: "user_message", text: "hello" },
     ]);
     expect(firstUserMessageAnchor(turn)).toEqual({
@@ -479,6 +500,17 @@ describe("lastUserMessageAnchor", () => {
     });
   });
 
+  it("skips legacy process notification anchors", () => {
+    const turn = buildTurn([
+      { id: "u-1", type: "user_message", text: "hello" },
+      { id: "process", type: "user_message", text: processNotificationText() },
+    ]);
+    expect(lastUserMessageAnchor(turn)).toEqual({
+      turnID: "turn-1",
+      itemID: "u-1",
+    });
+  });
+
   it("matches the snapshot the fork picker checks against", () => {
     // App.tsx's `isForkTargetLatest` compares the (turnID, itemID) the
     // user clicked against the value this helper returns, so the
@@ -554,7 +586,7 @@ describe("threadReplySnippet", () => {
  * behavior (e.g. the conversation turn rail) in isolation.
  */
 function buildTurn(
-  items: Array<{ id: string; type: string; text?: string }>,
+  items: Array<{ id: string; type: string; text?: string; name?: string }>,
 ): Turn {
   return {
     id: "turn-1",
@@ -577,6 +609,20 @@ describe("firstUserMessageText", () => {
   it("skips internal agent handoff text", () => {
     const turn = buildTurn([
       { id: "handoff", type: "user_message", text: handoffText() },
+      { id: "u-1", type: "user_message", text: "hello" },
+    ]);
+    expect(firstUserMessageText(turn)).toBe("hello");
+  });
+
+  it("skips process notifications in turn previews", () => {
+    const turn = buildTurn([
+      {
+        id: "process-named",
+        type: "user_message",
+        name: PROCESS_NOTIFICATION_NAME,
+        text: "unparseable process payload",
+      },
+      { id: "process-legacy", type: "user_message", text: processNotificationText() },
       { id: "u-1", type: "user_message", text: "hello" },
     ]);
     expect(firstUserMessageText(turn)).toBe("hello");

--- a/desktop/src/renderer/TurnViewHelpers.ts
+++ b/desktop/src/renderer/TurnViewHelpers.ts
@@ -1,5 +1,5 @@
 import type { Thread, Turn } from "../shared/protocol";
-import { isAgentHandoffItem } from "./AgentHandoff";
+import { isInternalUserNotificationItem } from "./InternalUserNotification";
 import {
   messageFlowFinalTextIndex,
   messageFlowStatusLabel,
@@ -54,7 +54,7 @@ export function firstUserMessageAnchor(
     "turns" in source ? source.turns ?? [] : [source as Turn];
   for (const turn of turns) {
     for (const item of turn.items ?? []) {
-      if (item.type === "user_message" && !isAgentHandoffItem(item)) {
+      if (item.type === "user_message" && !isInternalUserNotificationItem(item)) {
         return { turnID: turn.id, itemID: item.id };
       }
     }
@@ -80,7 +80,7 @@ export function lastUserMessageAnchor(
     const items = turn.items ?? [];
     for (let itemIndex = items.length - 1; itemIndex >= 0; itemIndex -= 1) {
       const item = items[itemIndex];
-      if (item.type === "user_message" && !isAgentHandoffItem(item)) {
+      if (item.type === "user_message" && !isInternalUserNotificationItem(item)) {
         return { turnID: turn.id, itemID: item.id };
       }
     }
@@ -180,7 +180,7 @@ export function firstUserMessageText(
     }
     // Gate first on the item-level signal so corrupted payload text never
     // reaches the trim path.
-    if (isAgentHandoffItem(item)) {
+    if (isInternalUserNotificationItem(item)) {
       continue;
     }
     const trimmed = (item.text ?? "").trim();


### PR DESCRIPTION
## Summary

- classify user-role messages emitted by internal process/tool flows
- keep internal notifications out of app state, turn summaries, and direct turn rendering
- preserve normal user messages and add focused regression coverage

## Testing

- `npm run test:unit -- src/renderer/AppState.test.ts src/renderer/InternalUserNotification.test.ts src/renderer/TurnViewHelpers.test.ts src/renderer/TurnView.test.tsx` (209 passed)
- `npm run typecheck`