### PR TITLE
fix(desktop): 去掉 turn 内用户提问与助手回复之间的通栏分割线

### DIFF
--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,0 +1,1 @@
+/Users/blueberrycongee/blueberrycongee/wuu/desktop/node_modules

--- a/desktop/src/renderer/AssistantTurnShell.test.tsx
+++ b/desktop/src/renderer/AssistantTurnShell.test.tsx
@@ -1247,13 +1247,19 @@ describe("AssistantTurnShell — answer region (rule 1 + rule 8)", () => {
 });
 
 describe("AssistantTurnShell — turn divider styles", () => {
-  it("keeps the user query and assistant reply separated even in the first turn", () => {
-    expect(cssRule(".turn > .assistant-turn-shell")).toContain(
-      "border-top: 1px solid var(--wuu-hairline);",
-    );
-    expect(turnsCSS).not.toMatch(
-      /\.turn:first-(?:of-type|child)\s*>\s*\.assistant-turn-shell/,
-    );
+  it("separates the user query and assistant reply with whitespace, not a rule", () => {
+    const shellRule = cssRule(".turn > .assistant-turn-shell");
+    // The full-width hairline that used to split every Q&A pair is gone —
+    // turn-to-turn separation already owns the single visible boundary
+    // (the 32px --conversation-turn-boundary-gap band on .turn).
+    expect(shellRule).not.toContain("border-top");
+    expect(shellRule).not.toContain("var(--wuu-hairline)");
+    // Separation survives as whitespace: the shell still carries the
+    // query -> reply gap so the reply doesn't collide with the query.
+    expect(shellRule).toContain("var(--conversation-user-rule-gap)");
+    // And it must not have collapsed onto the old rule-process padding,
+    // which would have pushed the pair's gap past the 32px turn boundary.
+    expect(shellRule).not.toContain("padding-top");
   });
 
   it("shares the live gray sweep across process rows, reasoning labels, previews, and compaction", () => {

--- a/desktop/src/renderer/styles/conversation-shell.css
+++ b/desktop/src/renderer/styles/conversation-shell.css
@@ -144,9 +144,12 @@
   /*
    * Grouping rhythm: tight within a group, loose between groups.
    * One spacing ladder, one value per meaning. These landmarks match
-   * the visible message flow from top to bottom: user query -> rule,
-   * rule -> process header, process header -> expanded details,
+   * the visible message flow from top to bottom: user query -> assistant
+   * reply (whitespace only, no rule), process header -> expanded details,
    * process cluster -> final answer, final answer -> action row.
+   * `--conversation-user-rule-gap` keeps its name for the query -> reply
+   * gap (there is no longer a hairline rule; the 24px band stays under the
+   * 32px turn boundary so a Q&A pair reads as one group).
    */
   --conversation-user-rule-gap: 24px;
   --conversation-user-message-trailing-gap: 8px;

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -198,17 +198,15 @@
   font-weight: var(--weight-semibold);
 }
 
-                                                                
-                                                             
-                                                                  
-                                                                
-                                                             
-                                                                
-                                                          
-                
 .turn > .assistant-turn-shell {
-  border-top: 1px solid var(--wuu-hairline);
-  padding-top: var(--conversation-rule-process-gap);
+  /*
+   * User query → assistant reply is separated by whitespace alone — no
+   * hairline. Turn-to-turn separation already owns the single visible
+   * boundary (the 32px --conversation-turn-boundary-gap band on .turn), so a
+   * full-width rule inside a turn duplicated that meaning while splitting one
+   * Q&A pair in two. The gap holds at 24px (--conversation-user-rule-gap),
+   * tighter than the 32px turn boundary: tight within a group, loose between.
+   */
   margin-top: calc(
     var(--conversation-user-rule-gap) - var(--conversation-turn-item-gap) -
       var(--conversation-user-message-trailing-gap)
@@ -764,8 +762,8 @@
 }
 
 /* Hover actions live outside the flow but below the query bubble. The
- * 2px padding is the hover bridge; the 20px controls leave 2px before
- * the divider while staying inside the 24px query -> rule gap. */
+ * 2px padding is the hover bridge; the 20px controls stay inside the 24px
+ * query -> reply gap (--conversation-user-rule-gap). */
 .user-message-block-with-actions {
   position: relative;
 }

--- a/desktop/src/renderer/styles/turns.test.ts
+++ b/desktop/src/renderer/styles/turns.test.ts
@@ -180,8 +180,10 @@ describe("turns.css message-flow typography", () => {
     expect(lastCssRuleBody(".turn > .assistant-turn-shell")).toMatch(
       /margin-top:\s*calc\(\s*var\(--conversation-user-rule-gap\)\s*-\s*var\(--conversation-turn-item-gap\)\s*-\s*var\(--conversation-user-message-trailing-gap\)\s*\);/,
     );
-    expect(lastCssRuleBody(".turn > .assistant-turn-shell")).toMatch(
-      /padding-top:\s*var\(--conversation-rule-process-gap\);/,
+    // The query -> reply gap is whitespace only now; the old
+    // rule-process padding-top went away with the hairline divider.
+    expect(lastCssRuleBody(".turn > .assistant-turn-shell")).not.toMatch(
+      /padding-top:/,
     );
     expect(lastCssRuleBody(".user-message-block")).toMatch(
       /margin-bottom:\s*var\(--conversation-user-message-trailing-gap\);/,


### PR DESCRIPTION
## 背景

对话流里,每个 turn 都会在用户提问和助手回复之间画一整条通栏 hairline 分割线(`.turn > .assistant-turn-shell` 的 `border-top: 1px solid var(--wuu-hairline)`)。用一条通栏实线来做 turn *内部* 的区隔并不好:

- **语义重复**。turn 与 turn 之间的边界本就由 32px 留白带 `--conversation-turn-boundary-gap` 独立承担(`.turn` 的 `margin-bottom`,源码注释即写着 "Turn-to-turn separation is the single deliberate boundary value")。再叠一条通栏线,是用两种手段表达同一件事。
- **通栏硬线偏重**。一条横贯整个阅读宽度的实线视觉重量太大,把本属于一对问答的 query 与 reply 割成两块,反而削弱了"同一个 turn"的整体感。

Closes #80。

## 改动

- **去掉分割线**:移除 `.turn > .assistant-turn-shell` 的 `border-top` 及其配套的 `padding-top: var(--conversation-rule-process-gap)`。
- **校准留白(关键)**:去线之后不能只删 `border-top`。原本 query→reply 的留白是 24px + 16px = 40px,靠中间那条线拆成两段,单段都没超过 32px 的 turn 边界。线一旦拿掉,40px 变成一段连续留白,**大于** 32px 的 turn 间距,分组关系会被反转 —— reply 看起来更贴向下一个 turn。因此把 query→reply 收敛成单段 24px(`--conversation-user-rule-gap`),稳稳落在 32px 边界之下,保持代码库自己的原则:"tight within a group, loose between groups"。
- 顺手清掉此处一段被历史工具剥成纯空格的注释残留,替换为解释"为何不再有分割线"的正式注释。
- 更新 `conversation-shell.css` 的间距阶梯注释,以及 `turns.css` 里引用 "divider / query -> rule" 的旧注释。
- 更新 `turns.test.ts` 与 `AssistantTurnShell.test.tsx` 的相关用例:由"断言存在分割线"改为"断言分割线已移除、区隔改由留白承担"。

> 备注:`--conversation-rule-process-gap` 变量保留 —— 它在 `chat.css` 中另有独立用途,只是不再用于本处的分隔线。`.assistant-turn-shell.missing-reply-turn` 的 `border/padding` 重置现已成为防御性无操作,故意不动以缩小改动面。

## 验证

- `vitest run`:覆盖所有读取 `turns.css` / `conversation-shell.css` 或涉及分割线的测试文件,**14 个文件 / 274 用例全绿**。
- `tsc --noEmit` 通过。
- 用真实 CSS(`base/theme/conversation-shell/chat/turns.css`)+ 真实 turn DOM 结构做 headless Chromium 截图比对:

**改动前**(通栏实线把每个 turn 切成两半):

```
┌────────────────────────────────────────┐
│                        用户的第 1 个问题 │
│ ──────────────────────────────────────  │  ← 通栏分割线
│ 已处理  3 步 · 4.2s                       │
│ 助手回答正文……                            │
└────────────────────────────────────────┘
```

**改动后**(无线,query 与 reply 仍是一组;turn 间留白更大):

```
┌────────────────────────────────────────┐
│                        用户的第 1 个问题 │
│ 已处理  3 步 · 4.2s                       │  ← 24px 留白,无线
│ 助手回答正文……                            │
└────────────────────────────────────────┘
        （32px turn 边界留白,明显更松）
┌────────────────────────────────────────┐
│                        用户的第 2 个问题 │
└────────────────────────────────────────┘
```

截图确认:分割线消失,turn 内 24px < turn 间 32px,分组关系正确。
