### PR TITLE
fix(desktop): handle browser PiP startup race

### DIFF
--- a/desktop/src/main/browserPiPWindow.test.ts
+++ b/desktop/src/main/browserPiPWindow.test.ts
@@ -57,9 +57,11 @@ class FakePipWindow {
   setAlwaysOnTop(): void {}
   setVisibleOnAllWorkspaces(): void {}
   showInactive(): void {
+    if (this.destroyed) throw new Error("Object has been destroyed");
     this.visible = true;
   }
   hide(): void {
+    if (this.destroyed) throw new Error("Object has been destroyed");
     this.visible = false;
   }
   isDestroyed(): boolean {
@@ -292,6 +294,43 @@ describe("BrowserPiPSurface", () => {
     expect(host.mounts).toHaveLength(0);
     expect(sink.gone).toBe(1);
     surface.stop();
+  });
+
+  it("waits for a starting browser tab to become mountable", () => {
+    const host = new FakeHost();
+    host.bounds = undefined;
+    const { surface, win, sink } = makeSurface({ host });
+    surface.updateActivity({ ...makeActivity(), state: "starting" });
+    surface.start();
+    surface.setVisible(true);
+
+    expect(sink.gone).toBe(0);
+    expect(win.visible).toBe(true);
+    expect(host.mounts).toHaveLength(0);
+
+    host.bounds = { x: 0, y: 0, width: 1000, height: 500 };
+    surface.updateActivity({ ...makeActivity(), state: "background_controlled" });
+    surface.setVisible(true);
+
+    expect(host.mounts).toHaveLength(1);
+    expect(sink.gone).toBe(0);
+    surface.stop();
+  });
+
+  it("does not reuse a window synchronously destroyed by a gone callback", () => {
+    const host = new FakeHost();
+    host.bounds = undefined;
+    const { surface, win, sink } = makeSurface({ host });
+    const countGone = sink.onGone.bind(sink);
+    sink.onGone = () => {
+      countGone();
+      surface.stop();
+    };
+    surface.start();
+
+    expect(() => surface.setVisible(true)).not.toThrow();
+    expect(sink.gone).toBe(1);
+    expect(win.destroyed).toBe(true);
   });
 
   it("shows the placeholder again when a takeover adopts the mounted tab", async () => {

--- a/desktop/src/main/browserPiPWindow.ts
+++ b/desktop/src/main/browserPiPWindow.ts
@@ -218,9 +218,11 @@ export class BrowserPiPSurface implements ObservationPiPHandle {
     if (!win || win.isDestroyed()) return;
     if (visible) {
       this.mount();
+      if (this.win !== win || win.isDestroyed()) return;
       win.showInactive();
     } else {
       this.unmount();
+      if (this.win !== win || win.isDestroyed()) return;
       win.hide();
     }
   }
@@ -276,7 +278,7 @@ export class BrowserPiPSurface implements ObservationPiPHandle {
     const { workdir, tabID, host } = this.deps;
     const bounds = host.tabBounds(workdir, tabID);
     if (!bounds) {
-      this.deps.sink.onGone();
+      this.reportTabGoneUnlessStarting();
       return;
     }
     this.viewport = {
@@ -292,7 +294,7 @@ export class BrowserPiPSurface implements ObservationPiPHandle {
       fit.scale,
     );
     if (!restore) {
-      this.deps.sink.onGone();
+      this.reportTabGoneUnlessStarting();
       return;
     }
     this.restoreBounds = restore;
@@ -303,6 +305,13 @@ export class BrowserPiPSurface implements ObservationPiPHandle {
       this.announced = true;
       this.deps.sink.onEvent({ event: "ready" });
     }
+  }
+
+  private reportTabGoneUnlessStarting(): void {
+    // Activity creation precedes the first browser/open_tab request. Keep the
+    // placeholder alive until the post-action update retries the mount; only a
+    // missing tab after startup means that the observed target is truly gone.
+    if (this.activity.state !== "starting") this.deps.sink.onGone();
   }
 
   private unmount(): void {


### PR DESCRIPTION
## Summary

- keep the Browser PiP placeholder alive while the first browser tab is still being created
- revalidate the BrowserWindow after mount and unmount callbacks that can synchronously stop the surface
- cover the activity-before-open-tab ordering and synchronous teardown regression

## Verification

- focused Browser PiP and observation tests: 27 passed
- full Desktop unit suite: 2086 passed
- Desktop typecheck
- Electron production build
- full Dev restart from this worktree with Browser and CUA enabled
