### PR TITLE
fix(desktop): 让嵌入面板跟随暗色主题

### DIFF
--- a/desktop/src/renderer/RichContent.test.tsx
+++ b/desktop/src/renderer/RichContent.test.tsx
@@ -5,6 +5,20 @@ import type { WorkspaceFileReferenceResolveResult } from "../shared/protocol";
 import { ImagePreviewProvider } from "./ImagePreview";
 import { RichContent, __resetRichFileReferenceResolutionCacheForTests } from "./RichContent";
 
+const { mermaidInitialize, mermaidRender } = vi.hoisted(() => ({
+  mermaidInitialize: vi.fn(),
+  mermaidRender: vi.fn(async (id: string) => ({
+    svg: `<svg data-diagram-id="${id}"></svg>`,
+  })),
+}));
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: mermaidInitialize,
+    render: mermaidRender,
+  },
+}));
+
 let container: HTMLDivElement;
 let root: Root | null = null;
 let writeTextMock: ReturnType<typeof vi.fn>;
@@ -12,6 +26,9 @@ let resolveWorkspaceFileReferenceMock: ReturnType<typeof vi.fn>;
 let openExternalMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  document.documentElement.dataset.theme = "light";
+  mermaidInitialize.mockClear();
+  mermaidRender.mockClear();
   writeTextMock = vi.fn().mockResolvedValue(undefined);
   // jsdom does not implement the clipboard API; inject a mock for the
   // success-path tests.
@@ -43,6 +60,7 @@ afterEach(() => {
   root = null;
   container.remove();
   delete (window as { wuu?: unknown }).wuu;
+  delete document.documentElement.dataset.theme;
   __resetRichFileReferenceResolutionCacheForTests();
 });
 
