### PR TITLE
docs: add bilingual user guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ thirdparty/
 
 /docs/*
 !/docs/README.md
+!/docs/user-guide.md
+!/docs/user-guide-zh.md
 !/docs/exec.md
 !/docs/app-server-protocol.md
 !/docs/jsonl-events.md

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ go run ./cmd/wuu --version
 
 ## Quick Start
 
+For installation, provider setup, sessions, attachments, trust boundaries, and
+common problems, read the [user guide](docs/user-guide.md).
+
 **Desktop**
 
 Open `wuu.app`, choose a local project folder, and start a thread from the composer.
@@ -257,6 +260,7 @@ For another provider, the same config shape applies:
 ## Docs
 
 - Browse all maintained documentation: [Documentation index](docs/README.md)
+- Install, configure, and use wuu: [User guide](docs/user-guide.md)
 - Drive wuu from scripts, CI, or other agents: [`wuu exec`](docs/exec.md)
 - Parse the streaming output: [JSONL events](docs/jsonl-events.md)
 - Embed the core in a new shell: [`app-server` protocol](docs/app-server-protocol.md)

--- a/README_zh.md
+++ b/README_zh.md
@@ -95,6 +95,8 @@ go run ./cmd/wuu --version
 
 ## 快速开始
 
+安装、提供商配置、会话、附件、信任边界和常见问题见[用户指南](docs/user-guide-zh.md)。
+
 **桌面端**
 
 打开 `wuu.app`，选择一个本地项目文件夹，然后在输入框里开始任务。
@@ -240,6 +242,7 @@ export ANTHROPIC_API_KEY="..."
 ## 文档
 
 - 浏览所有持续维护的文档：[文档索引](docs/README.md)
+- 安装、配置和使用 wuu：[用户指南](docs/user-guide-zh.md)
 - 在脚本、CI 或其他 agent 中调用 wuu：[`wuu exec`](docs/exec.md)
 - 解析流式输出：[JSONL 事件](docs/jsonl-events.md)
 - 将核心嵌入新的 Shell：[`app-server` 协议](docs/app-server-protocol.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,9 @@ developing wuu. Start with the section that matches what you are trying to do.
 
 ## Use wuu
 
+- [User guide](user-guide.md) ([中文](user-guide-zh.md)) — install wuu,
+  connect a provider, work in a repository, continue sessions, and solve common
+  setup problems.
 - [`wuu exec`](exec.md) — run wuu from a terminal, script, CI job, or another agent.
 - [Configuration model](configuration-model-zh.md) — understand configuration
   sources, ownership, trust boundaries, and platform-specific behavior (Chinese).

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -1,0 +1,161 @@
+# 用户指南
+
+这份指南覆盖从安装 wuu 到完成日常工作的稳定路径。每个任务都在一个本地工作区中
+执行，并使用你自己配置的凭据调用模型提供商。
+
+## 选择使用方式
+
+- **桌面端：**适合交互式工作、多会话、附件和可视化审查。
+- **CLI：**通过 `wuu exec` 从终端、脚本、CI 或其他 agent 调用。
+
+桌面应用自带私有 core，不依赖单独安装的 CLI。两者可以同时存在，版本也可能不同。
+
+## 安装
+
+### macOS 桌面预览版
+
+从 [GitHub Releases](https://github.com/blueberrycongee/wuu/releases) 下载 arm64
+DMG 或 ZIP，然后把 `wuu.app` 移到 `/Applications`。
+
+当前预览版没有签名和公证。如果确认下载来源可信，但 macOS 阻止打开，可以移除
+quarantine 标记：
+
+```bash
+xattr -dr com.apple.quarantine /Applications/wuu.app
+open /Applications/wuu.app
+```
+
+不要对来源不可信的应用运行这条命令。
+
+### CLI
+
+使用 Go 安装 CLI：
+
+```bash
+go install github.com/blueberrycongee/wuu/cmd/wuu@latest
+wuu --version
+```
+
+GitHub Releases 不提供单独的 CLI 压缩包。
+
+## 连接模型提供商
+
+wuu 使用 BYOK 模式：模型请求使用你自己配置的提供商和凭据。
+
+### 桌面端
+
+打开**设置 → 提供商**，选择或添加提供商，填写模型、端点和 API Key，然后保存，
+再开始会话。
+
+### CLI
+
+首次使用时创建用户配置：
+
+```bash
+wuu init
+```
+
+默认写入 `~/.wuu/config.json`；设置了 `WUU_HOME` 时写入
+`$WUU_HOME/config.json`。初始配置包含 OpenAI、Anthropic 和 OpenRouter。按照所选
+提供商的 `api_key_env` 设置环境变量，例如：
+
+```bash
+export OPENAI_API_KEY="..."
+wuu exec "描述一下这个仓库"
+```
+
+单次运行切换到另一个已配置的提供商：
+
+```bash
+wuu exec --provider anthropic "审查当前改动"
+```
+
+配置覆盖顺序和信任边界见[配置模型](configuration-model-zh.md)，完整自动化参数见
+[`wuu exec`](exec.md)。
+
+## 在正确的仓库中工作
+
+工作区决定文件工具、命令和可见会话的范围。
+
+- 桌面端先打开或选择本地项目文件夹，再开始会话。
+- CLI 在目标仓库中运行，或者显式传入 `--workdir`。
+
+```bash
+cd path/to/project
+wuu exec "运行测试并修复失败"
+
+wuu exec --workdir path/to/project "总结这个代码库"
+```
+
+描述你真正想得到的结果；如果有影响产品行为、安全、兼容性或数据的约束，也一并
+说明。常规实现细节可以让 wuu 先检查仓库后自行判断。
+
+## 添加文件和图片
+
+桌面输入框支持附件。CLI 需要显式传入：
+
+```bash
+wuu exec --file report.pdf "总结这份报告"
+wuu exec --image screenshot.png "找出这个界面的问题"
+```
+
+附件只让当前任务能够读取该文件，不会自动把它加入仓库。
+
+## 继续和查看会话
+
+wuu 会保存持久会话，方便跨多次运行继续工作：
+
+```bash
+wuu exec --continue "继续上一个会话"
+wuu exec --resume THREAD_ID "继续这个任务"
+wuu session list
+wuu session show --last
+```
+
+自动化任务不需要保存会话时使用 `--ephemeral`。`wuu session archive` 只会把会话
+从普通列表中隐藏；只有确定要移除已保存历史时才使用 `wuu session delete`。
+
+## 理解信任边界
+
+- wuu 操作本地文件，并按当前权限模式运行本地命令。
+- 提示词和相关上下文会发送给配置的模型提供商。BYOK 不代表模型在本地运行。
+- API Key 应通过桌面提供商设置或环境变量提供，不要提交到仓库。
+- 正常启动时，提供商端点、凭据、记忆路径和权限模式始终由用户控制；项目配置不能
+  静默替换这些内容。
+- 用户配置、会话、日志和其他状态默认位于 `~/.wuu`。设置 `WUU_HOME` 可以整体迁移
+  这些状态。
+
+处理不可信仓库或敏感数据前，请先阅读[安全模型](security-model.md)。
+
+## 常见问题
+
+### `wuu: command not found`
+
+确认 Go 的二进制目录已经加入 `PATH`：
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+如果这样可以解决问题，再把等价配置加入 shell 启动文件。
+
+### 提供商提示缺少 API Key
+
+确认配置中的 `api_key_env` 与实际导出的环境变量名一致，并从能读取该变量的环境中
+启动 wuu。桌面端应在**设置 → 提供商**中填写 Key，不要依赖只对某个终端生效的
+`export`。
+
+### 出现了错误的仓库或会话
+
+检查桌面端当前选择的工作区、终端当前目录或 `--workdir`。默认情况下，会话列表按
+工作区隔离。
+
+### `wuu init` 提示配置已存在
+
+直接编辑已有配置，不要覆盖。`wuu init --force` 会替换文件，只有在备份好需要保留的
+内容后才应使用。
+
+### macOS 不允许打开桌面应用
+
+先确认应用来自官方 GitHub Releases，再运行安装章节中的 quarantine 命令。当前预览版
+确实没有签名和公证。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,176 @@
+# User Guide
+
+This guide covers the stable path from installing wuu to completing daily work.
+For every task, wuu operates on a local workspace and calls a model provider with
+credentials you control.
+
+## Choose how to use wuu
+
+- **Desktop:** use the macOS app for interactive work, multiple conversations,
+  attachments, and visual review.
+- **CLI:** use `wuu exec` from a terminal, script, CI job, or another agent.
+
+The desktop app includes its own private core. A separately installed CLI is not
+required by the desktop app, and the two may have different versions.
+
+## Install
+
+### macOS desktop preview
+
+Download the arm64 DMG or ZIP from
+[GitHub Releases](https://github.com/blueberrycongee/wuu/releases), then move
+`wuu.app` to `/Applications`.
+
+The current preview is unsigned and not notarized. For a release you trust, remove
+the quarantine attribute if macOS blocks the app:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/wuu.app
+open /Applications/wuu.app
+```
+
+Do not run this command for an app downloaded from an untrusted source.
+
+### CLI
+
+Install the CLI with Go:
+
+```bash
+go install github.com/blueberrycongee/wuu/cmd/wuu@latest
+wuu --version
+```
+
+GitHub Releases do not contain standalone CLI archives.
+
+## Connect a model provider
+
+wuu is BYOK: model requests use a provider and credentials that you configure.
+
+### Desktop
+
+Open **Settings → Providers**, choose or add a provider, then enter its model,
+endpoint, and API key. Save the provider before starting a conversation.
+
+### CLI
+
+Create a starter user config once:
+
+```bash
+wuu init
+```
+
+This writes `~/.wuu/config.json`, or `$WUU_HOME/config.json` when `WUU_HOME` is
+set. The starter config includes OpenAI, Anthropic, and OpenRouter entries. Set
+the environment variable named by the selected provider, for example:
+
+```bash
+export OPENAI_API_KEY="..."
+wuu exec "describe this repository"
+```
+
+To use a different configured provider for one run:
+
+```bash
+wuu exec --provider anthropic "review the current changes"
+```
+
+See the [configuration model](configuration-model-zh.md) for configuration
+precedence and trust boundaries, and [`wuu exec`](exec.md) for all automation
+options.
+
+## Work in the right repository
+
+The workspace is the boundary for file tools, commands, and visible sessions.
+
+- In the desktop app, open or select the local project folder before starting a
+  conversation.
+- In the CLI, run wuu from the repository or pass `--workdir` explicitly.
+
+```bash
+cd path/to/project
+wuu exec "run the tests and fix the failure"
+
+wuu exec --workdir path/to/project "summarize this codebase"
+```
+
+Describe the outcome you want. Include constraints that affect product behavior,
+security, compatibility, or data. wuu can inspect the repository to decide routine
+implementation details.
+
+## Attach files and images
+
+The desktop composer accepts attachments. In the CLI, pass them explicitly:
+
+```bash
+wuu exec --file report.pdf "summarize this report"
+wuu exec --image screenshot.png "find the visual issue"
+```
+
+An attachment gives the current task access to that file; it does not add the file
+to the repository automatically.
+
+## Continue and inspect sessions
+
+wuu stores persistent sessions so work can continue across runs:
+
+```bash
+wuu exec --continue "continue from the last session"
+wuu exec --resume THREAD_ID "continue this task"
+wuu session list
+wuu session show --last
+```
+
+Use `--ephemeral` when an automated run should not create a persistent session.
+Use `wuu session archive` to hide a session from normal lists and
+`wuu session delete` only when its stored history should be removed.
+
+## Understand the trust boundary
+
+- wuu works on local files and can run local commands according to the active
+  permission mode.
+- Prompts and relevant context are sent to the configured model provider. BYOK
+  does not mean the model runs locally.
+- API keys should come from the desktop provider settings or environment
+  variables. Do not commit keys to a repository.
+- Normal startup keeps provider endpoints, credentials, memory paths, and
+  permission mode under user control; project config cannot silently replace
+  them.
+- User config, sessions, logs, and other state live under `~/.wuu` by default.
+  Set `WUU_HOME` to move that state as one unit.
+
+Read the [security model](security-model.md) before using wuu with untrusted
+repositories or sensitive data.
+
+## Common problems
+
+### `wuu: command not found`
+
+Ensure Go's binary directory is on `PATH`:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
+Add the equivalent line to your shell profile if it fixes the problem.
+
+### The provider reports a missing API key
+
+Confirm that the configured `api_key_env` name matches the variable you exported,
+then start wuu from an environment that can see it. For the desktop app, enter the
+key in **Settings → Providers** instead of relying on a terminal-only export.
+
+### The wrong repository or sessions appear
+
+Check the selected desktop workspace, the current terminal directory, or the
+`--workdir` value. Session lists are scoped to a workspace by default.
+
+### `wuu init` says the config already exists
+
+Edit the existing config instead of overwriting it. `wuu init --force` replaces
+the file and should only be used after saving anything you need from it.
+
+### macOS refuses to open the desktop app
+
+Confirm that the app came from the official GitHub Releases page, then use the
+quarantine command in the installation section. The current preview is not signed
+or notarized.


### PR DESCRIPTION
## Summary

- add English and Chinese user guides for the stable daily workflow
- cover installation, provider setup, workspaces, attachments, sessions, trust boundaries, and common setup problems
- link the guides from the documentation index and both root READMEs

## Validation

- checked local links across 26 primary Markdown files; no broken links
- matched documented CLI flags and commands against the current command implementation
- ran `git diff --check`