### PR TITLE
fix(desktop): deduplicate held composer messages

### DIFF
--- a/desktop/src/renderer/ComposerPendingMessages.test.ts
+++ b/desktop/src/renderer/ComposerPendingMessages.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Thread, ThreadItem } from "../shared/protocol";
 import type { QueuedComposerMessage } from "./ComposerMessages";
 import {
+  appendPendingComposerMessage,
+  applyHeldComposerSnapshot,
   findPendingComposerMessage,
   materializedComposerMessageIDs,
   pendingComposerMessageCount,
@@ -24,6 +26,53 @@ function threadWithItems(id: string, items: ThreadItem[]): Thread {
 }
 
 describe("composer pending messages", () => {
+  it("does not append an optimistic message whose id already exists", () => {
+    const previous = {
+      queued: [message("queue-1", "Held queue")],
+      guides: [message("guide-1", "Held guide")],
+    };
+
+    expect(
+      appendPendingComposerMessage(
+        previous,
+        "queue",
+        message("queue-1", "Late response"),
+      ),
+    ).toBe(previous);
+    expect(
+      appendPendingComposerMessage(
+        previous,
+        "queue",
+        message("guide-1", "Late cross-list response"),
+      ),
+    ).toBe(previous);
+  });
+
+  it("lets a held snapshot replace matching optimistic state across both lists", () => {
+    const heldQueue = {
+      ...message("shared-id", "Server snapshot"),
+      held: true,
+      heldPosition: 0,
+      origin: "queue" as const,
+    };
+    const previous = {
+      queued: [
+        message("shared-id", "Optimistic queue"),
+        message("queue-in-flight", "Still in flight"),
+        { ...message("stale-held", "Stale"), held: true },
+      ],
+      guides: [message("shared-id", "Optimistic guide")],
+    };
+
+    const next = applyHeldComposerSnapshot(previous, [heldQueue]);
+
+    expect(next.queued).toEqual([
+      message("queue-in-flight", "Still in flight"),
+      heldQueue,
+    ]);
+    expect(next.guides).toEqual([]);
+  });
+
   it("returns only the pending messages for the requested thread", () => {
     const byThread: PendingComposerMessagesByThread = {
       "thread-a": {

--- a/desktop/src/renderer/ComposerPendingMessages.ts
+++ b/desktop/src/renderer/ComposerPendingMessages.ts
@@ -18,6 +18,7 @@ export type LocatedPendingComposerMessage = {
 };
 
 export type PendingComposerMessageRemovalScope = "queue" | "guide" | "all";
+export type PendingComposerMessageKind = "queue" | "guide";
 
 export function emptyThreadPendingComposerMessages(): ThreadPendingComposerMessages {
   return { queued: [], guides: [] };
@@ -37,6 +38,53 @@ export function threadPendingComposerMessagesIsEmpty(
   pending: ThreadPendingComposerMessages,
 ): boolean {
   return pending.queued.length === 0 && pending.guides.length === 0;
+}
+
+/**
+ * Append an optimistic pending message without duplicating a server-confirmed
+ * entry. Queue ids identify a message across both queue and guide states, so a
+ * late IPC response must not recreate an item already supplied by a snapshot.
+ */
+export function appendPendingComposerMessage(
+  previous: ThreadPendingComposerMessages,
+  kind: PendingComposerMessageKind,
+  message: QueuedComposerMessage,
+): ThreadPendingComposerMessages {
+  if (
+    previous.queued.some((candidate) => candidate.id === message.id) ||
+    previous.guides.some((candidate) => candidate.id === message.id)
+  ) {
+    return previous;
+  }
+  return kind === "queue"
+    ? { ...previous, queued: [...previous.queued, message] }
+    : { ...previous, guides: [...previous.guides, message] };
+}
+
+/**
+ * Reconcile the authoritative held snapshot with optimistic pending state.
+ * The snapshot replaces all prior held entries and wins over a non-held entry
+ * with the same id, while unrelated in-flight optimistic messages survive.
+ */
+export function applyHeldComposerSnapshot(
+  previous: ThreadPendingComposerMessages,
+  snapshot: QueuedComposerMessage[],
+): ThreadPendingComposerMessages {
+  const snapshotIDs = new Set(snapshot.map((message) => message.id));
+  return {
+    queued: [
+      ...previous.queued.filter(
+        (message) => !message.held && !snapshotIDs.has(message.id),
+      ),
+      ...snapshot.filter((message) => message.origin === "queue"),
+    ],
+    guides: [
+      ...previous.guides.filter(
+        (message) => !message.held && !snapshotIDs.has(message.id),
+      ),
+      ...snapshot.filter((message) => message.origin === "steer"),
+    ],
+  };
 }
 
 export function removePendingComposerMessagesByID(

--- a/desktop/src/renderer/ComposerPendingState.test.tsx
+++ b/desktop/src/renderer/ComposerPendingState.test.tsx
@@ -140,6 +140,74 @@ describe("useComposerPendingState", () => {
     ).toEqual([message("queue-1", "First")]);
   });
 
+  it("deduplicates a held snapshot that arrives after the queue response", async () => {
+    const hook = await renderComposerPendingState();
+
+    act(() => {
+      hook
+        .get()
+        .enqueueComposerMessage("thread-a", message("queue-1", "One send"));
+      hook.get().syncPendingComposerMessagesFromServerEvent({
+        kind: "notification",
+        message: {
+          method: "turn/held",
+          params: {
+            thread_id: "thread-a",
+            messages: [
+              {
+                id: "queue-1",
+                origin: "queue",
+                prompt: "One send",
+                images: [],
+                files: [],
+              },
+            ],
+          },
+        },
+      } as ServerEvent);
+    });
+
+    expect(
+      hook.get().pendingComposerMessagesByThread["thread-a"]?.queued,
+    ).toEqual([
+      expect.objectContaining({ id: "queue-1", held: true, origin: "queue" }),
+    ]);
+  });
+
+  it("does not recreate an optimistic row when the held snapshot arrives first", async () => {
+    const hook = await renderComposerPendingState();
+
+    act(() => {
+      hook.get().syncPendingComposerMessagesFromServerEvent({
+        kind: "notification",
+        message: {
+          method: "turn/held",
+          params: {
+            thread_id: "thread-a",
+            messages: [
+              {
+                id: "queue-1",
+                origin: "queue",
+                prompt: "One send",
+                images: [],
+                files: [],
+              },
+            ],
+          },
+        },
+      } as ServerEvent);
+      hook
+        .get()
+        .enqueueComposerMessage("thread-a", message("queue-1", "One send"));
+    });
+
+    expect(
+      hook.get().pendingComposerMessagesByThread["thread-a"]?.queued,
+    ).toEqual([
+      expect.objectContaining({ id: "queue-1", held: true, origin: "queue" }),
+    ]);
+  });
+
   it("syncs server events by removing materialized queue and guide messages", async () => {
     const hook = await renderComposerPendingState();
 

--- a/desktop/src/renderer/ComposerPendingState.ts
+++ b/desktop/src/renderer/ComposerPendingState.ts
@@ -16,6 +16,8 @@ import {
   type QueuedComposerMessage,
 } from "./ComposerMessages";
 import {
+  appendPendingComposerMessage,
+  applyHeldComposerSnapshot,
   emptyThreadPendingComposerMessages,
   findPendingComposerMessage,
   pendingComposerMessagesForThread,
@@ -244,16 +246,9 @@ export function useComposerPendingState({
       if (!snapshot) {
         return;
       }
-      updateThreadPendingComposerMessages(snapshot.threadID, (previous) => ({
-        queued: [
-          ...previous.queued.filter((message) => !message.held),
-          ...snapshot.messages.filter((message) => message.origin === "queue"),
-        ],
-        guides: [
-          ...previous.guides.filter((message) => !message.held),
-          ...snapshot.messages.filter((message) => message.origin === "steer"),
-        ],
-      }));
+      updateThreadPendingComposerMessages(snapshot.threadID, (previous) =>
+        applyHeldComposerSnapshot(previous, snapshot.messages),
+      );
       return;
     }
     if (event.message.method === "turn/started") {
@@ -296,10 +291,9 @@ export function useComposerPendingState({
     threadID: string,
     message: QueuedComposerMessage,
   ): void {
-    updateThreadPendingComposerMessages(threadID, (previous) => ({
-      ...previous,
-      queued: [...previous.queued, message],
-    }));
+    updateThreadPendingComposerMessages(threadID, (previous) =>
+      appendPendingComposerMessage(previous, "queue", message),
+    );
   }
 
   async function removeQueuedMessage(id: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- reconcile authoritative held snapshots by queue ID across queued and guide state
- make late optimistic queue acknowledgements idempotent
- cover both response/notification delivery orders and cross-list replacement

## Tests
- npm run typecheck
- npx vitest run src/renderer/ComposerPendingMessages.test.ts src/renderer/ComposerPendingState.test.tsx src/renderer/AppQueuedTurnReconciliation.test.tsx src/renderer/ComposerView.test.tsx
- npm run test:unit (2048 tests passed; two Electron bootstrap suites initially hit a parallel install race, then passed 40/40 with one worker)