### PR TITLE
fix(desktop): center conversation flow on wide screens

### DIFF
--- a/desktop/scripts/resize-e2e.cjs
+++ b/desktop/scripts/resize-e2e.cjs
@@ -184,6 +184,8 @@ async function run() {
   assert.equal(defaultEnvironment.visible, true, "Environment panel should start visible above the wide-window breakpoint.");
   assert.equal(typeof defaultEnvironment.panelRightGap, "number", "Environment panel right gap should be measurable.");
   assert.equal(typeof defaultEnvironment.panelMessageGap, "number", "Environment panel message gap should be measurable.");
+  assert.equal(typeof defaultEnvironment.panelWidth, "number", "Environment panel width should be measurable.");
+  assert.equal(typeof defaultEnvironment.conversationContentWidth, "number", "Message flow width should be measurable.");
   assert.ok(defaultEnvironment.panelRightGap <= 24, "Environment panel should sit near the right edge on wide windows.");
 
   win.setSize(1720, 860);
@@ -198,23 +200,104 @@ async function run() {
   );
   assert.equal(typeof beforeEnvironmentResize.panelRightGap, "number", "Wide environment panel right gap should be measurable.");
   assert.equal(typeof beforeEnvironmentResize.panelMessageGap, "number", "Wide environment panel message gap should be measurable.");
-  assert.ok(beforeEnvironmentResize.panelRightGap <= 24, "Environment panel should keep a stable right edge as width grows.");
   assert.ok(
-    beforeEnvironmentResize.panelMessageGap >= defaultEnvironment.panelMessageGap - 2,
-    `Extra width should not reduce the gap between the message flow and the environment panel. Default=${JSON.stringify(defaultEnvironment)} Wide=${JSON.stringify(beforeEnvironmentResize)}`
+    beforeEnvironmentResize.panelRightGap <= 24,
+    `Environment panel should keep its right-side anchor as width grows. Wide=${JSON.stringify(beforeEnvironmentResize)}`
   );
   assert.ok(
-    beforeEnvironmentResize.panelMessageGap >= 72,
-    `Environment panel should keep a comfortable gap from the message flow. Wide=${JSON.stringify(beforeEnvironmentResize)}`
+    beforeEnvironmentResize.panelWidth >= 320 && beforeEnvironmentResize.panelWidth >= defaultEnvironment.panelWidth + 40,
+    `Extra width should grow the environment panel toward full size. Default=${JSON.stringify(defaultEnvironment)} Wide=${JSON.stringify(beforeEnvironmentResize)}`
   );
   assert.ok(
-    beforeEnvironmentResize.scrollPaddingRight > 300,
-    "Scroll region should reserve inline environment panel space before resize."
+    beforeEnvironmentResize.conversationContentWidth <= 680,
+    `Extra width should preserve the readable message-flow cap. Wide=${JSON.stringify(beforeEnvironmentResize)}`
+  );
+  const wideFlow = await waitFor(win, () => flowSnapshot(), 1000);
+  assert.ok(
+    Math.abs(wideFlow.composerStackCenter - wideFlow.conversationContentCenter) <= 2,
+    `Wide-screen composer and message flow should share a center. Flow=${JSON.stringify(wideFlow)}`
   );
   assert.ok(
-    beforeEnvironmentResize.composerPaddingRight > 300,
-    "Composer should reserve inline environment panel space before resize."
+    Math.abs(wideFlow.composerStackWidth - wideFlow.conversationContentWidth) <= 4,
+    `Wide-screen composer and message flow should share a width. Flow=${JSON.stringify(wideFlow)}`
   );
+  assert.ok(
+    beforeEnvironmentResize.panelMessageGap <= 136,
+    `The wider flow and panel should keep the full-screen gap controlled. Wide=${JSON.stringify(beforeEnvironmentResize)}`
+  );
+  assert.ok(
+    beforeEnvironmentResize.scrollPaddingRight >= 40 && beforeEnvironmentResize.scrollPaddingRight <= 100,
+    `Scroll region should reserve only the space needed to clear the environment panel. Wide=${JSON.stringify(beforeEnvironmentResize)}`
+  );
+  assert.ok(
+    Math.abs(beforeEnvironmentResize.composerPaddingRight - beforeEnvironmentResize.scrollPaddingRight) <= 1,
+    "Composer and message flow should consume the same dynamic environment-panel inset."
+  );
+
+  await evaluate(win, () => {
+    const button = Array.from(document.querySelectorAll(".sidebar-toggle-button")).find((candidate) =>
+      candidate.getAttribute("aria-label")?.includes("收起左侧栏")
+    );
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("Sidebar collapse button not found.");
+    }
+    button.click();
+  });
+  await waitFor(
+    win,
+    () => {
+      const shell = document.querySelector(".app-shell");
+      const pane = document.querySelector(".conversation-pane");
+      if (!(shell instanceof HTMLElement) || !(pane instanceof HTMLElement)) {
+        return null;
+      }
+      return shell.classList.contains("sidebar-collapsed") &&
+        !shell.classList.contains("sidebar-animating") &&
+        pane.getBoundingClientRect().left <= 1
+        ? true
+        : null;
+    },
+    1200
+  );
+  win.setSize(2000, 860);
+  await waitFor(win, () => !document.documentElement.classList.contains("window-resizing"), 1000);
+  const collapsedWideFlow = await waitFor(win, () => flowSnapshot(), 1000);
+  assert.ok(
+    Math.abs(collapsedWideFlow.conversationContentCenter - collapsedWideFlow.paneCenter) <= 6,
+    `With no fixed sidebar, the full-screen message flow should return to the pane center. Flow=${JSON.stringify(collapsedWideFlow)}`
+  );
+  assert.ok(
+    collapsedWideFlow.conversationContentLeft >= collapsedWideFlow.sidebarOpenWidth + 24,
+    `The centered message flow should stay clear of the hover sidebar drawer. Flow=${JSON.stringify(collapsedWideFlow)}`
+  );
+  assert.ok(
+    Math.abs(collapsedWideFlow.composerStackCenter - collapsedWideFlow.conversationContentCenter) <= 2 &&
+      Math.abs(collapsedWideFlow.composerStackWidth - collapsedWideFlow.conversationContentWidth) <= 4,
+    `Collapsed-sidebar composer and message flow should remain aligned. Flow=${JSON.stringify(collapsedWideFlow)}`
+  );
+  await evaluate(win, () => {
+    const button = Array.from(document.querySelectorAll(".sidebar-toggle-button")).find((candidate) =>
+      candidate.getAttribute("aria-label")?.includes("展开左侧栏")
+    );
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("Sidebar expand button not found.");
+    }
+    button.click();
+  });
+  await waitFor(
+    win,
+    () => {
+      const shell = document.querySelector(".app-shell");
+      return shell instanceof HTMLElement &&
+        !shell.classList.contains("sidebar-collapsed") &&
+        !shell.classList.contains("sidebar-animating")
+        ? true
+        : null;
+    },
+    1200
+  );
+  win.setSize(1720, 860);
+  await waitFor(win, () => !document.documentElement.classList.contains("window-resizing"), 1000);
 
   win.setSize(1280, 640);
   const duringEnvironmentResize = await waitFor(
@@ -924,6 +1007,8 @@ async function evaluate(win, fn) {
         resizing: document.documentElement.classList.contains("window-resizing"),
         panelMessageGap: panelRect && flow ? panelRect.left - flow.conversationContentRight : null,
         panelRightGap: panelRect ? paneRect.right - panelRect.right : null,
+        panelWidth: panelRect?.width ?? null,
+        conversationContentWidth: flow?.conversationContentWidth ?? null,
         scrollPaddingRight: Number.parseFloat(scrollStyle.paddingRight || "0"),
         composerPaddingRight: Number.parseFloat(composerStyle.paddingRight || "0"),
         scrollTransitionProperty: scrollStyle.transitionProperty,
@@ -937,13 +1022,17 @@ async function evaluate(win, fn) {
       const conversation = document.querySelector(".conversation-width");
       const composer = document.querySelector(".dock-composer-wrap");
       const stack = composer?.querySelector(".composer-stack");
-      if (!scroll || !conversation || !composer || !stack) {
+      const pane = document.querySelector(".conversation-pane");
+      const shell = document.querySelector(".app-shell");
+      if (!scroll || !conversation || !composer || !stack || !pane || !shell) {
         return null;
       }
       const scrollRect = scroll.getBoundingClientRect();
       const conversationRect = conversation.getBoundingClientRect();
       const composerRect = composer.getBoundingClientRect();
       const stackRect = stack.getBoundingClientRect();
+      const paneRect = pane.getBoundingClientRect();
+      const shellStyle = getComputedStyle(shell);
       const conversationStyle = getComputedStyle(conversation);
       const scrollStyle = getComputedStyle(scroll);
       const composerStyle = getComputedStyle(composer);
@@ -962,6 +1051,8 @@ async function evaluate(win, fn) {
         conversationContentLeft,
         conversationContentRight,
         conversationContentWidth: conversationContentRight - conversationContentLeft,
+        paneCenter: paneRect.left + paneRect.width / 2,
+        sidebarOpenWidth: Number.parseFloat(shellStyle.getPropertyValue("--sidebar-open-width") || "0"),
         conversationCenter: conversationRect.left + conversationRect.width / 2,
         conversationRight: conversationRect.right,
         conversationWidth: conversationRect.width,

--- a/desktop/src/renderer/EnvironmentPanelScale.ts
+++ b/desktop/src/renderer/EnvironmentPanelScale.ts
@@ -1,15 +1,30 @@
 const FULL_SIZE_PANEL_CONTAINER_WIDTH = 560;
-const MAXIMUM_ENVIRONMENT_PANEL_SCALE = 0.8;
+const WIDE_PANEL_GROWTH_START_WIDTH = 1_000;
+const FULL_SCALE_PANEL_CONTAINER_WIDTH = 1_400;
+const COMPACT_ENVIRONMENT_PANEL_SCALE = 0.8;
+const MAXIMUM_ENVIRONMENT_PANEL_SCALE = 1;
 const MINIMUM_ENVIRONMENT_PANEL_SCALE = 0.576;
 
 export function environmentPanelScaleForWidth(containerWidth: number): number {
-  const scale = Math.min(
-    MAXIMUM_ENVIRONMENT_PANEL_SCALE,
+  const compactScale = Math.min(
+    COMPACT_ENVIRONMENT_PANEL_SCALE,
     Math.max(
       MINIMUM_ENVIRONMENT_PANEL_SCALE,
       (containerWidth / FULL_SIZE_PANEL_CONTAINER_WIDTH) *
-        MAXIMUM_ENVIRONMENT_PANEL_SCALE,
+        COMPACT_ENVIRONMENT_PANEL_SCALE,
     ),
+  );
+  const wideGrowth = Math.min(
+    1,
+    Math.max(
+      0,
+      (containerWidth - WIDE_PANEL_GROWTH_START_WIDTH) /
+        (FULL_SCALE_PANEL_CONTAINER_WIDTH - WIDE_PANEL_GROWTH_START_WIDTH),
+    ),
+  );
+  const scale = Math.min(
+    MAXIMUM_ENVIRONMENT_PANEL_SCALE,
+    compactScale + wideGrowth * (MAXIMUM_ENVIRONMENT_PANEL_SCALE - compactScale),
   );
   return Math.round(scale * 1_000) / 1_000;
 }

--- a/desktop/src/renderer/EnvironmentSideStack.test.tsx
+++ b/desktop/src/renderer/EnvironmentSideStack.test.tsx
@@ -130,6 +130,9 @@ describe("EnvironmentSideStack", () => {
     expect(environmentPanelScaleForWidth(560)).toBe(0.8);
     expect(environmentPanelScaleForWidth(420)).toBe(0.6);
     expect(environmentPanelScaleForWidth(320)).toBe(0.576);
+    expect(environmentPanelScaleForWidth(1_000)).toBe(0.8);
+    expect(environmentPanelScaleForWidth(1_200)).toBe(0.9);
+    expect(environmentPanelScaleForWidth(1_400)).toBe(1);
 
     const stack = container.querySelector<HTMLElement>(
       ".environment-info-side-stack",

--- a/desktop/src/renderer/styles/conversation-shell.css
+++ b/desktop/src/renderer/styles/conversation-shell.css
@@ -63,6 +63,23 @@
   --environment-panel-reserved-width: 372px;
   --environment-panel-width: 328px;
   --environment-panel-edge-gap: 18px;
+  --environment-panel-flow-gap: calc(
+    var(--environment-panel-reserved-width) - var(--environment-panel-width)
+  );
+  /* Reserve only the space needed to keep a centered composer clear of the
+     right panel. As the effective sidebar shrinks and the conversation pane
+     grows, this falls smoothly to zero so the message flow returns to the
+     visual center of the window. */
+  --environment-panel-content-inset: clamp(
+    0px,
+    calc(
+      var(--session-composer-width) + var(--environment-panel-width) +
+        var(--environment-panel-width) + var(--environment-panel-edge-gap) +
+        var(--environment-panel-edge-gap) + var(--environment-panel-flow-gap) +
+        var(--environment-panel-flow-gap) - 100vw + var(--sidebar-width, 0px)
+    ),
+    var(--environment-panel-reserved-width)
+  );
   /*
    * Thread (reply) panel width is deliberately NOT declared here. It is owned by
    * useAppLayoutState and written to `.app-shell` — statically via shellStyle and
@@ -198,13 +215,13 @@
 
 .conversation-pane.environment-panel-reserved.subthread-panel-visible {
   --conversation-visible-inset-right: calc(
-    var(--environment-panel-reserved-width) + var(--thread-panel-width, 372px)
+    var(--environment-panel-content-inset) + var(--thread-panel-width, 372px)
   );
 }
 
 .conversation-pane.environment-panel-reserved.side-thread-panel-visible {
   --conversation-visible-inset-right: calc(
-    var(--environment-panel-reserved-width) + var(--side-thread-width, 400px)
+    var(--environment-panel-content-inset) + var(--side-thread-width, 400px)
   );
 }
 
@@ -242,7 +259,7 @@
 }
 
 .conversation-pane.environment-panel-reserved {
-  --conversation-visible-inset-right: var(--environment-panel-reserved-width);
+  --conversation-visible-inset-right: var(--environment-panel-content-inset);
 }
 
 .titlebar {

--- a/desktop/src/renderer/styles/conversation-shell.test.ts
+++ b/desktop/src/renderer/styles/conversation-shell.test.ts
@@ -32,7 +32,7 @@ describe("conversation shell visible center", () => {
       /--conversation-visible-inset-right:\s*0px;/,
     );
     expect(cssRuleBody(".conversation-pane.environment-panel-reserved")).toMatch(
-      /--conversation-visible-inset-right:\s*var\(--environment-panel-reserved-width\);/,
+      /--conversation-visible-inset-right:\s*var\(--environment-panel-content-inset\);/,
     );
     expect(cssRuleBody(".jump-to-latest-cluster")).toMatch(
       /right:\s*var\(--conversation-visible-inset-right\);/,
@@ -48,6 +48,15 @@ describe("conversation shell visible center", () => {
     // The panel column still reads it, with a first-open fallback of 372px.
     expect(cssRuleBody(".conversation-pane.subthread-panel-visible")).toMatch(
       /grid-template-columns:\s*minmax\(0,\s*1fr\)\s*var\(--thread-panel-width,\s*372px\);/,
+    );
+  });
+
+  it("re-centers the fixed readable flow instead of widening it on wide screens", () => {
+    expect(cssRuleBody(".conversation-pane")).toMatch(
+      /--environment-panel-content-inset:\s*clamp\([\s\S]*?var\(--session-composer-width\)[\s\S]*?-\s*100vw\s*\+\s*var\(--sidebar-width,\s*0px\)[\s\S]*?var\(--environment-panel-reserved-width\)/,
+    );
+    expect(conversationShellCssNoComments).not.toMatch(
+      /\.conversation-pane\.environment-panel-reserved\s*\{[^}]*--session-(?:outer|composer)-width\s*:/,
     );
   });
 });

--- a/desktop/src/renderer/styles/responsive-design.css
+++ b/desktop/src/renderer/styles/responsive-design.css
@@ -38,7 +38,7 @@
 
 .conversation-pane.environment-panel-reserved .scroll-region,
 .conversation-pane.environment-panel-reserved .dock-composer-wrap {
-  padding-right: var(--environment-panel-reserved-width);
+  padding-right: var(--environment-panel-content-inset);
 }
 
 @media (max-width: 1060px) {


### PR DESCRIPTION
## Summary
- keep the conversation and composer at their readable width while dynamically centering them on wide screens
- preserve the environment panel right-side anchor and let it scale up when space is available
- keep the collapsed-sidebar flow clear of the hover drawer and add Electron geometry regressions for alignment

## Verification
- `vitest run src/renderer/styles/conversation-shell.test.ts src/renderer/EnvironmentSideStack.test.tsx` (13 tests passed)
- `npm run typecheck`
- `npm run build`
- Electron resize geometry checks reached and passed the new wide-screen, composer-alignment, collapsed-sidebar, and drawer-clearance assertions; the full existing script later timed out waiting for the unrelated workspace file-tree fixture