### PR TITLE
fix(desktop): 移除误提交的 desktop/node_modules 符号链接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 /bin/
 dist/
 node_modules/
+# Also ignore a `node_modules` symlink (worktrees sometimes link a shared
+# install): the trailing-slash rule above only matches real directories, so
+# a symlink would otherwise slip past `git add`.
+node_modules
 .vite/
 desktop/out/
 # Browser PiP E2E bundles its entry here before launching Electron.

--- a/desktop/node_modules
+++ b/desktop/node_modules
@@ -1,1 +1,0 @@
-/Users/blueberrycongee/blueberrycongee/wuu/desktop/node_modules


### PR DESCRIPTION
## 问题

#83 合入 main 时,意外把 `desktop/node_modules` 当作**符号链接**提交了进去,指向一个机器本地的绝对路径 `/Users/blueberrycongee/blueberrycongee/wuu/desktop/node_modules`(见 main 上的 commit `0d6182f2`)。这在任何其他机器/克隆上都是一条断链。

**根因**:该 worktree 用符号链接共享了一份 node_modules 来跑测试;而 `.gitignore` 里的 `node_modules/`(带尾斜杠)**只匹配真实目录**,不匹配符号链接,于是 `git add` 把它收了进去。

## 改动

- 从版本树移除 `desktop/node_modules`。
- `.gitignore` 增加一条不带斜杠的 `node_modules` 规则,使符号链接形式的安装目录今后也无法被提交。

## 验证

- `git check-ignore -v desktop/node_modules` → 命中新规则 `.gitignore:14`。
- 移除后工作区符号链接不再作为 untracked 出现,`git status` 干净。
- 纯基础设施改动(删链接 + gitignore),不触碰任何产品代码。