### PR TITLE
fix(desktop): theme inline code in dark mode

### DIFF
--- a/desktop/src/renderer/styles/base.test.ts
+++ b/desktop/src/renderer/styles/base.test.ts
@@ -44,6 +44,16 @@ describe("global text selection", () => {
   });
 });
 
+describe("dark theme inline code", () => {
+  it("overrides the light message-flow chip instead of leaving a bright surface", () => {
+    const darkTheme = themeCss.match(
+      /:root\[data-theme="dark"\]\s*\{([\s\S]*?)\n\}/,
+    )?.[1] ?? "";
+
+    expect(darkTheme).toMatch(/--surface-chip:\s*var\(--surface-4\);/);
+  });
+});
+
 /**
  * Neutral-hue regression guard.
  *

--- a/desktop/src/renderer/styles/theme.css
+++ b/desktop/src/renderer/styles/theme.css
@@ -321,6 +321,7 @@
   --rich-link-color: #60a5fa;
   --rich-link-hover-color: #79b8ff;
   --rich-code-surface-bg: #26292d;
+  --surface-chip: var(--surface-4);
   --fork-worktree-copy-bg: rgba(38, 42, 46, 0.9);
   --fork-worktree-focus-ring: rgba(88, 166, 255, 0.3);
   --rich-blockquote-color: #a3a9ae;

--- a/desktop/src/renderer/styles/workspace.css
+++ b/desktop/src/renderer/styles/workspace.css
@@ -1945,11 +1945,12 @@ html.resizing-workspace-file-split * {
   text-decoration: underline;
 }
 
-/* Inline code: react-markdown renders this as a bare <code>. */
-.workspace-markdown-reading code {
+/* Inline code: keep this selector more specific than the shared message-flow
+   rule and exclude fenced code, which owns its surface through .rich-code. */
+.workspace-markdown-reading .rich-content :not(pre) > code {
   font-family: var(--font-mono, "SFMono-Regular", Consolas, "Liberation Mono", monospace);
   font-size: 0.88em;
-  background: var(--surface-2);
+  background: var(--surface-chip);
   padding: 0.1em 0.36em;
   border-radius: 4px;
 }

--- a/desktop/src/renderer/styles/workspace.test.ts
+++ b/desktop/src/renderer/styles/workspace.test.ts
@@ -159,6 +159,15 @@ describe("workspace markdown reading prose", () => {
     expect(hoveredLink).toMatch(/text-decoration:\s*underline;/);
   });
 
+  it("uses the shared theme-aware chip only for inline code", () => {
+    const inlineCode = cssRuleBody(
+      ".workspace-markdown-reading .rich-content :not(pre) > code",
+    );
+
+    expect(inlineCode).toMatch(/background:\s*var\(--surface-chip\);/);
+    expect(workspaceCss).not.toMatch(/\.workspace-markdown-reading\s+code\s*\{/);
+  });
+
   it("frames code blocks, tables, and blockquotes so they read as artifacts", () => {
     const codeBlock = cssRuleBody(".workspace-markdown-reading .rich-code-block");
     const tableWrap = cssRuleBody(".workspace-markdown-reading .rich-table-wrap");


### PR DESCRIPTION
## Summary

- override the inline-code chip surface for dark mode
- apply the same theme-aware inline-code surface to workspace Markdown previews
- exclude fenced code blocks and add regression coverage

## Verification

- `npm --prefix desktop test`
- `npm --prefix desktop run build`
- CUA verification in dark mode for message flow and workspace Markdown preview