### PR TITLE
fix(desktop): restore jump-to-latest label

### DIFF
--- a/desktop/src/renderer/JumpToLatestPill.test.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.test.tsx
@@ -198,6 +198,10 @@ describe("JumpToLatestPill", () => {
     const pill = host.querySelector<HTMLButtonElement>(".jump-to-latest-pill");
     expect(pill).not.toBeNull();
     expect(pill?.className).toContain("jump-to-latest-pill-sticky-centered");
+    expect(pill?.querySelector("span")?.textContent).toBeTruthy();
+    expect(pill?.querySelector("span")?.textContent).toBe(
+      pill?.getAttribute("aria-label"),
+    );
   });
 
   it("shows immediately when mounted into an already scrolled-away container", () => {
@@ -340,6 +344,10 @@ describe("JumpToLatestPill", () => {
       ".jump-to-latest-pill-anchored",
     );
     expect(pill).not.toBeNull();
+    expect(pill?.querySelector("span")?.textContent).toBeTruthy();
+    expect(pill?.querySelector("span")?.textContent).toBe(
+      pill?.getAttribute("aria-label"),
+    );
     // left = container.left + container.width / 2 = 100 + 300
     expect(pill?.style.left).toBe("400px");
     // Expanded composers move their frame above the outer footer. Position

--- a/desktop/src/renderer/JumpToLatestPill.tsx
+++ b/desktop/src/renderer/JumpToLatestPill.tsx
@@ -284,7 +284,7 @@ export function JumpToLatestPill({
           strokeLinejoin="round"
         />
       </svg>
-      <span>{label}</span>
+      <span>{accessibleLabel}</span>
     </>
   );
 
@@ -296,7 +296,7 @@ export function JumpToLatestPill({
       <button
         type="button"
         className="jump-to-latest-pill jump-to-latest-pill-anchored"
-        aria-label={label}
+        aria-label={accessibleLabel}
         style={{
           left: `${position.left}px`,
           bottom: `${position.bottom}px`,


### PR DESCRIPTION
## Summary
- restore the localized visible label on the jump-to-latest button
- use the same localized label for the anchored button accessible name
- cover both sticky and anchored variants with regression assertions

## Testing
- `cd desktop && npm run test:unit -- src/renderer/JumpToLatestPill.test.tsx`
- `cd desktop && npm run typecheck`
- verified in the running desktop app that the button shows “跳到最新”, remains centered, and keeps the 12px composer gap