### PR TITLE
fix(core): persist interrupted partial responses

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -485,6 +485,17 @@ func RunToolLoop(
 					})
 				}
 			}
+			// A streaming step can fail after content deltas were already shown to
+			// the user. Keep that visible text in durable history, but deliberately
+			// drop provider-native identity, reasoning, and tool calls because the
+			// failed stream may have left those structures incomplete.
+			if strings.TrimSpace(result.Content) != "" {
+				appendMessage(providers.ChatMessage{
+					Role:    "assistant",
+					Content: result.Content,
+					Phase:   result.Phase,
+				})
+			}
 			return LoopResult{
 				NewMessages:         newMessagesForReturn(messages, startLen, historyRewritten),
 				HistoryRewritten:    historyRewritten,

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -37,10 +37,47 @@ func (f *fakeStep) Execute(_ context.Context, req providers.ChatRequest) (StepRe
 		err = f.errs[f.idx]
 	}
 	f.idx++
-	if err != nil {
-		return StepResult{}, err
+	return r, err
+}
+
+func TestRunToolLoopPreservesVisiblePartialAssistantOnStepError(t *testing.T) {
+	streamErr := errors.New("stream interrupted")
+	step := &fakeStep{
+		results: []StepResult{{
+			Content:           "partial answer",
+			Phase:             providers.MessagePhaseFinalAnswer,
+			ProviderItemID:    "incomplete-provider-item",
+			ProviderItemModel: "provider-model",
+			ReasoningContent:  "incomplete reasoning",
+			ToolCalls: []providers.ToolCall{{
+				ID:        "incomplete-call",
+				Name:      "read_file",
+				Arguments: `{"path":"README.md"}`,
+			}},
+		}},
+		errs: []error{streamErr},
 	}
-	return r, nil
+
+	result, err := RunToolLoop(
+		context.Background(),
+		[]providers.ChatMessage{{Role: "user", Content: "hello"}},
+		LoopConfig{Model: "test-model"},
+		step,
+	)
+	if !errors.Is(err, streamErr) {
+		t.Fatalf("error = %v, want %v", err, streamErr)
+	}
+	visible := visibleMessagesForTest(result.NewMessages)
+	if len(visible) != 1 {
+		t.Fatalf("new messages = %+v, want one partial assistant message", result.NewMessages)
+	}
+	partial := visible[0]
+	if partial.Role != "assistant" || partial.Content != "partial answer" || partial.Phase != providers.MessagePhaseFinalAnswer {
+		t.Fatalf("partial assistant = %+v", partial)
+	}
+	if partial.ProviderItemID != "" || partial.ProviderItemModel != "" || partial.ReasoningContent != "" || len(partial.ToolCalls) != 0 {
+		t.Fatalf("partial assistant retained incomplete provider state: %+v", partial)
+	}
 }
 
 func TestRunToolLoopBeforeRequestTransformsProviderRequest(t *testing.T) {

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -899,10 +899,14 @@ func (s *streamStep) Execute(ctx context.Context, req providers.ChatRequest) (St
 		if failure.Category == providers.FailureCanceled || failure.Category == providers.FailureDeadline {
 			outcome = providers.InferenceOutcomeCanceled
 		}
-		if journalErr := req.Execution.Complete(outcome, failure); journalErr != nil {
-			return StepResult{}, errors.Join(fmt.Errorf("stream request failed: %w", err), fmt.Errorf("complete failed inference operation: %w", journalErr))
+		partial := StepResult{
+			Content: contentBuf.String(),
+			Phase:   messagePhase,
 		}
-		return StepResult{}, fmt.Errorf("stream request failed: %w", err)
+		if journalErr := req.Execution.Complete(outcome, failure); journalErr != nil {
+			return partial, errors.Join(fmt.Errorf("stream request failed: %w", err), fmt.Errorf("complete failed inference operation: %w", journalErr))
+		}
+		return partial, fmt.Errorf("stream request failed: %w", err)
 	}
 	// Build ordered tool calls list from the pending map.
 	toolCalls := make([]providers.ToolCall, 0, len(pendingTools))

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -580,9 +580,17 @@ func TestStreamRunner_StreamError(t *testing.T) {
 	}
 
 	runner := StreamRunner{Client: client, Model: "m"}
-	_, err := runner.Run(context.Background(), "hi")
+	result, err := runner.RunWithCallback(
+		context.Background(),
+		[]providers.ChatMessage{{Role: "user", Content: "hi"}},
+		nil,
+	)
 	if err == nil {
 		t.Fatal("expected error from stream error event")
+	}
+	visible := visibleMessagesForTest(result.NewMessages)
+	if len(visible) != 1 || visible[0].Role != "assistant" || visible[0].Content != "partial" {
+		t.Fatalf("partial assistant output was not returned for persistence: %+v", result.NewMessages)
 	}
 }
 

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -198,6 +198,12 @@ type blockingStreamClient struct {
 	once    sync.Once
 }
 
+type partialBlockingStreamClient struct {
+	started chan struct{}
+	content string
+	once    sync.Once
+}
+
 type usageStreamClient struct {
 	events []providers.StreamEvent
 }
@@ -221,6 +227,34 @@ func newBlockingStreamClient(content string) *blockingStreamClient {
 		release: make(chan struct{}),
 		content: content,
 	}
+}
+
+func newPartialBlockingStreamClient(content string) *partialBlockingStreamClient {
+	return &partialBlockingStreamClient{
+		started: make(chan struct{}),
+		content: content,
+	}
+}
+
+func (c *partialBlockingStreamClient) Chat(ctx context.Context, _ providers.ChatRequest) (providers.ChatResponse, error) {
+	<-ctx.Done()
+	return providers.ChatResponse{}, ctx.Err()
+}
+
+func (c *partialBlockingStreamClient) StreamChat(ctx context.Context, _ providers.ChatRequest) (<-chan providers.StreamEvent, error) {
+	ch := make(chan providers.StreamEvent, 2)
+	go func() {
+		defer close(ch)
+		ch <- providers.StreamEvent{
+			Type:    providers.EventContentDelta,
+			Content: c.content,
+			Phase:   providers.MessagePhaseFinalAnswer,
+		}
+		c.once.Do(func() { close(c.started) })
+		<-ctx.Done()
+		ch <- providers.StreamEvent{Type: providers.EventError, Error: ctx.Err()}
+	}()
+	return ch, nil
 }
 
 func (c *blockingStreamClient) Chat(ctx context.Context, req providers.ChatRequest) (providers.ChatResponse, error) {
@@ -6484,28 +6518,36 @@ func TestServerFailedTurnPersistsPairedToolHistoryAndReloadsFailure(t *testing.T
 }
 
 func TestServerInterruptedPartialTurnReloadsInterrupted(t *testing.T) {
+	client := newPartialBlockingStreamClient("partial answer")
 	rt := newTestRuntime(t, &fakeClient{})
-	sess, err := session.CreateWithMetadata(rt.SessionDir, "20260716-000001-interrupted", rt.RootDir)
-	if err != nil {
-		t.Fatalf("create session: %v", err)
+	rt.StreamRunner.Client = client
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+
+	if err := srv.handleLine(context.Background(), []byte(`{"id":"start","method":"thread/start"}`)); err != nil {
+		t.Fatalf("thread/start: %v", err)
 	}
-	if _, err := appendChatMessage(rt.SessionDir, sess.ID, providers.ChatMessage{Role: "user", Content: "inspect"}); err != nil {
-		t.Fatalf("append user: %v", err)
+	threadID := remarshal[ThreadStartResult](t, responseByID(t, parseOutput(t, out.String()), "start")["result"]).Thread.ID
+	startTurn := fmt.Sprintf(`{"id":"turn","method":"turn/start","params":{"thread_id":%q,"prompt":"inspect"}}`, threadID)
+	if err := srv.handleLine(context.Background(), []byte(startTurn)); err != nil {
+		t.Fatalf("turn/start: %v", err)
 	}
-	if _, err := appendChatMessage(rt.SessionDir, sess.ID, providers.ChatMessage{Role: "assistant", Content: "partial answer"}); err != nil {
-		t.Fatalf("append partial assistant: %v", err)
+	<-client.started
+	deltaMessages := waitForMethod(t, out, NotificationAgentMessageDelta)
+	delta := remarshal[AgentMessageDeltaNotification](t, notificationByMethod(t, deltaMessages, NotificationAgentMessageDelta)["params"])
+	if delta.Delta != "partial answer" {
+		t.Fatalf("live partial delta = %q", delta.Delta)
 	}
 
-	srv := New(rt, &lockedBuffer{})
-	th := newThreadState(sess.ID, nil, rt.ProviderName, rt.Model, rt.RootDir, true, time.Now().UTC())
-	completedAt := time.Date(2026, 7, 16, 10, 30, 0, 0, time.UTC)
-	if err := srv.persistTurnTerminal(th, sess.ID+"-turn-0001", TurnKindUser, TurnStatusInterrupted, context.Canceled, completedAt); err != nil {
-		t.Fatalf("persist terminal turn: %v", err)
+	interrupt := fmt.Sprintf(`{"id":"interrupt","method":"turn/interrupt","params":{"thread_id":%q}}`, threadID)
+	if err := srv.handleLine(context.Background(), []byte(interrupt)); err != nil {
+		t.Fatalf("turn/interrupt: %v", err)
 	}
+	waitForMethod(t, out, NotificationTurnError)
 
 	reloadOut := &lockedBuffer{}
 	reloaded := New(rt, reloadOut)
-	resume := fmt.Sprintf(`{"id":"reload","method":"thread/resume","params":{"session_id":%q}}`, sess.ID)
+	resume := fmt.Sprintf(`{"id":"reload","method":"thread/resume","params":{"session_id":%q}}`, threadID)
 	if err := reloaded.handleLine(context.Background(), []byte(resume)); err != nil {
 		t.Fatalf("thread/resume: %v", err)
 	}
@@ -6514,7 +6556,7 @@ func TestServerInterruptedPartialTurnReloadsInterrupted(t *testing.T) {
 		t.Fatalf("reloaded turns = %+v, want one interrupted turn", result.Thread.Turns)
 	}
 	turn := result.Thread.Turns[0]
-	if turn.Status != TurnStatusInterrupted || turn.Error == nil || turn.Error.Message != context.Canceled.Error() || turn.CompletedAt == nil || !turn.CompletedAt.Equal(completedAt) {
+	if turn.Status != TurnStatusInterrupted || turn.Error == nil || !strings.Contains(turn.Error.Message, context.Canceled.Error()) || turn.CompletedAt == nil {
 		t.Fatalf("reloaded turn did not restore interruption: %+v", turn)
 	}
 	if len(turn.Items) < 3 || turn.Items[1].Type != ThreadItemAgentMessage || turn.Items[1].Text != "partial answer" || turn.Items[len(turn.Items)-1].Type != ThreadItemError {


### PR DESCRIPTION
## 问题

补全 #35：流式回答已经发送给用户后，如果 turn 被取消或流中途失败，runner 会丢弃当前 step 的内容。终态虽然能恢复为 interrupted/failed，但重载后用户已经看到的部分回答会消失。

## 修复

- 流式 step 出错时返回已经发送的可见 assistant 文本和 phase。
- tool loop 在返回错误前把这段文本加入 durable NewMessages。
- 不保留未完成的 provider item ID、reasoning 或 tool calls，避免写入无效 provider 历史。
- 将 app-server 回归测试升级为真实 delta → turn/interrupt → 新 Server 重载链路。

## 验证

- go test ./...
- go test -race ./internal/agent -run TestRunToolLoopPreservesVisiblePartialAssistantOnStepError\|TestStreamRunner_StreamError -count=1
- go test -race ./internal/appserver -run TestServerInterruptedPartialTurnReloadsInterrupted -count=1
- 真实进程探针：本地 SSE provider → wuu exec --json → SIGINT → 新 app-server thread/resume；结果 partial_text_restored=true

Follow-up to #35.