### PR TITLE
fix(desktop): disable production reload and DevTools

### DIFF
--- a/desktop/src/main/appShellGuards.test.ts
+++ b/desktop/src/main/appShellGuards.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  appShellWebPreferences,
+  installProductionAppShellGuards,
+  isBlockedProductionShortcut,
+  productionApplicationMenuTemplate,
+  type AppShellKeyboardInput,
+  type AppShellWebContents,
+} from "./appShellGuards";
+
+const input = (
+  key: string,
+  modifiers: Partial<Omit<AppShellKeyboardInput, "key">> = {},
+): AppShellKeyboardInput => ({
+  key,
+  alt: false,
+  control: false,
+  meta: false,
+  shift: false,
+  ...modifiers,
+});
+
+type TestWebContents = AppShellWebContents & {
+  sendKey(value: AppShellKeyboardInput): ReturnType<typeof vi.fn>;
+  openDevTools(): void;
+};
+
+function testWebContents(): TestWebContents {
+  let inputListener:
+    | ((event: { preventDefault(): void }, value: AppShellKeyboardInput) => void)
+    | undefined;
+  let devToolsListener: (() => void) | undefined;
+  const closeDevTools = vi.fn();
+  return {
+    onBeforeInputEvent: (listener) => {
+      inputListener = listener;
+    },
+    onDevToolsOpened: (listener) => {
+      devToolsListener = listener;
+    },
+    closeDevTools,
+    sendKey: (value) => {
+      const preventDefault = vi.fn();
+      inputListener?.({ preventDefault }, value);
+      return preventDefault;
+    },
+    openDevTools: () => devToolsListener?.(),
+  };
+}
+
+describe("production app shell shortcuts", () => {
+  it.each([
+    input("r", { meta: true }),
+    input("R", { meta: true, shift: true }),
+    input("r", { control: true }),
+    input("R", { control: true, shift: true }),
+    input("F5"),
+    input("i", { meta: true, alt: true }),
+    input("j", { meta: true, alt: true }),
+    input("c", { meta: true, alt: true }),
+    input("i", { control: true, shift: true }),
+    input("j", { control: true, shift: true }),
+    input("c", { control: true, shift: true }),
+    input("F12"),
+  ])("blocks packaged reload and DevTools chord %#", (value) => {
+    expect(isBlockedProductionShortcut(value)).toBe(true);
+  });
+
+  it.each([
+    input("r"),
+    input("r", { alt: true }),
+    input("b", { meta: true }),
+    input("i", { control: true }),
+  ])("leaves unrelated product input alone %#", (value) => {
+    expect(isBlockedProductionShortcut(value)).toBe(false);
+  });
+});
+
+describe("production app shell guards", () => {
+  it("guards main and popped-out web contents uniformly in packaged builds", () => {
+    const setApplicationMenu = vi.fn();
+    let webContentsCreated: ((contents: AppShellWebContents) => void) | undefined;
+    installProductionAppShellGuards({
+      isPackaged: true,
+      setApplicationMenu,
+      onWebContentsCreated: (listener) => {
+        webContentsCreated = listener;
+      },
+    });
+
+    expect(setApplicationMenu).toHaveBeenCalledTimes(1);
+    const mainWindow = testWebContents();
+    const popOutWindow = testWebContents();
+    webContentsCreated?.(mainWindow);
+    webContentsCreated?.(popOutWindow);
+
+    for (const contents of [mainWindow, popOutWindow]) {
+      expect(contents.sendKey(input("r", { meta: true }))).toHaveBeenCalledTimes(1);
+      expect(contents.sendKey(input("b", { meta: true }))).not.toHaveBeenCalled();
+      contents.openDevTools();
+      expect(contents.closeDevTools).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("does not alter menus, shortcuts, or DevTools in development", () => {
+    const setApplicationMenu = vi.fn();
+    const onWebContentsCreated = vi.fn();
+    installProductionAppShellGuards({
+      isPackaged: false,
+      setApplicationMenu,
+      onWebContentsCreated,
+    });
+
+    expect(setApplicationMenu).not.toHaveBeenCalled();
+    expect(onWebContentsCreated).not.toHaveBeenCalled();
+    expect(appShellWebPreferences(false)).toEqual({});
+  });
+
+  it("disables BrowserWindow DevTools in packaged builds", () => {
+    expect(appShellWebPreferences(true)).toEqual({ devTools: false });
+  });
+
+  it("keeps standard menus without exposing the reload and DevTools view menu", () => {
+    expect(productionApplicationMenuTemplate("darwin")).toEqual([
+      { role: "appMenu" },
+      { role: "editMenu" },
+      { role: "windowMenu" },
+    ]);
+    expect(productionApplicationMenuTemplate("win32")).toEqual([
+      { role: "fileMenu" },
+      { role: "editMenu" },
+      { role: "windowMenu" },
+    ]);
+  });
+});

--- a/desktop/src/main/appShellGuards.ts
+++ b/desktop/src/main/appShellGuards.ts
@@ -1,0 +1,77 @@
+import type { MenuItemConstructorOptions } from "electron";
+
+export type AppShellKeyboardInput = {
+  key: string;
+  alt: boolean;
+  control: boolean;
+  meta: boolean;
+  shift: boolean;
+};
+
+type PreventableInputEvent = {
+  preventDefault(): void;
+};
+
+export type AppShellWebContents = {
+  onBeforeInputEvent(
+    listener: (event: PreventableInputEvent, input: AppShellKeyboardInput) => void,
+  ): void;
+  onDevToolsOpened(listener: () => void): void;
+  closeDevTools(): void;
+};
+
+type ProductionAppShellGuardOptions = {
+  isPackaged: boolean;
+  setApplicationMenu(): void;
+  onWebContentsCreated(listener: (contents: AppShellWebContents) => void): void;
+};
+
+export function appShellWebPreferences(isPackaged: boolean): { devTools?: false } {
+  return isPackaged ? { devTools: false } : {};
+}
+
+export function productionApplicationMenuTemplate(
+  platform: string,
+): MenuItemConstructorOptions[] {
+  return [
+    { role: platform === "darwin" ? "appMenu" : "fileMenu" },
+    { role: "editMenu" },
+    { role: "windowMenu" },
+  ];
+}
+
+export function isBlockedProductionShortcut(input: AppShellKeyboardInput): boolean {
+  const key = input.key.toLowerCase();
+  const commandOrControl = input.meta || input.control;
+
+  if (key === "f5" || (key === "r" && commandOrControl && !input.alt)) {
+    return true;
+  }
+
+  if (key === "f12") {
+    return true;
+  }
+
+  const devToolsKey = key === "i" || key === "j" || key === "c";
+  const macDevToolsChord = input.meta && input.alt;
+  const otherDevToolsChord = input.control && input.shift;
+  return devToolsKey && (macDevToolsChord || otherDevToolsChord);
+}
+
+export function installProductionAppShellGuards(
+  options: ProductionAppShellGuardOptions,
+): void {
+  if (!options.isPackaged) return;
+
+  options.setApplicationMenu();
+  options.onWebContentsCreated((contents) => {
+    contents.onBeforeInputEvent((event, input) => {
+      if (isBlockedProductionShortcut(input)) {
+        event.preventDefault();
+      }
+    });
+    contents.onDevToolsOpened(() => {
+      contents.closeDevTools();
+    });
+  });
+}

--- a/desktop/src/main/codexPetWindow.ts
+++ b/desktop/src/main/codexPetWindow.ts
@@ -11,6 +11,7 @@ import {
   type CodexPetsSnapshot,
 } from "../shared/protocol";
 import { CODEX_PET_CELL_HEIGHT, CODEX_PET_CELL_WIDTH, CODEX_PET_STATES } from "./codexPets";
+import { appShellWebPreferences } from "./appShellGuards";
 
 export type CodexPetRuntime = { running: boolean; status: string };
 
@@ -786,6 +787,7 @@ export class CodexPetWindowManager {
     private readonly onJumpRequested: (hint: CodexPetHint) => void,
     private readonly onSizeChange?: (size: CodexPetSize) => void,
     private readonly onScaleChange?: (scale: number) => void,
+    private readonly isPackaged = false,
   ) {}
 
   setSize(size: CodexPetSize): void {
@@ -963,6 +965,7 @@ export class CodexPetWindowManager {
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: true,
+        ...appShellWebPreferences(this.isPackaged),
       },
     });
     this.win = win;

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import {
   dialog,
   ipcMain,
   type IpcMainInvokeEvent,
+  Menu,
   nativeTheme,
   screen,
   session as electronSession,
@@ -124,6 +125,11 @@ import {
 import { TerminalSessionManager } from "./terminalSessions";
 import { WorkspaceFileService } from "./workspaceFiles";
 
+import {
+  appShellWebPreferences,
+  installProductionAppShellGuards,
+  productionApplicationMenuTemplate,
+} from "./appShellGuards";
 import { createWindowRegistry, type WindowRegistry } from "./windowRegistry";
 import {
   computeDefaultMainWindowBounds,
@@ -223,6 +229,7 @@ const codexPetWindowManager = new CodexPetWindowManager(
     // per-frame scale updates never reach this callback.
     updateCodexPetSettings({ scale });
   },
+  app.isPackaged,
 );
 const terminalSessionManager = new TerminalSessionManager(
   (windowID, event) => emitTerminalEvent(windowID, event),
@@ -612,6 +619,7 @@ function createPopOutWindow(params: PopOutWindowParams): BrowserWindow {
       contextIsolation: true,
       nodeIntegration: false,
       webviewTag: true,
+      ...appShellWebPreferences(app.isPackaged),
     },
   });
   const windowID = win.webContents.id;
@@ -685,6 +693,7 @@ function createWindow(): void {
       contextIsolation: true,
       nodeIntegration: false,
       webviewTag: true,
+      ...appShellWebPreferences(app.isPackaged),
     },
   };
   if (restoredBounds) {
@@ -791,6 +800,27 @@ async function directorySize(path: string): Promise<number> {
 }
 
 app.whenReady().then(async () => {
+  installProductionAppShellGuards({
+    isPackaged: app.isPackaged,
+    setApplicationMenu: () => {
+      Menu.setApplicationMenu(
+        Menu.buildFromTemplate(productionApplicationMenuTemplate(process.platform)),
+      );
+    },
+    onWebContentsCreated: (listener) => {
+      app.on("web-contents-created", (_event, contents) => {
+        listener({
+          onBeforeInputEvent: (handler) => {
+            contents.on("before-input-event", (event, value) => handler(event, value));
+          },
+          onDevToolsOpened: (handler) => {
+            contents.on("devtools-opened", handler);
+          },
+          closeDevTools: () => contents.closeDevTools(),
+        });
+      });
+    },
+  });
   await clearOversizedDevCaches();
   await removeLegacyDesktopCliLink().catch(() => false);
   projectManager.load();


### PR DESCRIPTION
## Summary
- block reload, force-reload, and DevTools shortcuts for every packaged app webContents
- disable BrowserWindow DevTools for the main, popped-out session, and Codex Pet windows
- keep standard production application menus while omitting the View menu debug entries
- preserve all existing development behavior

## Testing
- `npm run typecheck`
- `npx vitest run src/main/appShellGuards.test.ts src/main/codexPetWindow.test.ts`
- `npm run test:unit`
- `npm run build`

Closes #37