### PR TITLE
fix(desktop): tighten process commentary line height

### DIFF
--- a/desktop/src/renderer/AssistantTurnShell.test.tsx
+++ b/desktop/src/renderer/AssistantTurnShell.test.tsx
@@ -41,6 +41,10 @@ const turnsCSS = readFileSync(
   resolve(process.cwd(), "src/renderer/styles/turns.css"),
   "utf8",
 );
+const conversationShellCSS = readFileSync(
+  resolve(process.cwd(), "src/renderer/styles/conversation-shell.css"),
+  "utf8",
+);
 
 function cssRule(selector: string): string {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -1278,6 +1282,20 @@ describe("AssistantTurnShell — turn divider styles", () => {
 
     expect(cssRule(".activity-timeline-item")).not.toContain("animation:");
     expect(turnsCSS).not.toContain("activity-timeline-item-in");
+  });
+});
+
+describe("AssistantTurnShell — process typography", () => {
+  it("keeps process commentary tighter than long-form answer prose", () => {
+    const commentaryRule = cssRule(".turn-process-entry-commentary");
+
+    expect(commentaryRule).toContain(
+      "line-height: var(--conversation-commentary-line-height);",
+    );
+    expect(commentaryRule).not.toContain("--conversation-reading-line-height");
+    expect(conversationShellCSS).toContain(
+      "--conversation-commentary-line-height: 1.6;",
+    );
   });
 });
 

--- a/desktop/src/renderer/styles/conversation-shell.css
+++ b/desktop/src/renderer/styles/conversation-shell.css
@@ -122,6 +122,10 @@
    * dense against 14px type on screen.
    */
   --conversation-reading-line-height: 1.75;
+  /* Commentary is short process narration, not long-form answer prose. A
+     tighter pitch avoids the excess optical whitespace that Latin glyphs
+     leave inside the mixed-script reading line box. */
+  --conversation-commentary-line-height: 1.6;
   --conversation-prose-block-gap: 18px;
   --conversation-message-element-gap: 18px;
   /* Process rows share the message size and weight; color and spacing,

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -1927,7 +1927,7 @@
   color: var(--ink);
   font-size: var(--conversation-message-font-size);
   font-weight: var(--conversation-message-font-weight);
-  line-height: var(--conversation-reading-line-height);
+  line-height: var(--conversation-commentary-line-height);
 }
 
 /*


### PR DESCRIPTION
## Summary

Give process commentary its own tighter line-height so multi-line English narration no longer inherits the spacious long-form answer rhythm. The same rule remains language-neutral for mixed CJK/Latin content.

## Changes

- Add a dedicated `--conversation-commentary-line-height` token at `1.6`
- Keep final-answer prose at the existing `1.75` reading line-height
- Add a CSS regression test that prevents commentary from reusing the answer token

## Test plan

- [x] Added or updated unit tests for the change
- [ ] `go test ./...` passes (not run; no Go changes)
- [ ] `cd desktop && npm test` passes (not run as a single command)
- [ ] Manually verified the behavior in the desktop shell
- [x] `cd desktop && npm run typecheck`
- [x] `cd desktop && npm run test:unit`
- [x] `cd desktop && npm run build`

## Risk and rollback

- Risk level: low
- Revert the commit to restore commentary to the shared answer line-height.

## Linked issues / docs

No linked issue; follows up on the reported English/CJK commentary spacing mismatch.