@@ -81,6 +99,43 @@ function resolvedFileReference(
 }
 
 describe("RichContent code block", () => {
+  it("rerenders Mermaid diagrams when the applied theme changes", async () => {
+    render(<RichContent text={"```mermaid\ngraph TD\nA --> B\n```"} />);
+
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(mermaidRender).toHaveBeenCalledTimes(1);
+      });
+    });
+    expect(mermaidInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          background: "#ffffff",
+          primaryTextColor: "#202427",
+        }),
+      }),
+    );
+    expect(container.querySelector(".rich-mermaid svg")).not.toBeNull();
+
+    await act(async () => {
+      document.documentElement.dataset.theme = "dark";
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(mermaidRender).toHaveBeenCalledTimes(2);
+      });
+    });
+    expect(mermaidInitialize).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        themeVariables: expect.objectContaining({
+          background: "#1d2024",
+          primaryTextColor: "#e4e6e8",
+        }),
+      }),
+    );
+  });
+
   it("renders an explicit markdown-link file reference as a clickable workspace file link", () => {
     const openFile = vi.fn();
     render(

--- a/desktop/src/renderer/RichContent.tsx
+++ b/desktop/src/renderer/RichContent.tsx
@@ -11,6 +11,7 @@ import {
   type WorkspaceFileLinkTarget,
 } from "./LinkTargets";
 import { MessageCopyButton } from "./MessageActions";
+import { currentAppliedTheme, observeAppliedTheme, type AppliedTheme } from "./Theme";
 
 type RichContentProps = {
   text?: string;
@@ -1417,7 +1418,10 @@ function base64URL(value: string): string {
 function MermaidDiagram({ code }: { code: string }): JSX.Element {
   const reactID = useId();
   const diagramID = useMemo(() => `wuu-mermaid-${reactID.replace(/[^a-zA-Z0-9_-]/g, "")}-${hashString(code)}`, [code, reactID]);
+  const [theme, setTheme] = useState<AppliedTheme>(currentAppliedTheme);
   const [state, setState] = useState<MermaidState>({ status: "rendering" });
+
+  useEffect(() => observeAppliedTheme(setTheme), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -1430,16 +1434,9 @@ function MermaidDiagram({ code }: { code: string }): JSX.Element {
           startOnLoad: false,
           securityLevel: "strict",
           theme: "base",
-          themeVariables: {
-            background: "#ffffff",
-            primaryColor: "#eef2f0",
-            primaryTextColor: "#202427",
-            primaryBorderColor: "#ccd6d0",
-            lineColor: "#6f7478",
-            fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
-          }
+          themeVariables: mermaidThemeVariables(theme),
         });
-        const result = await mermaid.render(diagramID, code);
+        const result = await mermaid.render(`${diagramID}-${theme}`, code);
         if (!cancelled) {
           setState({ status: "rendered", svg: result.svg });
         }
@@ -1453,7 +1450,7 @@ function MermaidDiagram({ code }: { code: string }): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [code, diagramID]);
+  }, [code, diagramID, theme]);
 
   if (state.status === "rendered") {
     return <div className="rich-mermaid" dangerouslySetInnerHTML={{ __html: state.svg }} />;
@@ -1469,6 +1466,17 @@ function MermaidDiagram({ code }: { code: string }): JSX.Element {
     );
   }
   return <div className="rich-mermaid rich-mermaid-loading">正在渲染图表</div>;
+}
+
+function mermaidThemeVariables(theme: AppliedTheme): Record<string, string> {
+  return {
+    background: theme === "dark" ? "#1d2024" : "#ffffff",
+    primaryColor: theme === "dark" ? "#24282c" : "#eef2f0",
+    primaryTextColor: theme === "dark" ? "#e4e6e8" : "#202427",
+    primaryBorderColor: theme === "dark" ? "#3a4046" : "#ccd6d0",
+    lineColor: theme === "dark" ? "#a9aeb3" : "#6f7478",
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif",
+  };
 }
 
 function hashString(value: string): string {

--- a/desktop/src/renderer/Theme.test.ts
+++ b/desktop/src/renderer/Theme.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyThemePreference, resolveThemePreference } from "./Theme";
+import {
+  applyThemePreference,
+  currentAppliedTheme,
+  observeAppliedTheme,
+  resolveThemePreference,
+} from "./Theme";
 
 type MediaListener = (event: { matches: boolean }) => void;
 
@@ -84,5 +89,25 @@ describe("applyThemePreference", () => {
 
     media.fire(true);
     expect(document.documentElement.dataset.theme).toBe("light");
+  });
+});
+describe("observeAppliedTheme", () => {
+  it("reports concrete theme changes from the document attribute", async () => {
+    document.documentElement.dataset.theme = "light";
+    expect(currentAppliedTheme()).toBe("light");
+    const onChange = vi.fn();
+    const stop = observeAppliedTheme(onChange);
+
+    document.documentElement.dataset.theme = "dark";
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith("dark"));
+
+    document.documentElement.dataset.theme = "dark";
+    await Promise.resolve();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    stop();
+    document.documentElement.dataset.theme = "light";
+    await Promise.resolve();
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/desktop/src/renderer/Theme.ts
+++ b/desktop/src/renderer/Theme.ts
@@ -20,6 +20,8 @@ const DARK_SCHEME_QUERY = "(prefers-color-scheme: dark)";
 
 let systemListenerCleanup: (() => void) | undefined;
 
+export type AppliedTheme = "light" | "dark";
+
 export function resolveThemePreference(
   preference: ThemePreference,
 ): "light" | "dark" {
@@ -34,6 +36,29 @@ export function resolveThemePreference(
 
 export function appliedTheme(): string | undefined {
   return document.documentElement.dataset.theme;
+}
+
+export function currentAppliedTheme(): AppliedTheme {
+  return appliedTheme() === "dark" ? "dark" : "light";
+}
+
+export function observeAppliedTheme(
+  onChange: (theme: AppliedTheme) => void,
+): () => void {
+  let current = currentAppliedTheme();
+  const observer = new MutationObserver(() => {
+    const next = currentAppliedTheme();
+    if (next === current) {
+      return;
+    }
+    current = next;
+    onChange(next);
+  });
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  return () => observer.disconnect();
 }
 
 /**

--- a/desktop/src/renderer/WorkspaceMonacoEditor.tsx
+++ b/desktop/src/renderer/WorkspaceMonacoEditor.tsx
@@ -6,6 +6,7 @@ import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import TsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import { useEffect, useMemo, useRef } from "react";
 import type { WorkspaceFileSelection } from "./LinkTargets";
+import { currentAppliedTheme, observeAppliedTheme, type AppliedTheme } from "./Theme";
 
 declare global {
   interface Window {
@@ -30,6 +31,10 @@ type MonacoLanguage =
   | "typescript"
   | "xml"
   | "yaml";
+
+function workspaceMonacoTheme(theme: AppliedTheme): string {
+  return theme === "dark" ? "wuu-workspace-dark" : "wuu-workspace";
+}
 
 export type WorkspaceMonacoViewState = monaco.editor.ICodeEditorViewState;
 
@@ -109,8 +114,11 @@ export function WorkspaceMonacoEditor({
         verticalSliderSize: Math.max(4, scrollbarSize - 2),
       },
       tabSize: 2,
-      theme: "wuu-workspace",
+      theme: workspaceMonacoTheme(currentAppliedTheme()),
       wordWrap: "on",
+    });
+    const stopObservingTheme = observeAppliedTheme((theme) => {
+      monaco.editor.setTheme(workspaceMonacoTheme(theme));
     });
 
     const changeDisposable = editor.onDidChangeModelContent(() => {
@@ -130,6 +138,7 @@ export function WorkspaceMonacoEditor({
 
     return () => {
       onViewStateChangeRef.current?.(editor.saveViewState());
+      stopObservingTheme();
       changeDisposable.dispose();
       editor.dispose();
       model.dispose();
@@ -300,5 +309,20 @@ monaco.editor.defineTheme("wuu-workspace", {
     "editorLineNumber.activeForeground": "#24282d",
     "editor.selectionBackground": "#ef5b1838",
     "editorCursor.foreground": "#ef5b18",
+  },
+});
+
+monaco.editor.defineTheme("wuu-workspace-dark", {
+  base: "vs-dark",
+  inherit: true,
+  rules: [],
+  colors: {
+    "editor.background": "#1d202400",
+    "editor.foreground": "#e4e6e8",
+    "editor.lineHighlightBackground": "#dce4eb0d",
+    "editorLineNumber.foreground": "#7d8388",
+    "editorLineNumber.activeForeground": "#e4e6e8",
+    "editor.selectionBackground": "#ff5a2645",
+    "editorCursor.foreground": "#ff5a26",
   },
 });

--- a/desktop/src/renderer/WorkspaceTerminalPanel.test.tsx
+++ b/desktop/src/renderer/WorkspaceTerminalPanel.test.tsx
@@ -7,21 +7,32 @@ import {
   WorkspaceTerminalPanel,
 } from "./WorkspaceTerminalPanel";
 
+const { terminalConstructorOptions, terminalInstances } = vi.hoisted(() => ({
+  terminalConstructorOptions: [] as Array<{ theme?: Record<string, string> }>,
+  terminalInstances: [] as Array<{ options: { theme?: Record<string, string> } }>,
+}));
+
 // Stub xterm/the fit addon so mounting the real WorkspaceTerminalPanel
 // doesn't need an actual terminal renderer or ResizeObserver-driven
 // layout — mirrors the pattern used by AppApprovalFlow.test.tsx.
 vi.mock("@xterm/xterm", () => ({
-  Terminal: vi.fn().mockImplementation(() => ({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    focus: vi.fn(),
-    write: vi.fn(),
-    writeln: vi.fn(),
-    dispose: vi.fn(),
-    onData: vi.fn(() => ({ dispose: vi.fn() })),
-    cols: 80,
-    rows: 24,
-  })),
+  Terminal: vi.fn().mockImplementation((options: { theme?: Record<string, string> }) => {
+    terminalConstructorOptions.push(options);
+    const terminal = {
+      options: { theme: options.theme },
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      focus: vi.fn(),
+      write: vi.fn(),
+      writeln: vi.fn(),
+      dispose: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      cols: 80,
+      rows: 24,
+    };
+    terminalInstances.push(terminal);
+    return terminal;
+  }),
 }));
 
 vi.mock("@xterm/addon-fit", () => ({
@@ -41,6 +52,9 @@ let root: Root | null = null;
 let startTerminalSession: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  document.documentElement.dataset.theme = "light";
+  terminalConstructorOptions.length = 0;
+  terminalInstances.length = 0;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -70,7 +84,8 @@ afterEach(() => {
   });
   root = null;
   container.remove();
-  vi.restoreAllMocks();
+  delete document.documentElement.dataset.theme;
+  vi.clearAllMocks();
 });
 
 async function render(element: JSX.Element): Promise<void> {
@@ -87,13 +102,13 @@ async function render(element: JSX.Element): Promise<void> {
 }
 
 describe("WorkspaceTerminalPanel", () => {
-  it("starts the pty session rooted at the workspace context's cwd (Bug 3: worktree-fork panel root)", async () => {
-    const worktreeContext: RuntimeContext = {
-      kind: "project",
-      project_id: "project-1",
-      cwd: "/worktrees/fork-1/project",
-    };
+  const worktreeContext: RuntimeContext = {
+    kind: "project",
+    project_id: "project-1",
+    cwd: "/worktrees/fork-1/project",
+  };
 
+  it("starts the pty session rooted at the workspace context's cwd (Bug 3: worktree-fork panel root)", async () => {
     await render(<WorkspaceTerminalPanel activeContext={worktreeContext} />);
 
     expect(startTerminalSession).toHaveBeenCalledWith(
@@ -108,6 +123,18 @@ describe("WorkspaceTerminalPanel", () => {
 
     expect(startTerminalSession).not.toHaveBeenCalled();
     expect(container.textContent).toContain("没有项目");
+  });
+
+  it("uses the applied theme and updates an open terminal when it changes", async () => {
+    await render(<WorkspaceTerminalPanel activeContext={worktreeContext} />);
+
+    expect(terminalConstructorOptions[0]?.theme?.background).toBe("#ffffff");
+
+    document.documentElement.dataset.theme = "dark";
+    await vi.waitFor(() => {
+      expect(terminalInstances[0]?.options.theme?.background).toBe("#1d2024");
+      expect(terminalInstances[0]?.options.theme?.foreground).toBe("#e4e6e8");
+    });
   });
 });
 

--- a/desktop/src/renderer/WorkspaceTerminalPanel.tsx
+++ b/desktop/src/renderer/WorkspaceTerminalPanel.tsx
@@ -1,9 +1,10 @@
 import { FitAddon } from "@xterm/addon-fit";
-import { Terminal as XtermTerminal } from "@xterm/xterm";
+import { Terminal as XtermTerminal, type ITheme } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Terminal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { RuntimeContext, TerminalSessionEvent } from "../shared/protocol";
+import { currentAppliedTheme, observeAppliedTheme, type AppliedTheme } from "./Theme";
 import { WorkspacePanelEmpty } from "./WorkspaceFiles";
 import { desktopApiErrorMessage } from "./WorkspaceReviewHelpers";
 
@@ -12,6 +13,33 @@ const WORKSPACE_TERMINAL_PENDING_EVENTS_PER_ID = 256;
 const WORKSPACE_TERMINAL_PENDING_TEXT_PER_ID = 512 * 1024;
 
 type WorkspaceTerminalState = "starting" | "ready" | "exited" | "error";
+
+function workspaceTerminalTheme(theme: AppliedTheme): ITheme {
+  if (theme === "dark") {
+    return {
+      background: "#1d2024",
+      black: "#141618",
+      blue: "#58a6ff",
+      cursor: "#f2f3f4",
+      foreground: "#e4e6e8",
+      green: "#4cc38a",
+      red: "#f0705f",
+      selectionBackground: "#3a4046",
+      yellow: "#d9a84e",
+    };
+  }
+  return {
+    background: "#ffffff",
+    black: "#24292f",
+    blue: "#2f98ff",
+    cursor: "#202427",
+    foreground: "#1f2328",
+    green: "#1f9d46",
+    red: "#b42318",
+    selectionBackground: "#d7e9ff",
+    yellow: "#ffc21a",
+  };
+}
 
 export function appendPendingTerminalEvent(
   events: TerminalSessionEvent[],
@@ -95,23 +123,16 @@ export function WorkspaceTerminalPanel({ activeContext }: { activeContext?: Runt
       fontSize: 12,
       lineHeight: 1.45,
       scrollback: 5000,
-      theme: {
-        background: "#ffffff",
-        black: "#24292f",
-        blue: "#2f98ff",
-        cursor: "#202427",
-        foreground: "#1f2328",
-        green: "#1f9d46",
-        red: "#b42318",
-        selectionBackground: "#d7e9ff",
-        yellow: "#ffc21a"
-      }
+      theme: workspaceTerminalTheme(currentAppliedTheme()),
     });
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
     terminal.open(container);
     terminal.focus();
     terminalRef.current = terminal;
+    const stopObservingTheme = observeAppliedTheme((theme) => {
+      terminal.options.theme = workspaceTerminalTheme(theme);
+    });
 
     function fitAndResize(): void {
       if (disposed) {
@@ -231,6 +252,7 @@ export function WorkspaceTerminalPanel({ activeContext }: { activeContext?: Runt
         void window.wuu.stopTerminalSession(sessionID);
       }
       unsubscribeTerminal();
+      stopObservingTheme();
       dataDisposable.dispose();
       resizeObserver.disconnect();
       pendingTerminalEventsRef.current.clear();


### PR DESCRIPTION
## Summary

- observe the applied renderer theme from the document data-theme attribute
- update xterm and Monaco palettes immediately when the theme changes
- rerender Mermaid diagrams with matching light and dark colors
- add regression coverage for live terminal and Mermaid theme updates

## Verification

- npm run typecheck
- npm run test:unit (168 files, 1894 tests)
- npm run build

Closes #46