### PR TITLE
fix(desktop): 裸 URL 自动链接在中文标点处截断

### DIFF
--- a/desktop/src/renderer/RichContent.test.tsx
+++ b/desktop/src/renderer/RichContent.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceFileReferenceResolveResult } from "../shared/protocol";
 import { ImagePreviewProvider } from "./ImagePreview";
 import { RichContent, __resetRichFileReferenceResolutionCacheForTests } from "./RichContent";
+import { StreamingMarkdown } from "./StreamingMarkdown";
 
 let container: HTMLDivElement;
 let root: Root | null = null;
@@ -400,5 +401,95 @@ describe("RichContent raw HTML and heading levels", () => {
     expect(container.querySelector(".rich-heading.rich-heading--h1")?.textContent).toContain("alpha");
     expect(container.querySelector(".rich-heading.rich-heading--h2")?.textContent).toContain("beta");
     expect(container.querySelector(".rich-heading.rich-heading--h3")?.textContent).toContain("gamma");
+  });
+
+  describe("CJK autolink boundaries", () => {
+    function singleWebLink(): HTMLAnchorElement {
+      const links = container.querySelectorAll("a.rich-web-link");
+      expect(links).toHaveLength(1);
+      return links[0] as HTMLAnchorElement;
+    }
+
+    it("ends a bare URL before a fullwidth full stop", () => {
+      render(<RichContent text={"链接 https://example.com/a。"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://example.com/a");
+      expect(link.textContent).toBe("https://example.com/a");
+      expect(link.parentElement?.textContent).toBe("链接 https://example.com/a。");
+    });
+
+    it("ends a bare URL before a fullwidth comma and keeps the following text out", () => {
+      render(<RichContent text={"见 https://example.com/a?b=1，谢谢"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://example.com/a?b=1");
+      expect(link.textContent).toBe("https://example.com/a?b=1");
+      expect(link.parentElement?.textContent).toBe("见 https://example.com/a?b=1，谢谢");
+    });
+
+    it("keeps paired fullwidth parentheses inside the URL", () => {
+      render(<RichContent text={"https://example.com/a（注释）"} />);
+
+      const link = singleWebLink();
+      // jsdom reflects `href` through URL serialization, which percent-encodes
+      // non-ASCII; compare against the serialized form.
+      expect(link.getAttribute("href")).toBe(new URL("https://example.com/a（注释）").href);
+      expect(link.textContent).toBe("https://example.com/a（注释）");
+    });
+
+    it("excludes an unbalanced trailing fullwidth open paren and everything after it", () => {
+      render(<RichContent text={"PR：https://github.com/blueberrycongee/wuu/pull/45（分支 → main…）"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://github.com/blueberrycongee/wuu/pull/45");
+      expect(link.textContent).toBe("https://github.com/blueberrycongee/wuu/pull/45");
+    });
+
+    it("excludes an unmatched fullwidth close paren", () => {
+      render(<RichContent text={"（见 https://example.com/a）"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://example.com/a");
+      expect(link.textContent).toBe("https://example.com/a");
+    });
+
+    it("keeps the GFM ASCII trailing-punctuation behavior", () => {
+      render(<RichContent text={"https://example.com/a, next"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://example.com/a");
+      expect(link.textContent).toBe("https://example.com/a");
+    });
+
+    it("does not trim explicit markdown links", () => {
+      render(<RichContent text={"[文档](https://example.com/a。)"} />);
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe(new URL("https://example.com/a。").href);
+      expect(link.textContent).toBe("文档");
+    });
+
+    it("opens the trimmed URL on click", () => {
+      render(<RichContent text={"链接 https://example.com/a。"} />);
+
+      act(() => singleWebLink().click());
+      expect(openExternalMock).toHaveBeenCalledWith("https://example.com/a");
+    });
+
+    it("applies the same boundary in the streaming markdown path", () => {
+      render(
+        <StreamingMarkdown
+          streamKey="cjk-autolink-test"
+          initialText={"见 https://example.com/a。"}
+          isLive={false}
+          phase="final_answer"
+        />,
+      );
+
+      const link = singleWebLink();
+      expect(link.getAttribute("href")).toBe("https://example.com/a");
+      expect(link.textContent).toBe("https://example.com/a");
+    });
   });
 });

--- a/desktop/src/renderer/RichContent.tsx
+++ b/desktop/src/renderer/RichContent.tsx
@@ -3,6 +3,7 @@ import { FileText, Github, Globe2, Mail } from "lucide-react";
 import ReactMarkdown, { defaultUrlTransform, type Components, type UrlTransform } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import remarkCjkAutolinkBoundary from "./remarkCjkAutolinkBoundary";
 import type { WorkspaceFileReferenceResolveResult } from "../shared/protocol";
 import { useImagePreview } from "./ImagePreview";
 import {
@@ -188,7 +189,7 @@ function MarkdownContentView({
   return (
     <ReactMarkdown
       components={components}
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkCjkAutolinkBoundary]}
       rehypePlugins={allowRawHtml ? [rehypeRaw, rehypeHeadingIDs] : [rehypeHeadingIDs]}
       urlTransform={richMarkdownUrlTransform}
     >

--- a/desktop/src/renderer/remarkCjkAutolinkBoundary.ts
+++ b/desktop/src/renderer/remarkCjkAutolinkBoundary.ts
@@ -1,0 +1,142 @@
+/**
+ * remark plugin that fixes bare-URL autolink boundaries in CJK prose.
+ *
+ * remark-gfm (micromark-extension-gfm-autolink-literal) only trims trailing
+ * ASCII punctuation when deciding where a literal autolink ends, so in
+ * Chinese text the link swallows the following fullwidth punctuation — and
+ * everything after it — into both the label and the href
+ * (`https://example.com/a。` links the `。`). Clicking such a link opens a
+ * URL with a percent-encoded garbage tail and usually lands on a 404.
+ *
+ * This plugin runs after remark-gfm, finds link nodes that came from the
+ * autolink literal tokenizer (raw source text equals the link label), and
+ * moves the CJK tail back out of the link into a following plain-text node.
+ * Explicit markdown links `[text](url)` are never touched: their href is
+ * author-specified.
+ */
+
+type MdastPosition = {
+  start: { offset?: number };
+  end: { offset?: number };
+};
+
+type MdastNode = {
+  type: string;
+  url?: string;
+  value?: string;
+  children?: MdastNode[];
+  position?: MdastPosition;
+};
+
+type MdastFile = {
+  value?: unknown;
+};
+
+// Sentence-level CJK punctuation that can never be part of a URL someone
+// meant to share. Fullwidth parentheses are NOT in this set: they get
+// bracket-balancing semantics below, mirroring how GFM treats ASCII parens.
+const CJK_URL_TERMINATORS = new Set([
+  "。", "，", "、", "；", "：", "？", "！", "…",
+  "【", "】", "《", "》", "「", "」", "『", "』",
+  "“", "”", "‘", "’", "〈", "〉", "～",
+]);
+
+/**
+ * Split an autolink literal into the part that belongs to the URL and the
+ * trailing CJK tail that does not. Returns the index at which the URL ends;
+ * `url.length` means nothing to trim.
+ *
+ * Rules:
+ * - A terminator at top level ends the URL immediately.
+ * - Fullwidth parens balance: paired `（…）` stays inside the URL; an
+ *   unmatched trailing `（` ends the URL at that paren; an unmatched `）`
+ *   ends the URL before it.
+ * - Terminators inside a paired `（…）` group are left alone — the whole
+ *   group is kept, so their context is unambiguous.
+ */
+export function cjkAutolinkUrlEnd(url: string): number {
+  let depth = 0;
+  let firstUnmatchedOpen = -1;
+  for (let index = 0; index < url.length; index += 1) {
+    const char = url[index];
+    if (char === "（") {
+      if (depth === 0) {
+        firstUnmatchedOpen = index;
+      }
+      depth += 1;
+    } else if (char === "）") {
+      if (depth === 0) {
+        return index;
+      }
+      depth -= 1;
+    } else if (depth === 0 && CJK_URL_TERMINATORS.has(char)) {
+      return index;
+    }
+  }
+  return depth > 0 ? firstUnmatchedOpen : url.length;
+}
+
+function isAutolinkLiteral(node: MdastNode, source: string): boolean {
+  if (node.type !== "link" || typeof node.url !== "string") {
+    return false;
+  }
+  const children = node.children ?? [];
+  if (children.length !== 1 || children[0].type !== "text") {
+    return false;
+  }
+  const label = children[0].value ?? "";
+  if (!label || !node.url.endsWith(label)) {
+    return false;
+  }
+  // Explicit `[text](url)` links can also have label === url; tell them
+  // apart by the raw source the node was parsed from. Autolink literals
+  // cover exactly the URL text.
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (typeof start !== "number" || typeof end !== "number") {
+    return false;
+  }
+  return source.slice(start, end) === label;
+}
+
+function trimLinkNode(node: MdastNode): string {
+  const text = node.children?.[0];
+  if (!text || typeof text.value !== "string" || typeof node.url !== "string") {
+    return "";
+  }
+  const end = cjkAutolinkUrlEnd(text.value);
+  if (end >= text.value.length) {
+    return "";
+  }
+  const tail = text.value.slice(end);
+  text.value = text.value.slice(0, end);
+  node.url = node.url.slice(0, node.url.length - tail.length);
+  return tail;
+}
+
+function visit(parent: MdastNode, source: string): void {
+  const children = parent.children;
+  if (!children) {
+    return;
+  }
+  for (let index = 0; index < children.length; index += 1) {
+    const node = children[index];
+    if (isAutolinkLiteral(node, source)) {
+      const tail = trimLinkNode(node);
+      if (tail) {
+        children.splice(index + 1, 0, { type: "text", value: tail });
+        index += 1;
+        continue;
+      }
+    }
+    visit(node, source);
+  }
+}
+
+export function remarkCjkAutolinkBoundary() {
+  return (tree: MdastNode, file: MdastFile): void => {
+    visit(tree, typeof file?.value === "string" ? file.value : "");
+  };
+}
+
+export default remarkCjkAutolinkBoundary;


### PR DESCRIPTION
## 问题

聊天里的裸 URL 由 remark-gfm autolink 识别，但边界判定只裁剪 ASCII 尾随标点，不识别全角/中文标点。中文语境下 URL 后面的标点和文字会被吞进链接：链接文本变长，点击打开的 URL 带垃圾尾巴（百分号编码），实际跳到 404。见 #47 的复现表格。

## 改动

在 RichContent 的 markdown 管线新增一个小 remark 插件（`remarkCjkAutolinkBoundary`，跑在 remarkGfm 之后）：

- 识别 autolink literal 生成的 link 节点（用源码位置判定原始文本等于链接文本，显式 `[text](url)` 不受影响）；
- `。，、；：？！…【】《》「」『』“”‘’〈〉～` 等句读直接终止 URL；
- 全角括号按 GFM 配平语义：成对 `（…）` 保留在 URL 内，未配平的尾随 `（`/`）` 结束链接；
- 裁下的尾巴还原为后续普通文本节点，链接显示文本与 href 始终一致。

StreamingMarkdown 与最终渲染共用同一 MarkdownContent 管线，两条路径同时覆盖；`autoLinkFiles` 文件路径链接不受影响。

## 测试

- `RichContent.test.tsx` 新增 9 个用例：#47 复现表格全行、配平/未配平全角括号、混排查询参数、显式 markdown 链接不裁剪、点击打开的 URL、流式渲染路径；
- `npm test` 全量通过（typecheck + 169 文件 / 1909 测试 + 原生测试）。

Closes #47