### PR TITLE
fix(anthropic): preserve empty thinking blocks

### DIFF
--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -1472,22 +1472,28 @@ func mapReasoningBlocks(blocks []providers.ReasoningBlock) []anthropicBlock {
 	out := make([]anthropicBlock, 0, len(blocks))
 	for _, block := range blocks {
 		switch block.Type {
-		case "thinking", "redacted_thinking":
+		case "thinking":
+			thinking := block.Thinking
 			out = append(out, anthropicBlock{
-				Type:      block.Type,
-				Thinking:  block.Thinking,
+				Type:      "thinking",
+				Thinking:  &thinking,
 				Signature: block.Signature,
-				Data:      block.Data,
 			})
+		case "redacted_thinking":
+			out = append(out, anthropicBlock{Type: "redacted_thinking", Data: block.Data})
 		}
 	}
 	return out
 }
 
 func anthropicReasoningBlock(block anthropicBlock) providers.ReasoningBlock {
+	thinking := ""
+	if block.Thinking != nil {
+		thinking = *block.Thinking
+	}
 	return providers.ReasoningBlock{
 		Type:      block.Type,
-		Thinking:  block.Thinking,
+		Thinking:  thinking,
 		Signature: block.Signature,
 		Data:      block.Data,
 	}
@@ -1625,7 +1631,7 @@ type anthropicMessage struct {
 type anthropicBlock struct {
 	Type         string                 `json:"type"`
 	Text         string                 `json:"text,omitempty"`
-	Thinking     string                 `json:"thinking,omitempty"`
+	Thinking     *string                `json:"thinking,omitempty"`
 	Signature    string                 `json:"signature,omitempty"`
 	Data         string                 `json:"data,omitempty"`
 	Source       *anthropicImageSource  `json:"source,omitempty"`

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -220,6 +220,64 @@ func TestChat_AnthropicReplaysReasoningBlocksForAssistantToolUse(t *testing.T) {
 	}
 }
 
+func TestChat_AnthropicReplaysEmptySignedThinkingForAssistantToolUse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		msgs, ok := body["messages"].([]any)
+		if !ok || len(msgs) != 3 {
+			t.Fatalf("expected 3 messages, got %#v", body["messages"])
+		}
+		assistant, ok := msgs[1].(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected assistant message: %#v", msgs[1])
+		}
+		content, ok := assistant["content"].([]any)
+		if !ok || len(content) != 2 {
+			t.Fatalf("expected thinking + tool_use content, got %#v", assistant["content"])
+		}
+		thinking, ok := content[0].(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected thinking block: %#v", content[0])
+		}
+		thinkingText, present := thinking["thinking"]
+		if !present || thinkingText != "" || thinking["type"] != "thinking" || thinking["signature"] != "sig_empty" {
+			t.Fatalf("empty signed thinking must be replayed verbatim, got %#v", thinking)
+		}
+
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{BaseURL: server.URL, APIKey: "test-key"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	_, err = client.Chat(context.Background(), providers.ChatRequest{
+		Model: "claude-test",
+		Messages: []providers.ChatMessage{
+			{Role: "user", Content: "inspect repo"},
+			{
+				Role: "assistant",
+				ReasoningBlocks: []providers.ReasoningBlock{
+					{Type: "thinking", Thinking: "", Signature: "sig_empty"},
+				},
+				ToolCalls: []providers.ToolCall{
+					{ID: "call_1", Name: "list_files", Arguments: `{}`},
+				},
+			},
+			{Role: "tool", ToolCallID: "call_1", Name: "list_files", Content: "[]"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
 func TestChat_AnthropicFallsBackToReasoningContentReplay(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any


### PR DESCRIPTION
## Summary
- preserve explicit empty `thinking` fields when replaying provider-native Anthropic reasoning blocks
- map `thinking` and `redacted_thinking` to their distinct wire shapes
- cover signed empty thinking before tool use by asserting the actual HTTP request body

## Context
Anthropic-compatible endpoints can return a thinking block with an empty visible string and a non-empty signature. These blocks must be replayed unchanged. The previous string field used `omitempty`, which removed `thinking` entirely and produced a provider-invalid history block on the next request.

This matches the converged behavior in Anthropic documentation, Kimi Code, and pi: preserve the empty field and its signature instead of dropping the block or substituting placeholder text.

## Verification
- `go test ./internal/providers/anthropic -run 'TestChat_AnthropicReplays(ReasoningBlocks|EmptySignedThinking)ForAssistantToolUse|TestThinkingReplayModes' -count=1`\n- `go test ./internal/providers/anthropic ./internal/agent ./internal/runtime -count=1`\n- `go test ./...`\n- `git diff --check`