### PR TITLE
fix(desktop): preserve wallpaper tint in macOS sidebar

### DIFF
--- a/desktop/src/main/WindowMaterial.test.ts
+++ b/desktop/src/main/WindowMaterial.test.ts
@@ -13,8 +13,8 @@ const themeCSS = readFileSync(
 );
 
 describe("macOS sidebar material", () => {
-  it("lets the native sidebar material sample the wallpaper without a white veil", () => {
-    expect(mainSource).toContain('vibrancy: "sidebar"');
+  it("uses the under-window material to preserve wallpaper tint without a white veil", () => {
+    expect(mainSource).toContain('vibrancy: "under-window"');
     expect(sidebarCSS).toMatch(
       /--sidebar-material-fill:\s*rgba\(255, 255, 255, 0\.025\);/,
     );
@@ -29,7 +29,7 @@ describe("macOS sidebar material", () => {
     );
   });
 
-  it("uses a stable dark surface when the native sidebar material is light", () => {
+  it("uses a stable dark surface above the wallpaper material", () => {
     expect(themeCSS).toMatch(
       /:root\[data-theme="dark"\][\s\S]*?--sidebar-material-fill:\s*rgba\(16, 18, 21, 0\.88\);/,
     );

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -540,7 +540,7 @@ function mainWindowMaterialOptions(): Pick<
   return {
     backgroundColor: "#00000000",
     transparent: true,
-    vibrancy: "sidebar",
+    vibrancy: "under-window",
     visualEffectState: "active",
   };
 }

--- a/desktop/src/renderer/styles/theme.css
+++ b/desktop/src/renderer/styles/theme.css
@@ -267,9 +267,9 @@
   --participants-roster-focus-ring: rgba(228, 232, 235, 0.25);
 
   /* sidebar.css */
-  /* macOS's `sidebar` vibrancy material can remain light even when the
-     renderer is dark. Keep a little depth from the native material, but make
-     the dark surface dense enough that navigation text always has contrast.
+  /* macOS's `under-window` vibrancy material can remain light even when the
+     renderer is dark. Keep a little wallpaper depth from the native material,
+     but make the dark surface dense enough that navigation text has contrast.
      After the 2026-07-15 neutral rewrite, glass shadows + the dev-fixture
      text + the resizer overlay ride on the shared ink-overlay ladder; their
      hue now follows --ink-* instead of carrying its own green or blue cast. */


### PR DESCRIPTION
## Summary

- switch the macOS window vibrancy from `sidebar` to `under-window` so the rail preserves wallpaper tint instead of flattening into a uniform gray
- retain the existing light veil and dense dark-theme surface for navigation contrast
- update the material contract test and dark-theme documentation

## Testing

- `npm run typecheck`
- `npx vitest run src/main/WindowMaterial.test.ts`
- launched the full desktop dev stack on macOS and reviewed the visual result