### PR TITLE
fix(desktop): show session-bound runtime model

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -240,6 +240,10 @@ import {
   ConversationTitleContent,
   SettingsShellRenderer,
 } from "./ConversationShellRenderers";
+import {
+  runtimeViewForConversation,
+  runtimeViewForSession,
+} from "./SessionRuntimeState";
 export { SIDEBAR_DRAWER_HOVER_OPEN_DELAY_MS } from "./SidebarDrawerState";
 
 const ENVIRONMENT_PANEL_MOTION_MS = motionDurationMs(
@@ -1038,25 +1042,13 @@ export function App(): JSX.Element {
   // turns, so this misses live reply-count growth — acceptable until a
   // subthread-scoped notification lands; opening a reply bumps the nonce.)
   const activeThreadTurnCount = activeThread?.turns?.length ?? 0;
-  const composerInitialized = useMemo(
-    () => {
-      const initialized = state.initialized;
-      return initialized && activeThread
-        ? {
-            ...initialized,
-            provider: activeThread.model_provider,
-            model: activeThread.model,
-            variant: activeThread.model_variant ?? initialized.variant,
-            effort: activeThread.model_effort ?? initialized.effort,
-            permissions: {
-              ...initialized.permissions,
-              mode:
-                activeThread.permission_mode || initialized.permissions?.mode,
-            },
-          }
-        : initialized;
-    },
+  const sessionRuntime = useMemo(
+    () => runtimeViewForSession(state.initialized, activeThread),
     [state.initialized, activeThread],
+  );
+  const visibleConversationRuntime = useMemo(
+    () => runtimeViewForConversation(state.initialized, activeThread, activeTurn),
+    [state.initialized, activeThread, activeTurn],
   );
   // Per-thread keep-alive for the main conversation pane. We keep the active
   // thread and a small recency buffer mounted so switching back does not
@@ -2680,8 +2672,7 @@ export function App(): JSX.Element {
             : streamStatus?.liveProgress
         }
         readOnly={activeThreadReadOnly}
-        activeTurn={activeTurn}
-        initialized={composerInitialized}
+        initialized={visibleConversationRuntime}
         gitStatus={state.gitStatus}
         projects={state.projects}
         activeContext={state.activeContext}
@@ -4052,7 +4043,7 @@ export function App(): JSX.Element {
       <>
         {archiveTipNode}
         <SettingsShellRenderer
-          initialized={composerInitialized}
+          initialized={sessionRuntime}
           initialPage={settingsInitialPage}
           memoryFocusParticipantID={settingsMemoryFocusID}
           running={viewContextSwitchPending}
@@ -4417,7 +4408,7 @@ export function App(): JSX.Element {
           subthreadComposer={{
             draft: subthreadComposerDraft,
             setDraft: setSubthreadComposerDraft,
-            initialized: composerInitialized,
+            initialized: sessionRuntime,
             projects: state.projects,
             activeContext: state.activeContext,
             activeProject,

--- a/desktop/src/renderer/AppSessionSwitchLatency.test.tsx
+++ b/desktop/src/renderer/AppSessionSwitchLatency.test.tsx
@@ -77,12 +77,13 @@ function deferred<T>(): Deferred<T> {
 function initialized(): InitializeResult {
   return {
     protocol_version: "wuu-app-server/v0.1",
-    provider: "fake",
-    model: "fake-model",
+    provider: "provider-b",
+    model: "model-b",
     workspace_root: workspace,
     permissions: { mode: "standard" },
     providers: [
-      { name: "fake", type: "openai-compatible", model: "fake-model" },
+      { name: "provider-a", type: "openai-compatible", model: "model-a" },
+      { name: "provider-b", type: "openai-compatible", model: "model-b" },
     ],
     advanced_settings: {
       max_steps: 64,
@@ -98,17 +99,21 @@ function completedThread({
   preview,
   updatedAt,
   turns = 1,
+  provider,
+  model,
 }: {
   id: string;
   preview: string;
   updatedAt: string;
   turns?: number;
+  provider: string;
+  model: string;
 }): Thread {
   return {
     id,
     preview,
-    model_provider: "fake",
-    model: "fake-model",
+    model_provider: provider,
+    model,
     cwd: workspace,
     status: "idle",
     created_at: "2026-01-01T00:00:00Z",
@@ -139,6 +144,8 @@ function threadA(turns = 1): Thread {
     preview: "session switch A",
     updatedAt: "2026-01-02T00:00:00Z",
     turns,
+    provider: "provider-a",
+    model: "model-a",
   });
 }
 
@@ -147,6 +154,8 @@ function threadB(): Thread {
     id: threadBID,
     preview: "session switch B",
     updatedAt: "2026-01-01T00:00:00Z",
+    provider: "provider-b",
+    model: "model-b",
   });
 }
 
@@ -257,6 +266,24 @@ function activeThreadProbe(): HTMLElement | null {
   return container.querySelector('[data-testid="turn-list-probe"]');
 }
 
+function visibleRuntimeModel(): string {
+  return (
+    container.querySelector<HTMLButtonElement>(".codex-runtime-trigger")
+      ?.textContent ?? ""
+  );
+}
+
+function emitNotification(method: string, params: Record<string, unknown>): void {
+  const event = {
+    kind: "notification",
+    workdir: workspace,
+    message: { method, params },
+  } as ServerEvent;
+  for (const handler of serverEventHandlers) {
+    handler(event);
+  }
+}
+
 describe("session tab switch latency", () => {
   beforeEach(() => {
     installWindowStubs();
@@ -288,6 +315,7 @@ describe("session tab switch latency", () => {
     expect(resumeThread).toHaveBeenCalledWith(threadAID);
     expect(activeSessionTabLabel()).toContain("session switch A");
     expect(activeThreadProbe()?.dataset.threadId).toBe(threadAID);
+    expect(visibleRuntimeModel()).toContain("model-a");
 
     const rowB = threadRowButton("session switch B");
     expect(rowB).toBeDefined();
@@ -298,6 +326,7 @@ describe("session tab switch latency", () => {
 
     expect(activeSessionTabLabel()).toContain("session switch B");
     expect(activeThreadProbe()?.dataset.threadId).toBe(threadBID);
+    expect(visibleRuntimeModel()).toContain("model-b");
 
     const delayedResumeA = deferred<{ thread: Thread }>();
     resumeThread.mockClear();
@@ -319,6 +348,7 @@ describe("session tab switch latency", () => {
     expect(activeSessionTabLabel()).toContain("session switch A");
     expect(activeThreadProbe()?.dataset.threadId).toBe(threadAID);
     expect(activeThreadProbe()?.dataset.turnCount).toBe("1");
+    expect(visibleRuntimeModel()).toContain("model-a");
 
     delayedResumeA.resolve({ thread: threadA(2) });
     await flushAsync();
@@ -326,5 +356,43 @@ describe("session tab switch latency", () => {
     expect(activeSessionTabLabel()).toContain("session switch A");
     expect(activeThreadProbe()?.dataset.threadId).toBe(threadAID);
     expect(activeThreadProbe()?.dataset.turnCount).toBe("2");
+  });
+
+  it("shows the admitted model during a turn and the session pin after it settles", async () => {
+    installWuuApi();
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+    await flushAsync();
+
+    expect(visibleRuntimeModel()).toContain("model-a");
+
+    const runningTurn = {
+      id: "thread-switch-a-running-turn",
+      model_provider: "turn-provider",
+      model: "turn-model",
+      items_view: "full",
+      status: "in_progress",
+      items: [],
+    };
+    await act(async () => {
+      emitNotification("turn/started", {
+        thread_id: threadAID,
+        turn: runningTurn,
+      });
+    });
+
+    expect(visibleRuntimeModel()).toContain("turn-model");
+
+    await act(async () => {
+      emitNotification("turn/completed", {
+        thread_id: threadAID,
+        turn: { ...runningTurn, status: "completed" },
+      });
+    });
+
+    expect(visibleRuntimeModel()).toContain("model-a");
   });
 });

--- a/desktop/src/renderer/ComposerRuntimeMenus.tsx
+++ b/desktop/src/renderer/ComposerRuntimeMenus.tsx
@@ -25,8 +25,7 @@ import type {
   PermissionSummary,
   ProviderModelSummary,
   ProviderSummary,
-  RuntimeContext,
-  Turn
+  RuntimeContext
 } from "../shared/protocol";
 import { FloatingMenuPortal, isInsideFloatingMenu } from "./ComposerFloatingMenu";
 import type {
@@ -114,7 +113,6 @@ export function permissionModeOption(mode: PermissionModeState): Omit<Permission
 export function RuntimePicker({
   variant,
   initialized,
-  activeTurn,
   state,
   openMenu,
   anchorRef,
@@ -125,7 +123,6 @@ export function RuntimePicker({
 }: {
   variant: ComposerVariant;
   initialized: InitializeResult;
-  activeTurn?: Pick<Turn, "model_provider" | "model">;
   state: CodexModelLoadState;
   openMenu: CodexRuntimeMenu;
   anchorRef: RefObject<HTMLDivElement | null>;
@@ -134,18 +131,17 @@ export function RuntimePicker({
   onSelectModel: (provider: string, model: string, variant?: string) => void;
   onSelectEffort: (variant: string) => void;
 }): JSX.Element {
-  const runtimeInitialized = initializedForActiveTurn(initialized, activeTurn);
-  const currentProvider = runtimeInitialized.providers?.find((provider) => provider.name === runtimeInitialized.provider);
-  const codexProvider = isCodexProvider(runtimeInitialized);
-  const currentCodexModel = codexProvider ? state.models.find((model) => model.slug === runtimeInitialized.model) : undefined;
-  const currentProviderModel = currentProvider?.models?.find((model) => model.id === runtimeInitialized.model);
-  const currentVariant = runtimeInitialized.variant ?? runtimeInitialized.effort ?? "";
+  const currentProvider = initialized.providers?.find((provider) => provider.name === initialized.provider);
+  const codexProvider = isCodexProvider(initialized);
+  const currentCodexModel = codexProvider ? state.models.find((model) => model.slug === initialized.model) : undefined;
+  const currentProviderModel = currentProvider?.models?.find((model) => model.id === initialized.model);
+  const currentVariant = initialized.variant ?? initialized.effort ?? "";
   const variantOptions = codexProvider
     ? codexEffortOptions(currentCodexModel, currentVariant)
-    : providerModelVariantOptions(currentProvider, runtimeInitialized.model, currentVariant);
+    : providerModelVariantOptions(currentProvider, initialized.model, currentVariant);
   const reasoningMode = codexProvider
     ? "levels"
-    : providerModelReasoningMode(currentProvider, runtimeInitialized.model);
+    : providerModelReasoningMode(currentProvider, initialized.model);
   const placement: FloatingMenuPlacement = variant === "hero" ? "below" : "above";
   return (
     <div className="codex-runtime-anchor" ref={anchorRef}>
@@ -157,7 +153,7 @@ export function RuntimePicker({
         aria-expanded={openMenu !== null}
         onClick={() => onToggleMenu("main")}
       >
-        <span>{runtimeTriggerLabel(runtimeInitialized, currentProviderModel, currentCodexModel)}</span>
+        <span>{runtimeTriggerLabel(initialized, currentProviderModel, currentCodexModel)}</span>
         <span className="codex-runtime-effort">{variantLabel(currentVariant)}</span>
         <ChevronDown className="icon" />
       </button>
@@ -173,7 +169,7 @@ export function RuntimePicker({
             selectedVariant={currentVariant}
             options={variantOptions}
             reasoningMode={reasoningMode}
-            currentLabel={runtimeModelLabel(runtimeInitialized, currentProviderModel, currentCodexModel)}
+            currentLabel={runtimeModelLabel(initialized, currentProviderModel, currentCodexModel)}
             onOpenEffortMenu={() => onToggleMenu("effort")}
             onOpenModelMenu={() => onToggleMenu("model")}
           />
@@ -203,10 +199,10 @@ export function RuntimePicker({
           width={286}
         >
           <RuntimeModelMenu
-            initialized={runtimeInitialized}
+            initialized={initialized}
             state={state}
-            selectedProvider={runtimeInitialized.provider}
-            selectedModel={runtimeInitialized.model}
+            selectedProvider={initialized.provider}
+            selectedModel={initialized.model}
             selectedVariant={currentVariant}
             onSelectModel={onSelectModel}
           />
@@ -214,20 +210,6 @@ export function RuntimePicker({
       ) : null}
     </div>
   );
-}
-
-function initializedForActiveTurn(
-  initialized: InitializeResult,
-  activeTurn?: Pick<Turn, "model_provider" | "model">
-): InitializeResult {
-  if (!activeTurn?.model_provider || !activeTurn.model) {
-    return initialized;
-  }
-  return {
-    ...initialized,
-    provider: activeTurn.model_provider,
-    model: activeTurn.model
-  };
 }
 
 function RuntimeMainMenu({

--- a/desktop/src/renderer/ComposerView.test.tsx
+++ b/desktop/src/renderer/ComposerView.test.tsx
@@ -21,7 +21,6 @@ import type {
   PermissionSummary,
   RuntimeContext,
   SkillSummary,
-  Turn,
   WuuDesktopApi,
 } from "../shared/protocol";
 
@@ -94,7 +93,6 @@ function renderComposer(props: {
   statusLiveProgress?: boolean;
   runtimeControlsDisabled?: boolean;
   initialized?: InitializeResult;
-  activeTurn?: Pick<Turn, "model_provider" | "model">;
   readOnly?: boolean;
   onInterrupt?: () => void;
   onSend?: () => void;
@@ -148,7 +146,6 @@ function renderComposer(props: {
           ultraEnabled={props.ultraEnabled}
           onToggleUltra={props.onToggleUltra}
           runtimeControlsDisabled={props.runtimeControlsDisabled}
-          activeTurn={props.activeTurn}
           status={props.status ?? "ready"}
           statusLiveProgress={props.statusLiveProgress}
           readOnly={props.readOnly ?? false}
@@ -921,19 +918,18 @@ describe("Composer send control", () => {
     expect(sendButton?.disabled).toBe(false);
   });
 
-  it("shows the active turn model instead of the later global default", () => {
-    const globalDefault = initialized();
-    globalDefault.provider = "provider-b";
-    globalDefault.model = "model-b";
-    globalDefault.providers = [
+  it("renders the conversation runtime selected by the app", () => {
+    const runtime = initialized();
+    runtime.provider = "provider-a";
+    runtime.model = "model-a";
+    runtime.providers = [
       { name: "provider-a", type: "openai-compatible", model: "model-a" },
       { name: "provider-b", type: "openai-compatible", model: "model-b" }
     ];
 
     renderComposer({
       variant: "dock",
-      initialized: globalDefault,
-      activeTurn: { model_provider: "provider-a", model: "model-a" },
+      initialized: runtime,
       runtimeControlsDisabled: true
     });
 
@@ -942,18 +938,18 @@ describe("Composer send control", () => {
     expect(runtimeButton?.disabled).toBe(true);
   });
 
-  it("falls back to the global default once the active turn snapshot is gone", () => {
-    const globalDefault = initialized();
-    globalDefault.provider = "provider-b";
-    globalDefault.model = "model-b";
-    globalDefault.providers = [
+  it("renders the next-turn session runtime when controls unlock", () => {
+    const runtime = initialized();
+    runtime.provider = "provider-b";
+    runtime.model = "model-b";
+    runtime.providers = [
       { name: "provider-a", type: "openai-compatible", model: "model-a" },
       { name: "provider-b", type: "openai-compatible", model: "model-b" }
     ];
 
     renderComposer({
       variant: "dock",
-      initialized: globalDefault,
+      initialized: runtime,
       runtimeControlsDisabled: false
     });
 

--- a/desktop/src/renderer/ComposerView.tsx
+++ b/desktop/src/renderer/ComposerView.tsx
@@ -53,8 +53,7 @@ import type {
   ParticipantProfile,
   ParticipantSummary,
   RuntimeContext,
-  SkillSummary,
-  Turn
+  SkillSummary
 } from "../shared/protocol";
 import {
   buildComposerSlashCommands,
@@ -137,7 +136,6 @@ export function Composer({
   running,
   ultraEnabled = false,
   runtimeControlsDisabled = running,
-  activeTurn,
   status,
   statusLiveProgress,
   readOnly,
@@ -220,7 +218,6 @@ export function Composer({
   running: boolean;
   ultraEnabled?: boolean;
   runtimeControlsDisabled?: boolean;
-  activeTurn?: Pick<Turn, "model_provider" | "model">;
   status: string;
   statusLiveProgress?: boolean;
   readOnly: boolean;
@@ -1222,7 +1219,6 @@ export function Composer({
                       <RuntimePicker
                         variant={variant}
                         initialized={initialized}
-                        activeTurn={activeTurn}
                         state={codexModels}
                         openMenu={codexRuntimeMenu}
                         anchorRef={codexRuntimeRef}

--- a/desktop/src/renderer/RunDebugPanel.tsx
+++ b/desktop/src/renderer/RunDebugPanel.tsx
@@ -19,6 +19,7 @@ import {
   turnFromRecord,
   type AppState,
 } from "./AppState";
+import { runtimeViewForConversation } from "./SessionRuntimeState";
 import {
   streamTextKey,
   streamTextStore,
@@ -92,10 +93,11 @@ export function RunDebugPanel({
   useI18n();
   const thread = activeThreadForState(state);
   const turn = phase.turn ?? activeDebugTurn(thread);
+  const runtime = runtimeViewForConversation(state.initialized, thread, turn);
   const lastEvent = events.length > 0 ? events[events.length - 1] : undefined;
   const turnStartedAt = turn ? parseTurnTimestampMs(turn.started_at) : NaN;
-  const model = state.initialized
-    ? `${state.initialized.provider} / ${state.initialized.model}${state.initialized.variant || state.initialized.effort ? ` / ${state.initialized.variant || state.initialized.effort}` : ""}`
+  const model = runtime
+    ? `${runtime.provider} / ${runtime.model}${runtime.variant || runtime.effort ? ` / ${runtime.variant || runtime.effort}` : ""}`
     : t("runDebug.notInitialized");
   const queueDetail = [
     queuedMessages.length > 0
@@ -891,15 +893,16 @@ export function buildRunDebugSnapshot({
   const phase = runDebugPhaseForState(state);
   const thread = activeThreadForState(state);
   const turn = phase.turn ?? activeDebugTurn(thread);
+  const runtime = runtimeViewForConversation(state.initialized, thread, turn);
   const streamStats = streamTextStore.stats();
   const lines = [
     `phase: ${phase.label} (${phase.detail})`,
     `status: ${state.status}`,
     `running: ${String(state.running)}`,
-    `provider: ${state.initialized?.provider ?? "none"}`,
-    `model: ${state.initialized?.model ?? "none"}`,
-    `effort: ${state.initialized?.effort ?? ""}`,
-    `variant: ${state.initialized?.variant ?? ""}`,
+    `provider: ${runtime?.provider ?? "none"}`,
+    `model: ${runtime?.model ?? "none"}`,
+    `effort: ${runtime?.effort ?? ""}`,
+    `variant: ${runtime?.variant ?? ""}`,
     `cwd: ${state.activeContext?.cwd ?? thread?.cwd ?? ""}`,
     `thread: ${thread?.id ?? ""}`,
     `turn: ${turn?.id ?? ""}`,

--- a/desktop/src/renderer/RuntimeSettingsActions.test.ts
+++ b/desktop/src/renderer/RuntimeSettingsActions.test.ts
@@ -565,6 +565,31 @@ describe("createRuntimeSettingsActions", () => {
     expect(api.loadCodexModels).toHaveBeenCalledWith("codex");
   });
 
+  it("loads models for the active session instead of the workspace default", () => {
+    const api = installWuuApi();
+    const primary = thread();
+    const harness = buildActions({
+      initial: {
+        ...initialState,
+        initialized: initialized({
+          provider: "anthropic",
+          model: "claude-sonnet",
+          providers: [
+            { name: "anthropic", type: "anthropic", model: "claude-sonnet" },
+            { name: "codex", type: "chatgpt-codex", model: "gpt-5" },
+          ],
+        }),
+        thread: primary,
+        threads: [primary],
+        status: "ready",
+      },
+    });
+
+    harness.actions.toggleCodexRuntimeMenu("model");
+
+    expect(api.loadCodexModels).toHaveBeenCalledWith("codex");
+  });
+
   it("persists permission mode for the active thread and future threads", async () => {
     const api = installWuuApi();
     const harness = buildActions();

--- a/desktop/src/renderer/RuntimeSettingsActions.ts
+++ b/desktop/src/renderer/RuntimeSettingsActions.ts
@@ -18,6 +18,7 @@ import type {
   PermissionMode,
 } from "./ComposerTypes";
 import { isCodexProvider } from "./RuntimeHelpers";
+import { runtimeViewForSession } from "./SessionRuntimeState";
 import { translateCurrent } from "./i18n";
 
 type SetAppState = (update: SetStateAction<AppState>) => void;
@@ -427,8 +428,12 @@ export function createRuntimeSettingsActions(
     deps.setAccessMenuOpen(false);
     deps.setBranchMenuOpen(false);
     deps.setCodexRuntimeMenu((current) => (current === menu ? null : menu));
-    if (isCodexProvider(state.initialized)) {
-      void loadCodexModelsForProvider(state.initialized.provider);
+    const runtime = runtimeViewForSession(
+      state.initialized,
+      activeThreadForState(state),
+    );
+    if (runtime && isCodexProvider(runtime)) {
+      void loadCodexModelsForProvider(runtime.provider);
     }
   }
 

--- a/desktop/src/renderer/SessionRuntimeState.test.ts
+++ b/desktop/src/renderer/SessionRuntimeState.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { InitializeResult, Thread, Turn } from "../shared/protocol";
+import {
+  runtimeViewForConversation,
+  runtimeViewForSession,
+} from "./SessionRuntimeState";
+
+function workspaceDefaults(): InitializeResult {
+  return {
+    protocol_version: "wuu-app-server/v0.1",
+    provider: "workspace-provider",
+    model: "workspace-model",
+    variant: "medium",
+    workspace_root: "/tmp/project",
+    permissions: { mode: "standard" },
+  };
+}
+
+function session(): Thread {
+  return {
+    id: "session-a",
+    preview: "session A",
+    model_provider: "session-provider",
+    model: "session-model",
+    model_variant: "high",
+    model_effort: "",
+    permission_mode: "read_only",
+    cwd: "/tmp/project",
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    turns: [],
+  };
+}
+
+function turn(status: Turn["status"]): Turn {
+  return {
+    id: "turn-a",
+    status,
+    model_provider: "turn-provider",
+    model: "turn-model",
+    items_view: "full",
+    items: [],
+  };
+}
+
+describe("session runtime state", () => {
+  it("uses the session pin for the next turn instead of workspace defaults", () => {
+    expect(runtimeViewForSession(workspaceDefaults(), session())).toMatchObject({
+      provider: "session-provider",
+      model: "session-model",
+      variant: "high",
+      effort: "",
+      permissions: { mode: "read_only" },
+    });
+  });
+
+  it("shows the admitted turn model while it is running", () => {
+    expect(
+      runtimeViewForConversation(workspaceDefaults(), session(), turn("in_progress")),
+    ).toMatchObject({
+      provider: "turn-provider",
+      model: "turn-model",
+      variant: "high",
+    });
+  });
+
+  it("returns to the session pin as soon as the turn settles", () => {
+    expect(
+      runtimeViewForConversation(workspaceDefaults(), session(), turn("completed")),
+    ).toMatchObject({
+      provider: "session-provider",
+      model: "session-model",
+      variant: "high",
+    });
+  });
+});

--- a/desktop/src/renderer/SessionRuntimeState.ts
+++ b/desktop/src/renderer/SessionRuntimeState.ts
@@ -1,0 +1,42 @@
+import type { InitializeResult, Thread, Turn } from "../shared/protocol";
+
+// InitializeResult describes workspace defaults. Existing conversations carry
+// their persisted selection on Thread, while an in-progress Turn records what
+// is actually executing. Centralize that priority so every model-facing UI
+// tells the same story: running turn -> next turn in this session -> default
+// for a session that has not been created yet.
+export function runtimeViewForSession(
+  initialized: InitializeResult | undefined,
+  thread: Thread | undefined,
+): InitializeResult | undefined {
+  if (!initialized || !thread) {
+    return initialized;
+  }
+  return {
+    ...initialized,
+    provider: thread.model_provider || initialized.provider,
+    model: thread.model || initialized.model,
+    variant: thread.model_variant ?? initialized.variant,
+    effort: thread.model_effort ?? initialized.effort,
+    permissions: {
+      ...initialized.permissions,
+      mode: thread.permission_mode || initialized.permissions?.mode,
+    },
+  };
+}
+
+export function runtimeViewForConversation(
+  initialized: InitializeResult | undefined,
+  thread: Thread | undefined,
+  turn: Pick<Turn, "status" | "model_provider" | "model"> | undefined,
+): InitializeResult | undefined {
+  const session = runtimeViewForSession(initialized, thread);
+  if (!session || turn?.status !== "in_progress") {
+    return session;
+  }
+  return {
+    ...session,
+    provider: turn.model_provider || session.provider,
+    model: turn.model || session.model,
+  };
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -61,12 +61,11 @@ export type InitializeResult = {
   max_parallel?: number;
   workspace_root: string;
   permissions?: PermissionSummary;
-  // model_profile + tool_surface summarise the per-model tool
-  // surface the runtime compiled for the active session. The
-  // renderer uses these to drive capability-first activity and the
-  // debug surface view; the runtime side owns the values so the UI never
-  // has to re-derive the
-  // bash-first / patch-first split.
+  // model_profile + tool_surface summarise the workspace-default runtime.
+  // Existing sessions expose their persisted provider/model selection on
+  // Thread, and an in-progress Turn exposes the admitted provider/model. A
+  // shell must not present InitializeResult.provider/model as the active
+  // session after those selections diverge.
   model_profile?: ModelProfileSummary;
   tool_surface?: ToolSurfaceSummary;
   extension_trust?: ExtensionTrustSummary;


### PR DESCRIPTION
## Product behavior

- While a turn is running, the model picker displays the provider/model admitted for that turn.
- Once the turn settles, it returns to the current session pinned provider/model—the destination of the next query.
- Workspace defaults are used only when there is no existing session, so changing one session no longer changes the model shown for other sessions.
- Codex model options load from the active session provider instead of the workspace default provider.

## Implementation

- Centralize renderer runtime selection with one priority: in-progress turn, current session pin, workspace default.
- Route the composer, settings, subthread composer, and debug panel through that state.
- Clarify protocol ownership for workspace, session, and turn runtime fields.
- Add regressions for different session pins, running-turn admission, turn completion, and provider-specific model loading.

## Validation

- npm run typecheck
- 8 focused test files: 124 tests passed
- npm run test:unit: 183 files, 2081 tests passed
- npm run test:perf: passed
- npm run build: passed
- git diff --check: clean