### PR TITLE
fix(desktop): slide the hover drawer in and out instead of popping it

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -148,6 +148,7 @@ import {
 } from "./AppState";
 import {
   RIGHT_PANEL_MOTION_MS,
+  SIDEBAR_DRAWER_EXIT_MS,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
   SIDEBAR_MOTION_MS,
@@ -474,7 +475,7 @@ export function App(): JSX.Element {
     sidebarCollapsed: sidebarDrawerMode,
     resizingSidebar,
     activeSessionTabID: state.activeSessionTabID,
-    motionMs: SIDEBAR_MOTION_MS,
+    motionMs: SIDEBAR_DRAWER_EXIT_MS,
   });
   const {
     collapsedSidebarSectionIDs,

--- a/desktop/src/renderer/AppLayoutState.ts
+++ b/desktop/src/renderer/AppLayoutState.ts
@@ -18,6 +18,10 @@ export const SIDEBAR_MOTION_MS = motionDurationMs(
   "--sidebar-motion-duration",
   280,
 );
+export const SIDEBAR_DRAWER_EXIT_MS = motionDurationMs(
+  "--sidebar-drawer-exit-duration",
+  220,
+);
 export const RIGHT_PANEL_MOTION_MS = motionDurationMs(
   "--workspace-panel-motion-duration",
   280,

--- a/desktop/src/renderer/AppSidebar.test.tsx
+++ b/desktop/src/renderer/AppSidebar.test.tsx
@@ -199,6 +199,23 @@ describe("AppSidebar layout", () => {
     expect(sidebarCSS).toContain(
       ".sidebar-collapsed.sidebar-drawer-open .sidebar .sidebar-content",
     );
+    // The collapsed rail carries the drawer's off-canvas start transform
+    // (excluded while the dock<->collapse grid animation runs), so the open
+    // transition is a real slide-in instead of an instant pop.
+    expect(sidebarCSS).toMatch(
+      /\.sidebar-collapsed:not\(\.sidebar-animating\) :is\(\.sidebar, \.settings-sidebar\)\s*\{\s*transform:\s*translate3d\(-100%, 0, 0\);/,
+    );
+    expect(sidebarCSS).toMatch(
+      /\.sidebar-collapsed\.sidebar-drawer-open :is\(\.sidebar, \.settings-sidebar\)[\s\S]*?transition:\s*transform\s+var\(--sidebar-drawer-enter-duration\)\s+var\(--sidebar-drawer-enter-easing\);/,
+    );
+    // Closing slides the panel back off-screen with the exit tokens; the old
+    // whole-panel opacity fade must not come back.
+    expect(sidebarCSS).toMatch(
+      /\.sidebar-collapsed\.sidebar-drawer-closing \.sidebar,\s*\.sidebar-collapsed\.sidebar-drawer-closing \.settings-sidebar\s*\{\s*transform:\s*translate3d\(-100%, 0, 0\);\s*transition:\s*transform\s+var\(--sidebar-drawer-exit-duration\)\s+var\(--sidebar-drawer-exit-easing\);/,
+    );
+    expect(sidebarCSS).not.toMatch(
+      /\.sidebar-collapsed\.sidebar-drawer-closing \.settings-sidebar\s*\{[^}]*opacity:\s*0/,
+    );
   });
 
   it("keeps primary actions outside the scrollable sidebar list", () => {

--- a/desktop/src/renderer/SettingsView.tsx
+++ b/desktop/src/renderer/SettingsView.tsx
@@ -37,6 +37,7 @@ import {
 } from "react";
 import { SidePanelToggleIcon } from "./SidePanelToggleIcon";
 import { useSidebarDrawerState } from "./SidebarDrawerState";
+import { SIDEBAR_DRAWER_EXIT_MS } from "./AppLayoutState";
 import { SelectMenu } from "./SelectMenu";
 import type {
   CodexPetsSnapshot,
@@ -563,7 +564,7 @@ export function SettingsView({
     sidebarCollapsed,
     resizingSidebar,
     activeSessionTabID: activeSessionTabID || activePage,
-    motionMs: sidebarMotionMs,
+    motionMs: SIDEBAR_DRAWER_EXIT_MS,
     closeOnWindowResize: true
   });
   const shellClassName = `settings-shell${resizingSidebar ? " resizing-sidebar" : ""}${

--- a/desktop/src/renderer/styles/base.css
+++ b/desktop/src/renderer/styles/base.css
@@ -172,6 +172,14 @@
   --sheet-enter-easing: var(--ease-out);
   --sheet-exit-duration: 220ms;
   --sheet-exit-easing: var(--ease-in);
+  /* Collapsed-sidebar hover drawer: same enter-heavy/exit-light pairing as
+   * the sheet. Enter rides the ladder (so prefers-reduced-motion zeroes it);
+   * exit is pinned shorter and accelerates off-screen. JS reads the exit
+   * token for the closing-phase timer (SIDEBAR_DRAWER_EXIT_MS). */
+  --sidebar-drawer-enter-duration: var(--motion-slow);
+  --sidebar-drawer-enter-easing: var(--ease-out);
+  --sidebar-drawer-exit-duration: 220ms;
+  --sidebar-drawer-exit-easing: var(--ease-in);
   --sidebar-motion-duration: var(--motion-slow);
   --sidebar-motion-ease: var(--ease-out);
   --workspace-panel-motion-duration: var(--motion-slow);

--- a/desktop/src/renderer/styles/sidebar.css
+++ b/desktop/src/renderer/styles/sidebar.css
@@ -255,6 +255,18 @@
   pointer-events: none;
 }
 
+/* Parked transform: the collapsed rail carries the hover drawer's off-canvas
+ * start value, so opening the drawer is a plain transform transition with no
+ * arming frame. Invisible while collapsed — the grid column is 0-width and
+ * overflow-clipped, and -100% of a 0-width box is a 0px shift. Excluded
+ * while .sidebar-animating runs the dock<->collapse grid animation so the
+ * rail keeps its squish-fade instead of flinging off-screen. Specificity
+ * ties the drawer overlay rules below; it sits earlier in source order so
+ * every open/closing/focus-within state wins over it. */
+.sidebar-collapsed:not(.sidebar-animating) :is(.sidebar, .settings-sidebar) {
+  transform: translate3d(-100%, 0, 0);
+}
+
 .sidebar-content {
   --sidebar-row-pad-x: 8px;
   --sidebar-nav-icon-col: 22px;
@@ -351,6 +363,16 @@
   pointer-events: auto;
   transform: translate3d(0, 0, 0);
   opacity: 1;
+  /* The drawer slides in from the parked off-canvas transform on the
+   * collapsed rail (see above). The transition declared here is the one used
+   * to REACH the open/pinned state; the closing rule below declares the
+   * faster exit. Chrome (background/border/shadow) intentionally does NOT
+   * fade in separately — it rides the panel's transform, so the whole drawer
+   * moves as one piece instead of a white slab popping in ahead of the
+   * content. */
+  transition: transform var(--sidebar-drawer-enter-duration)
+    var(--sidebar-drawer-enter-easing);
+  will-change: transform;
 }
 
 .sidebar-collapsed.sidebar-drawer-open :is(.sidebar, .settings-sidebar) .sidebar-content,
@@ -383,6 +405,9 @@
   pointer-events: auto;
   transform: translate3d(0, 0, 0);
   opacity: 1;
+  transition: transform var(--sidebar-drawer-enter-duration)
+    var(--sidebar-drawer-enter-easing);
+  will-change: transform;
 }
 
 .sidebar-collapsed.sidebar-drawer-open .sidebar .sidebar-content,
@@ -392,14 +417,26 @@
 }
 
 /* Closing keeps the drawer mounted as an overlay (position/width above) so
-   there is room for the exit motion, but lets the content fall back to the
-   collapsed values (opacity 0, slide left) and fades the panel chrome with
-   it. When the closing phase ends the overlay rules drop with everything
-   already invisible. Shared with the settings rail via `:is()`. */
+   there is room for the exit motion, and slides the whole panel back
+   off-screen left — the reverse of the enter slide, in the sheet's
+   enter-heavy/exit-light timing (shorter, accelerating away). The panel
+   chrome stays opaque the whole way; only the inner content falls back to
+   the collapsed fade/slide values. When the closing phase ends the overlay
+   rules drop onto the collapsed parked transform — the same -100% value — so
+   nothing jumps. Shared with the settings rail via `:is()`. */
 .sidebar-collapsed.sidebar-drawer-closing .sidebar,
 .sidebar-collapsed.sidebar-drawer-closing .settings-sidebar {
-  opacity: 0;
-  transition: opacity var(--sidebar-motion-duration) var(--sidebar-motion-ease);
+  transform: translate3d(-100%, 0, 0);
+  transition: transform var(--sidebar-drawer-exit-duration)
+    var(--sidebar-drawer-exit-easing);
+}
+
+/* The content layer follows the panel's exit timing instead of the slower
+   enter curve, so the fade finishes as the panel leaves the stage. */
+.sidebar-collapsed.sidebar-drawer-closing :is(.sidebar, .settings-sidebar) .sidebar-content {
+  transition:
+    opacity var(--sidebar-drawer-exit-duration) var(--sidebar-drawer-exit-easing),
+    transform var(--sidebar-drawer-exit-duration) var(--sidebar-drawer-exit-easing);
 }
 
 .sidebar-resizer {


### PR DESCRIPTION
## 问题

折叠侧栏的悬停抽屉（左侧 14px 热区悬停 240ms 触发的浮层）动画两段式、不丝滑：

- **打开**：面板 chrome（背景/边框/阴影）一帧内凭空出现，没有任何面板级位移；只有内部 `.sidebar-content` 从 -18px 淡入+缩放。视觉上是白板先啪地出现、内容再慢悠悠滑进来。
- **关闭**：整个面板原地 opacity 淡出，不像抽屉收回去。
- 进出共用同一组 280ms ease-out，关闭没有加速离场；box-shadow 单独过渡，滞后于面板。

## 方案

沿用代码库右侧全局化面板 sheet 的动效语言（enter-heavy/exit-light，transform 位移），但比 sheet 更简单——折叠态天然提供了起始值，不需要 arming 帧：

- 折叠 rail 常驻 parked transform `translate3d(-100%, 0, 0)`（折叠列 0 宽，`:not(.sidebar-animating)` 排除停靠折叠动画，视觉无副作用）。
- `sidebar-drawer-open` 终态 transform 过渡到 0：真实滑入，chrome 随面板一起移动，不再两段式。
- `sidebar-drawer-closing` 滑回 -100%：220ms ease-in 加速离场，替代原地淡出；结束后落在相同 computed 值的 parked transform 上，无跳变。
- 新 tokens `--sidebar-drawer-enter/exit-duration/easing`（base.css，与 sheet 配对并列）；JS 通过 `SIDEBAR_DRAWER_EXIT_MS` 读取 exit token 作为 closing 计时器，保持 CSS-JS 同步（motion-token 约定）。
- 全部走 transform/opacity 合成器动画；被打断（closing 中重新悬停）时 CSS transition 从当前插值位置自然反向。

## 验证

- `tsc --noEmit` 通过
- desktop 全量单测 183 文件 / 2086 用例通过（含新增 CSS 规则断言）
- 真实 Chromium 渲染探针（加载 worktree 真实 base.css + sidebar.css，翻转 phase class 逐帧采样）：enter 从 -326px 滑到 0、exit 从 0 滑回 -326px，各 ~15 帧插值，时长约 233/238ms，exit 全程 opacity 保持 1——确认滑入滑出真实发生，不是瞬时切换

## 备注

peer agent（容器内 claude CLI）咨询因代理网关 ConnectionRefused 不可用，本次为独立实现。