### PR TITLE
test(desktop): make paired-at assertion timezone-independent

### DIFF
--- a/desktop/src/renderer/SettingsRemotePage.test.tsx
+++ b/desktop/src/renderer/SettingsRemotePage.test.tsx
@@ -152,7 +152,14 @@ describe("SettingsRemotePage devices", () => {
       })
     );
     expect(container!.textContent).toContain("我的手机");
-    expect(container!.textContent).toContain("2579e6ff1255 · 配对于 2026年7月7日");
+    // Format the fixture instant the same way the page does so the expected
+    // date follows the runtime timezone instead of hard-coding one zone's day.
+    const pairedAt = new Intl.DateTimeFormat("zh-CN", {
+      year: "numeric",
+      month: "short",
+      day: "numeric"
+    }).format(new Date("2026-07-07T00:00:00Z"));
+    expect(container!.textContent).toContain(`2579e6ff1255 · 配对于 ${pairedAt}`);
     expect(container!.textContent).toContain("未命名设备");
     expect(container!.textContent).toContain("not-a-date");
     const revoke = [...container!.querySelectorAll<HTMLButtonElement>("button")].filter(


### PR DESCRIPTION
## Summary

Fix the one timezone-dependent assertion in the desktop unit suite: `SettingsRemotePage.test.tsx` hard-coded the rendered pairing date as `2026年7月7日`, which only holds for the fixture instant `2026-07-07T00:00:00Z` in timezones at or east of UTC. In zones west of UTC (e.g. America/Los_Angeles) the page renders `7月6日` and `npm run test:unit` fails. CI passes only because GitHub runners are UTC.

## Changes

- Compute the expected date in the test through the same `Intl.DateTimeFormat("zh-CN", { year, month: "short", day })` path the page uses, so the expectation follows the runtime timezone instead of pinning one zone's calendar day. The rest of the assertion (fingerprint · 配对于 template and the `not-a-date` fallback) is unchanged.

## Test plan

- [x] Added or updated unit tests for the change
- [ ] `go test ./...` — not run; no Go changes
- [x] `cd desktop && npm run typecheck` passes
- [x] `npx vitest run src/renderer/SettingsRemotePage.test.tsx` passes under TZ=UTC, America/Los_Angeles, Asia/Shanghai, and Pacific/Kiritimati (UTC+14)
- [ ] Manually verified the behavior in the desktop shell — n/a, test-only change

## Risk and rollback

- Risk level: low. Test-only; no product code touched.
- Roll back by reverting the commit.

## Linked issues / docs

Found while verifying the PR #70 merge in a UTC-7 environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)