### PR TITLE
fix(desktop): render font-size preview as a real message-flow turn

### DIFF
--- a/desktop/src/renderer/MessageFlowFontSizeSection.tsx
+++ b/desktop/src/renderer/MessageFlowFontSizeSection.tsx
@@ -7,21 +7,40 @@ import {
 import {
   MESSAGE_FLOW_FONT_SIZE_RANGE,
   type MessageFlowFontSize,
+  type ThreadItem,
 } from "../shared/protocol";
-import { StreamingMarkdown } from "./StreamingMarkdown";
+import { ThreadItemView } from "./ThreadItemView";
 
-// Sample reply the Settings preview shows underneath the slider. It is
-// rendered through the exact pipeline the conversation pane uses
-// (.agent-block > .agent-text > StreamingMarkdown), so the slider
-// previews real message-flow typography instead of a look-alike
-// placeholder. Mixed CJK/Latin prose, inline code, and a short list
-// cover the shapes a typical agent reply takes.
-const PREVIEW_SAMPLE_MARKDOWN = [
-  "先看一下 README 的目录约定，再读一个相邻页面的 CSS——把改动控制在同一套既有规范里。",
-  "",
-  "- 改动只落在 `desktop/src/renderer`，不动 Go 核心",
-  "- 顺手跑一下单元测试，免得新代码悄悄破坏既有流程",
-].join("\n");
+// Mini conversation the Settings preview shows underneath the slider.
+// Both messages go through the same ThreadItemView pipeline the
+// conversation pane uses — user bubble, hairline divider, agent answer —
+// so the slider previews real message-flow typography instead of a
+// look-alike placeholder. The pair mirrors a typical exchange: a short
+// user request, then an agent reply with mixed CJK/Latin prose, inline
+// code, and a short list.
+const PREVIEW_TURN_ID = "settings-message-flow-preview-turn";
+
+const PREVIEW_USER_ITEM: ThreadItem = {
+  id: "settings-preview-user-message",
+  type: "user_message",
+  status: "completed",
+  text: "帮我把侧边栏的分组逻辑收敛到既有规范里，改完顺手跑一下测试。",
+};
+
+const PREVIEW_AGENT_ITEM: ThreadItem = {
+  id: "settings-preview-agent-message",
+  type: "agent_message",
+  status: "completed",
+  phase: "final_answer",
+  text: [
+    "先看一下 README 的目录约定，再读一个相邻页面的 CSS——把改动控制在同一套既有规范里。",
+    "",
+    "- 改动只落在 `desktop/src/renderer`，不动 Go 核心",
+    "- 顺手跑一下单元测试，免得新代码悄悄破坏既有流程",
+  ].join("\n"),
+};
+
+function noop(): void {}
 
 const { min, max, step, default: defaultSize } = MESSAGE_FLOW_FONT_SIZE_RANGE;
 
@@ -138,16 +157,26 @@ export function MessageFlowFontSizeControl(): JSX.Element {
         aria-label="消息流字号预览"
         data-testid="settings-message-flow-font-size-preview"
       >
-        <article className="agent-block">
-          <div className="agent-text">
-            <StreamingMarkdown
-              streamKey="settings-message-flow-font-size-preview"
-              initialText={PREVIEW_SAMPLE_MARKDOWN}
-              isLive={false}
-              phase="final_answer"
-            />
+        <section className="turn" data-turn-status="completed">
+          <ThreadItemView
+            turnID={PREVIEW_TURN_ID}
+            turnStatus="completed"
+            item={PREVIEW_USER_ITEM}
+            streaming={false}
+            onStreamFrame={noop}
+          />
+          <div className="assistant-turn-shell has-answer">
+            <div className="turn-answer-body">
+              <ThreadItemView
+                turnID={PREVIEW_TURN_ID}
+                turnStatus="completed"
+                item={PREVIEW_AGENT_ITEM}
+                streaming={false}
+                onStreamFrame={noop}
+              />
+            </div>
           </div>
-        </article>
+        </section>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Settings → 外观 → 消息流字号 的示例预览不再使用仿造的普通段落，而是渲染一个迷你对话回合——**用户气泡 + 分隔横线 + agent 回复**——全部通过与会话窗格完全相同的 `ThreadItemView` 渲染管线。

## Why

拖字号滑块时，预览的字体、字号、行高、间距和 Markdown 形态（行内代码、列表）与真实消息流像素级一致，所见即所得。

## How

- 构造一条 `user_message` 和一条 `agent_message`(final_answer, completed) 示例条目，直接交给 `ThreadItemView` 渲染
- 复用 `.turn > .assistant-turn-shell` 结构，横线和间距变量与真实会话同源
- 悬停气泡同样浮出复制按钮，行为与消息流一致

## Test

- `tsc --noEmit` 通过
- `vitest`: conversation-shell / MessageFlowFontSizeSection / SettingsView 共 42 个测试全部通过