### PR TITLE
feat: add Kimi K3 Anthropic compatibility

### DIFF
--- a/internal/modelcatalog/builtin_overrides.go
+++ b/internal/modelcatalog/builtin_overrides.go
@@ -31,6 +31,18 @@ func applyBuiltinCatalogOverrides(data *catalogData) {
 			provider.ModelOptions = mergeModelOptions(provider.ModelOptions, map[string]any{
 				"anthropic_default_betas": false,
 			})
+		case "xai":
+			for j := range provider.Models {
+				if len(provider.Models[j].SupportedEfforts) != 0 {
+					continue
+				}
+				switch provider.Models[j].ID {
+				case "grok-4.3":
+					provider.Models[j].SupportedEfforts = []string{"none", "low", "medium", "high"}
+				case "grok-4.20-multi-agent-0309":
+					provider.Models[j].SupportedEfforts = []string{"low", "medium", "high"}
+				}
+			}
 		}
 	}
 }

--- a/internal/modelcatalog/builtin_overrides.go
+++ b/internal/modelcatalog/builtin_overrides.go
@@ -12,6 +12,11 @@ func applyBuiltinCatalogOverrides(data *catalogData) {
 			continue
 		}
 		provider.API = "https://api.kimi.com/coding/"
+		provider.ModelOptions = map[string]any{
+			"force_adaptive_thinking": true,
+			"anthropic_default_betas": false,
+		}
+		provider.Headers = map[string]string{"User-Agent": "KimiCLI/1.5"}
 		for j := range provider.Models {
 			if provider.Models[j].ID == "k3" {
 				provider.Models[j] = kimiK3Model(provider.Models[j])
@@ -49,7 +54,6 @@ func kimiK3Model(model Model) Model {
 		"allow_empty_signature": true,
 		"thinking_replay":       "full",
 	}
-	model.Headers = map[string]string{"User-Agent": "KimiCLI/1.5"}
 	model.SupportedEfforts = []string{"max"}
 	model.DefaultVariant = "max"
 	model.Variants = map[string]map[string]any{

--- a/internal/modelcatalog/builtin_overrides.go
+++ b/internal/modelcatalog/builtin_overrides.go
@@ -8,23 +8,30 @@ func applyBuiltinCatalogOverrides(data *catalogData) {
 	}
 	for i := range data.Providers {
 		provider := &data.Providers[i]
-		if provider.ID != kimiForCodingProviderID {
-			continue
-		}
-		provider.API = "https://api.kimi.com/coding/"
-		provider.ModelOptions = map[string]any{
-			"force_adaptive_thinking": true,
-			"anthropic_default_betas": false,
-		}
-		provider.Headers = map[string]string{"User-Agent": "KimiCLI/1.5"}
-		for j := range provider.Models {
-			if provider.Models[j].ID == "k3" {
-				provider.Models[j] = kimiK3Model(provider.Models[j])
-				return
+		switch provider.ID {
+		case kimiForCodingProviderID:
+			provider.API = "https://api.kimi.com/coding/"
+			provider.ModelOptions = mergeModelOptions(provider.ModelOptions, map[string]any{
+				"force_adaptive_thinking": true,
+				"anthropic_default_betas": false,
+			})
+			provider.Headers = map[string]string{"User-Agent": "KimiCLI/1.5"}
+			found := false
+			for j := range provider.Models {
+				if provider.Models[j].ID == "k3" {
+					provider.Models[j] = kimiK3Model(provider.Models[j])
+					found = true
+					break
+				}
 			}
+			if !found {
+				provider.Models = append(provider.Models, kimiK3Model(Model{}))
+			}
+		case "minimax", "minimax-cn", "minimax-coding-plan", "minimax-cn-coding-plan":
+			provider.ModelOptions = mergeModelOptions(provider.ModelOptions, map[string]any{
+				"anthropic_default_betas": false,
+			})
 		}
-		provider.Models = append(provider.Models, kimiK3Model(Model{}))
-		return
 	}
 }
 

--- a/internal/modelcatalog/builtin_overrides.go
+++ b/internal/modelcatalog/builtin_overrides.go
@@ -1,0 +1,65 @@
+package modelcatalog
+
+const kimiForCodingProviderID = "kimi-for-coding"
+
+func applyBuiltinCatalogOverrides(data *catalogData) {
+	if data == nil {
+		return
+	}
+	for i := range data.Providers {
+		provider := &data.Providers[i]
+		if provider.ID != kimiForCodingProviderID {
+			continue
+		}
+		provider.API = "https://api.kimi.com/coding/"
+		for j := range provider.Models {
+			if provider.Models[j].ID == "k3" {
+				provider.Models[j] = kimiK3Model(provider.Models[j])
+				return
+			}
+		}
+		provider.Models = append(provider.Models, kimiK3Model(Model{}))
+		return
+	}
+}
+
+func kimiK3Model(model Model) Model {
+	attachment := false
+	toolCall := true
+	structuredOutput := true
+	temperature := true
+	model.ID = "k3"
+	model.Name = "Kimi K3"
+	model.Family = "kimi-k3"
+	model.ReleaseDate = "2026-07-16"
+	model.Reasoning = true
+	model.ReasoningOptions = []map[string]any{
+		{"type": "effort", "values": []any{"max"}},
+	}
+	model.Attachment = &attachment
+	model.ToolCall = &toolCall
+	model.StructuredOutput = &structuredOutput
+	model.Temperature = &temperature
+	model.Modalities = &Modalities{
+		Input:  []string{"text", "image", "video"},
+		Output: []string{"text"},
+	}
+	model.Limit = &Limit{Context: 1_048_576, Output: 131_072}
+	model.Options = map[string]any{
+		"allow_empty_signature": true,
+		"thinking_replay":       "full",
+	}
+	model.Headers = map[string]string{"User-Agent": "KimiCLI/1.5"}
+	model.SupportedEfforts = []string{"max"}
+	model.DefaultVariant = "max"
+	model.Variants = map[string]map[string]any{
+		"max": {
+			"thinking": map[string]any{
+				"type":    "adaptive",
+				"display": "summarized",
+			},
+			"effort": "max",
+		},
+	}
+	return model
+}

--- a/internal/modelcatalog/catalog.go
+++ b/internal/modelcatalog/catalog.go
@@ -25,25 +25,28 @@ type Provider struct {
 }
 
 type Model struct {
-	ID               string            `json:"id"`
-	APIID            string            `json:"api_id,omitempty"`
-	Name             string            `json:"name,omitempty"`
-	Family           string            `json:"family,omitempty"`
-	Status           string            `json:"status,omitempty"`
-	ReleaseDate      string            `json:"release_date,omitempty"`
-	Reasoning        bool              `json:"reasoning"`
-	ReasoningOptions []map[string]any  `json:"reasoning_options,omitempty"`
-	Attachment       *bool             `json:"attachment,omitempty"`
-	ToolCall         *bool             `json:"tool_call,omitempty"`
-	StructuredOutput *bool             `json:"structured_output,omitempty"`
-	Temperature      *bool             `json:"temperature,omitempty"`
-	Interleaved      any               `json:"interleaved,omitempty"`
-	Modalities       *Modalities       `json:"modalities,omitempty"`
-	Cost             map[string]any    `json:"cost,omitempty"`
-	Provider         *ModelProvider    `json:"provider,omitempty"`
-	Limit            *Limit            `json:"limit,omitempty"`
-	Options          map[string]any    `json:"options,omitempty"`
-	Headers          map[string]string `json:"headers,omitempty"`
+	ID               string                    `json:"id"`
+	APIID            string                    `json:"api_id,omitempty"`
+	Name             string                    `json:"name,omitempty"`
+	Family           string                    `json:"family,omitempty"`
+	Status           string                    `json:"status,omitempty"`
+	ReleaseDate      string                    `json:"release_date,omitempty"`
+	Reasoning        bool                      `json:"reasoning"`
+	ReasoningOptions []map[string]any          `json:"reasoning_options,omitempty"`
+	Attachment       *bool                     `json:"attachment,omitempty"`
+	ToolCall         *bool                     `json:"tool_call,omitempty"`
+	StructuredOutput *bool                     `json:"structured_output,omitempty"`
+	Temperature      *bool                     `json:"temperature,omitempty"`
+	Interleaved      any                       `json:"interleaved,omitempty"`
+	Modalities       *Modalities               `json:"modalities,omitempty"`
+	Cost             map[string]any            `json:"cost,omitempty"`
+	Provider         *ModelProvider            `json:"provider,omitempty"`
+	Limit            *Limit                    `json:"limit,omitempty"`
+	Options          map[string]any            `json:"options,omitempty"`
+	Headers          map[string]string         `json:"headers,omitempty"`
+	SupportedEfforts []string                  `json:"supported_efforts,omitempty"`
+	DefaultVariant   string                    `json:"default_variant,omitempty"`
+	Variants         map[string]map[string]any `json:"variants,omitempty"`
 }
 
 type ModelProvider struct {
@@ -75,6 +78,9 @@ var (
 func Providers() ([]Provider, error) {
 	loadOnce.Do(func() {
 		loadErr = json.Unmarshal(catalogJSON, &loaded)
+		if loadErr == nil {
+			applyBuiltinCatalogOverrides(&loaded)
+		}
 	})
 	if loadErr != nil {
 		return nil, loadErr
@@ -382,6 +388,9 @@ func ModelConfig(model Model) config.ProviderModelConfig {
 		Temperature:      cloneBool(model.Temperature),
 		Interleaved:      cloneAny(model.Interleaved),
 		Cost:             cloneOptions(model.Cost),
+		SupportedEfforts: append([]string(nil), model.SupportedEfforts...),
+		DefaultVariant:   strings.TrimSpace(model.DefaultVariant),
+		Variants:         cloneVariants(model.Variants),
 	}
 	if model.Modalities != nil {
 		out.Modalities = &config.ProviderModelModalitiesConfig{
@@ -517,6 +526,15 @@ func MergeModelConfig(primary, fallback config.ProviderModelConfig) config.Provi
 	if len(out.Headers) == 0 {
 		out.Headers = cloneHeaders(fallback.Headers)
 	}
+	if len(out.SupportedEfforts) == 0 {
+		out.SupportedEfforts = append([]string(nil), fallback.SupportedEfforts...)
+	}
+	if strings.TrimSpace(out.DefaultVariant) == "" {
+		out.DefaultVariant = fallback.DefaultVariant
+	}
+	if len(out.Variants) == 0 {
+		out.Variants = cloneVariants(fallback.Variants)
+	}
 	return out
 }
 
@@ -550,6 +568,17 @@ func cloneOptionList(input []map[string]any) []map[string]any {
 	out := make([]map[string]any, 0, len(input))
 	for _, item := range input {
 		out = append(out, cloneOptions(item))
+	}
+	return out
+}
+
+func cloneVariants(input map[string]map[string]any) map[string]map[string]any {
+	if len(input) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]any, len(input))
+	for key, options := range input {
+		out[key] = cloneOptions(options)
 	}
 	return out
 }

--- a/internal/modelcatalog/catalog.go
+++ b/internal/modelcatalog/catalog.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/blueberrycongee/wuu/internal/config"
+	"github.com/blueberrycongee/wuu/internal/provideroptions"
 )
 
 //go:generate go run ../../cmd/wuu-modelcatalog-gen -input https://models.dev/api.json -output models_dev_catalog.json
@@ -520,21 +521,15 @@ func MergeModelConfig(primary, fallback config.ProviderModelConfig) config.Provi
 	if out.ContextWindow == 0 && !userSetContext {
 		out.ContextWindow = fallback.ContextWindow
 	}
-	if len(out.Options) == 0 {
-		out.Options = cloneOptions(fallback.Options)
-	}
-	if len(out.Headers) == 0 {
-		out.Headers = cloneHeaders(fallback.Headers)
-	}
+	out.Options = mergeModelOptions(fallback.Options, out.Options)
+	out.Headers = mergeHeaders(fallback.Headers, out.Headers)
 	if len(out.SupportedEfforts) == 0 {
 		out.SupportedEfforts = append([]string(nil), fallback.SupportedEfforts...)
 	}
 	if strings.TrimSpace(out.DefaultVariant) == "" {
 		out.DefaultVariant = fallback.DefaultVariant
 	}
-	if len(out.Variants) == 0 {
-		out.Variants = cloneVariants(fallback.Variants)
-	}
+	out.Variants = mergeVariants(fallback.Variants, out.Variants)
 	return out
 }
 
@@ -583,13 +578,34 @@ func cloneVariants(input map[string]map[string]any) map[string]map[string]any {
 	return out
 }
 
-func cloneOptions(input map[string]any) map[string]any {
-	if len(input) == 0 {
-		return nil
+func mergeVariants(base, override map[string]map[string]any) map[string]map[string]any {
+	out := cloneVariants(base)
+	if len(override) == 0 {
+		return out
 	}
-	out := make(map[string]any, len(input))
-	for key, value := range input {
-		out[key] = value
+	if out == nil {
+		out = make(map[string]map[string]any, len(override))
+	}
+	for key, options := range override {
+		out[key] = mergeModelOptions(out[key], options)
+	}
+	return out
+}
+
+func cloneOptions(input map[string]any) map[string]any {
+	return provideroptions.Clone(input)
+}
+
+func mergeModelOptions(base, override map[string]any) map[string]any {
+	out := provideroptions.Clone(base)
+	if len(override) == 0 {
+		return out
+	}
+	if out == nil {
+		out = make(map[string]any, len(override))
+	}
+	for key, value := range override {
+		provideroptions.MergeValue(out, key, value)
 	}
 	return out
 }

--- a/internal/modelcatalog/catalog.go
+++ b/internal/modelcatalog/catalog.go
@@ -17,12 +17,14 @@ import (
 var catalogJSON []byte
 
 type Provider struct {
-	ID     string   `json:"id"`
-	Name   string   `json:"name,omitempty"`
-	API    string   `json:"api,omitempty"`
-	NPM    string   `json:"npm,omitempty"`
-	Env    []string `json:"env,omitempty"`
-	Models []Model  `json:"models"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name,omitempty"`
+	API          string            `json:"api,omitempty"`
+	NPM          string            `json:"npm,omitempty"`
+	Env          []string          `json:"env,omitempty"`
+	ModelOptions map[string]any    `json:"model_options,omitempty"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	Models       []Model           `json:"models"`
 }
 
 type Model struct {
@@ -289,6 +291,7 @@ func MergeProvider(provider config.ProviderConfig, catalogProvider Provider, mod
 		!isCodexSubscriptionProviderType(out.Type) {
 		out.APIKeyEnv = firstCatalogEnv(catalogProvider.Env)
 	}
+	out.Headers = mergeHeaders(catalogProvider.Headers, out.Headers)
 
 	modelSet := make(map[string]bool, len(modelIDs))
 	for _, modelID := range modelIDs {
@@ -299,9 +302,12 @@ func MergeProvider(provider config.ProviderConfig, catalogProvider Provider, mod
 	}
 	includeAll := len(modelSet) == 0
 
+	providerModelDefaults := config.ProviderModelConfig{
+		Options: cloneOptions(catalogProvider.ModelOptions),
+	}
 	models := make(map[string]config.ProviderModelConfig, len(out.Models)+len(catalogProvider.Models))
 	for id, model := range out.Models {
-		models[id] = model
+		models[id] = MergeModelConfig(model, providerModelDefaults)
 	}
 	for _, model := range catalogProvider.Models {
 		id := strings.TrimSpace(model.ID)
@@ -311,7 +317,8 @@ func MergeProvider(provider config.ProviderConfig, catalogProvider Provider, mod
 		if !includeAll && !modelSet[id] {
 			continue
 		}
-		models[id] = MergeModelConfig(models[id], ModelConfig(model))
+		catalogModel := MergeModelConfig(ModelConfig(model), providerModelDefaults)
+		models[id] = MergeModelConfig(models[id], catalogModel)
 	}
 	if len(models) > 0 {
 		out.Models = models

--- a/internal/modelcatalog/catalog_test.go
+++ b/internal/modelcatalog/catalog_test.go
@@ -72,6 +72,21 @@ func TestMatchProviderTreatsTerminalV1AsOptional(t *testing.T) {
 	if enriched.ContextWindow != 0 {
 		t.Fatalf("provider ContextWindow = %d, want 0 without explicit provider override", enriched.ContextWindow)
 	}
+	if got := model.Options["anthropic_default_betas"]; got != false {
+		t.Fatalf("MiniMax default anthropic_default_betas = %#v, want false", got)
+	}
+
+	_, overridden := EnrichProvider("minimax", config.ProviderConfig{
+		Type:    "anthropic",
+		BaseURL: "https://api.minimaxi.com/anthropic",
+		Model:   "MiniMax-M3",
+		Models: map[string]config.ProviderModelConfig{
+			"MiniMax-M3": {Options: map[string]any{"anthropic_default_betas": true}},
+		},
+	}, "MiniMax-M3")
+	if got := overridden.Models["MiniMax-M3"].Options["anthropic_default_betas"]; got != true {
+		t.Fatalf("explicit MiniMax anthropic_default_betas = %#v, want true", got)
+	}
 }
 
 func TestEnrichProviderInheritsKnownOpenAIModelForCompatibleGateway(t *testing.T) {

--- a/internal/modelcatalog/catalog_test.go
+++ b/internal/modelcatalog/catalog_test.go
@@ -184,8 +184,55 @@ func TestCatalogSnapshotMatchesOpenCodeDefaultVisibleCounts(t *testing.T) {
 			}
 		}
 	}
-	if modelCount != 5211 {
-		t.Fatalf("model count = %d, want 5211", modelCount)
+	if modelCount != 5212 {
+		t.Fatalf("model count = %d, want 5212", modelCount)
+	}
+}
+
+func TestKimiK3BuiltinCatalogOverride(t *testing.T) {
+	provider, ok := ProviderByID("kimi-for-coding")
+	if !ok {
+		t.Fatal("expected Kimi For Coding provider")
+	}
+	if provider.API != "https://api.kimi.com/coding/" || provider.NPM != "@ai-sdk/anthropic" {
+		t.Fatalf("unexpected Kimi provider transport: %+v", provider)
+	}
+	var k3 Model
+	for _, model := range provider.Models {
+		if model.ID == "k3" {
+			k3 = model
+			break
+		}
+	}
+	if k3.ID == "" {
+		t.Fatal("expected built-in K3 model")
+	}
+	if k3.Limit == nil || k3.Limit.Context != 1_048_576 || k3.Limit.Output != 131_072 {
+		t.Fatalf("unexpected K3 limits: %+v", k3.Limit)
+	}
+	if got := reasoningEfforts(k3); !equalStrings(got, []string{"max"}) {
+		t.Fatalf("unexpected K3 efforts: %v", got)
+	}
+	if k3.DefaultVariant != "max" || len(k3.Variants) != 1 || k3.Variants["max"] == nil {
+		t.Fatalf("unexpected K3 variants: default=%q variants=%+v", k3.DefaultVariant, k3.Variants)
+	}
+
+	ruleName, enriched := EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "k3",
+	}, "k3")
+	if ruleName != "kimi-for-coding" || enriched.BaseURL != "https://api.kimi.com/coding/" {
+		t.Fatalf("unexpected enriched K3 provider: rule=%q provider=%+v", ruleName, enriched)
+	}
+	model := enriched.Models["k3"]
+	if model.Limit == nil || model.Limit.Context != 1_048_576 || model.Limit.Output != 131_072 {
+		t.Fatalf("unexpected enriched K3 limits: %+v", model.Limit)
+	}
+	if model.Options["allow_empty_signature"] != true || model.Options["thinking_replay"] != "full" {
+		t.Fatalf("unexpected K3 compatibility options: %+v", model.Options)
+	}
+	if enriched.Headers["User-Agent"] != "KimiCLI/1.5" {
+		t.Fatalf("unexpected K3 headers: %+v", enriched.Headers)
 	}
 }
 

--- a/internal/modelcatalog/catalog_test.go
+++ b/internal/modelcatalog/catalog_test.go
@@ -482,3 +482,46 @@ func TestMergeModelConfigUserContextWinsOverCatalog(t *testing.T) {
 		t.Fatalf("Limit = %+v, want Context 0 (catalog must not fill the other spelling)", merged.Limit)
 	}
 }
+
+func TestMergeModelConfigPreservesCatalogCompatibilityMaps(t *testing.T) {
+	catalog := config.ProviderModelConfig{
+		Options: map[string]any{
+			"allow_empty_signature": true,
+			"thinking":              map[string]any{"type": "adaptive", "display": "summarized"},
+		},
+		Headers: map[string]string{"User-Agent": "KimiCLI/1.5"},
+		Variants: map[string]map[string]any{
+			"max": {"effort": "max", "thinking": map[string]any{"type": "adaptive"}},
+		},
+	}
+	user := config.ProviderModelConfig{
+		Options: map[string]any{
+			"custom":   true,
+			"thinking": map[string]any{"display": "omitted"},
+		},
+		Headers: map[string]string{"X-Custom": "value"},
+		Variants: map[string]map[string]any{
+			"custom": {"effort": "high"},
+			"max":    {"thinking": map[string]any{"display": "omitted"}},
+		},
+	}
+
+	merged := MergeModelConfig(user, catalog)
+	if merged.Options["allow_empty_signature"] != true || merged.Options["custom"] != true {
+		t.Fatalf("options did not merge: %+v", merged.Options)
+	}
+	thinking, _ := merged.Options["thinking"].(map[string]any)
+	if thinking["type"] != "adaptive" || thinking["display"] != "omitted" {
+		t.Fatalf("nested options did not merge with user precedence: %+v", thinking)
+	}
+	if merged.Headers["User-Agent"] != "KimiCLI/1.5" || merged.Headers["X-Custom"] != "value" {
+		t.Fatalf("headers did not merge: %+v", merged.Headers)
+	}
+	if merged.Variants["custom"]["effort"] != "high" || merged.Variants["max"]["effort"] != "max" {
+		t.Fatalf("variants did not merge: %+v", merged.Variants)
+	}
+	maxThinking, _ := merged.Variants["max"]["thinking"].(map[string]any)
+	if maxThinking["type"] != "adaptive" || maxThinking["display"] != "omitted" {
+		t.Fatalf("nested variant options did not merge with user precedence: %+v", maxThinking)
+	}
+}

--- a/internal/modelcatalog/catalog_test.go
+++ b/internal/modelcatalog/catalog_test.go
@@ -197,6 +197,11 @@ func TestKimiK3BuiltinCatalogOverride(t *testing.T) {
 	if provider.API != "https://api.kimi.com/coding/" || provider.NPM != "@ai-sdk/anthropic" {
 		t.Fatalf("unexpected Kimi provider transport: %+v", provider)
 	}
+	if provider.Headers["User-Agent"] != "KimiCLI/1.5" ||
+		provider.ModelOptions["force_adaptive_thinking"] != true ||
+		provider.ModelOptions["anthropic_default_betas"] != false {
+		t.Fatalf("unexpected Kimi provider defaults: options=%+v headers=%+v", provider.ModelOptions, provider.Headers)
+	}
 	var k3 Model
 	for _, model := range provider.Models {
 		if model.ID == "k3" {
@@ -228,11 +233,42 @@ func TestKimiK3BuiltinCatalogOverride(t *testing.T) {
 	if model.Limit == nil || model.Limit.Context != 1_048_576 || model.Limit.Output != 131_072 {
 		t.Fatalf("unexpected enriched K3 limits: %+v", model.Limit)
 	}
-	if model.Options["allow_empty_signature"] != true || model.Options["thinking_replay"] != "full" {
+	if model.Options["allow_empty_signature"] != true || model.Options["thinking_replay"] != "full" ||
+		model.Options["force_adaptive_thinking"] != true || model.Options["anthropic_default_betas"] != false {
 		t.Fatalf("unexpected K3 compatibility options: %+v", model.Options)
 	}
 	if enriched.Headers["User-Agent"] != "KimiCLI/1.5" {
 		t.Fatalf("unexpected K3 headers: %+v", enriched.Headers)
+	}
+}
+
+func TestKimiProviderDefaultsApplyWithoutK3ModelOverrides(t *testing.T) {
+	_, enriched := EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "k2p7",
+	}, "k2p7")
+
+	model := enriched.Models["k2p7"]
+	if model.Options["force_adaptive_thinking"] != true || model.Options["anthropic_default_betas"] != false {
+		t.Fatalf("unexpected Kimi provider options: %+v", model.Options)
+	}
+	if _, exists := model.Options["allow_empty_signature"]; exists {
+		t.Fatalf("K3-only empty signature option leaked to k2p7: %+v", model.Options)
+	}
+	if enriched.Headers["User-Agent"] != "KimiCLI/1.5" {
+		t.Fatalf("unexpected Kimi provider headers: %+v", enriched.Headers)
+	}
+
+	_, overridden := EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:    "anthropic",
+		Model:   "k2p7",
+		Headers: map[string]string{"User-Agent": "custom-client"},
+		Models: map[string]config.ProviderModelConfig{
+			"k2p7": {Options: map[string]any{"anthropic_default_betas": true}},
+		},
+	}, "k2p7")
+	if overridden.Headers["User-Agent"] != "custom-client" || overridden.Models["k2p7"].Options["anthropic_default_betas"] != true {
+		t.Fatalf("user Kimi overrides lost: provider=%+v model=%+v", overridden.Headers, overridden.Models["k2p7"].Options)
 	}
 }
 

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -975,6 +975,39 @@ func TestResolveMergesProviderCompatBaseOptions(t *testing.T) {
 	if got := selection.ProviderOptions["store"]; got != false {
 		t.Fatalf("store = %#v", got)
 	}
+	if got := selection.ProviderOptions["promptCacheKeySupported"]; got != true {
+		t.Fatalf("promptCacheKeySupported = %#v", got)
+	}
+}
+
+func TestResolveScopesPromptCacheKeyToSupportingProviders(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		provider   config.ProviderConfig
+		want       bool
+	}{
+		{name: "OpenAI", providerID: "openai", provider: config.ProviderConfig{Type: "openai", NPM: "@ai-sdk/openai", Model: "gpt-5.5"}, want: true},
+		{name: "OpenRouter", providerID: "openrouter", provider: config.ProviderConfig{Type: "openai-compatible", NPM: "@openrouter/ai-sdk-provider", Model: "openai/gpt-5.5"}, want: true},
+		{name: "xAI", providerID: "xai", provider: config.ProviderConfig{Type: "openai-compatible", NPM: "@ai-sdk/xai", Model: "grok-4"}},
+		{name: "GLM", providerID: "zai", provider: config.ProviderConfig{Type: "openai-compatible", NPM: "@ai-sdk/openai-compatible", Model: "glm-4.6"}},
+		{name: "Qwen", providerID: "alibaba", provider: config.ProviderConfig{Type: "openai-compatible", NPM: "@ai-sdk/openai-compatible", Model: "qwen-plus"}},
+		{name: "DeepSeek", providerID: "deepseek", provider: config.ProviderConfig{Type: "openai-compatible", NPM: "@ai-sdk/openai-compatible", Model: "deepseek-chat"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			selection := ResolveForProvider(tc.providerID, tc.provider, tc.provider.Model, "", "")
+			got, exists := selection.ProviderOptions["promptCacheKeySupported"]
+			if tc.want {
+				if got != true {
+					t.Fatalf("promptCacheKeySupported = %#v; options=%#v", got, selection.ProviderOptions)
+				}
+			} else if exists {
+				t.Fatalf("unsupported provider inherited prompt cache key: %#v", selection.ProviderOptions)
+			}
+		})
+	}
 }
 
 func TestResolveKeepsProviderCompatDefaultOptionsWithoutVariant(t *testing.T) {

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -109,6 +109,28 @@ func TestSummariesInferOpenRouterNonOpenAIReasoningEfforts(t *testing.T) {
 	}
 }
 
+func TestSummariesUseExplicitXAIReasoningEfforts(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{model: "grok-4.3", want: "none,low,medium,high"},
+		{model: "grok-4.20-multi-agent-0309", want: "low,medium,high"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.model, func(t *testing.T) {
+			providerName, provider := modelcatalog.EnrichProvider("xai", config.ProviderConfig{
+				Type:  "openai-compatible",
+				Model: tc.model,
+			}, tc.model)
+			variants := SummariesForProvider(providerName, provider, tc.model)
+			if got := strings.Join(variantIDs(variants), ","); got != tc.want {
+				t.Fatalf("variants = %q, want %q: %+v", got, tc.want, variants)
+			}
+		})
+	}
+}
+
 func TestSummariesMatchProviderCompatForGenericOpenAICompatible(t *testing.T) {
 	provider := config.ProviderConfig{
 		Type:  "openai-compatible",

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -412,6 +412,22 @@ func TestResolveMatchesProviderCompatForZAIAndZhipuThinking(t *testing.T) {
 	}
 }
 
+func TestResolveDeepSeekV4EffortEnablesThinking(t *testing.T) {
+	providerName, provider := modelcatalog.EnrichProvider("deepseek", config.ProviderConfig{
+		Type:  "openai-compatible",
+		Model: "deepseek-v4-pro",
+	}, "deepseek-v4-pro")
+
+	selection := ResolveForProvider(providerName, provider, "deepseek-v4-pro", "high", "")
+	if got := selection.ProviderOptions["reasoningEffort"]; got != "high" {
+		t.Fatalf("reasoningEffort = %#v", got)
+	}
+	thinking, ok := selection.ProviderOptions["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "enabled" {
+		t.Fatalf("thinking = %#v; options=%#v", selection.ProviderOptions["thinking"], selection.ProviderOptions)
+	}
+}
+
 func TestResolveMatchesProviderCompatForAlibabaReasoning(t *testing.T) {
 	reasoning := true
 	provider := config.ProviderConfig{

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -32,6 +32,29 @@ func TestKimiK3UsesExplicitMaxVariant(t *testing.T) {
 	}
 }
 
+func TestKimiProviderDefaultsUseAdaptiveThinking(t *testing.T) {
+	providerName, provider := modelcatalog.EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "k2p7",
+	}, "k2p7")
+
+	variants := SummariesForProvider(providerName, provider, "k2p7")
+	if got := strings.Join(variantIDs(variants), ","); got != "low,medium,high" {
+		t.Fatalf("Kimi k2p7 variants = %s, want low,medium,high", got)
+	}
+	selection := ResolveForProvider(providerName, provider, "k2p7", "medium", "")
+	if selection.ProviderOptions["effort"] != "medium" || selection.ProviderOptions["force_adaptive_thinking"] != true {
+		t.Fatalf("unexpected Kimi provider options: %+v", selection.ProviderOptions)
+	}
+	thinking, ok := selection.ProviderOptions["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "adaptive" || thinking["display"] != "summarized" {
+		t.Fatalf("unexpected Kimi adaptive thinking: %+v", selection.ProviderOptions)
+	}
+	if _, exists := selection.ProviderOptions["allow_empty_signature"]; exists {
+		t.Fatalf("K3-only empty signature option leaked to k2p7: %+v", selection.ProviderOptions)
+	}
+}
+
 func TestSummariesInferXiaomiReasoningEfforts(t *testing.T) {
 	provider := config.ProviderConfig{
 		Type:    "openai-compatible",

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -339,6 +339,27 @@ func TestResolveKeepsExplicitMiniMaxToolSearchOption(t *testing.T) {
 	}
 }
 
+func TestResolveKeepsExplicitMiniMaxThinkingOption(t *testing.T) {
+	reasoning := true
+	provider := config.ProviderConfig{
+		Type:  "anthropic",
+		NPM:   "@ai-sdk/anthropic",
+		Model: "minimax-m3",
+		Models: map[string]config.ProviderModelConfig{
+			"minimax-m3": {
+				Reasoning: &reasoning,
+				Options:   map[string]any{"thinking": map[string]any{"type": "disabled"}},
+			},
+		},
+	}
+
+	selection := Resolve(provider, provider.Model, "", "")
+	thinking, ok := selection.ProviderOptions["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "disabled" {
+		t.Fatalf("explicit thinking option was overwritten: %#v", selection.ProviderOptions)
+	}
+}
+
 func TestResolveMatchesProviderCompatForZAIAndZhipuThinking(t *testing.T) {
 	for _, providerID := range []string{"zai-coding-plan", "zai", "zhipuai-coding-plan", "zhipuai"} {
 		t.Run(providerID, func(t *testing.T) {
@@ -356,6 +377,15 @@ func TestResolveMatchesProviderCompatForZAIAndZhipuThinking(t *testing.T) {
 			if thinking["type"] != "enabled" || thinking["clear_thinking"] != false {
 				t.Fatalf("thinking = %#v", thinking)
 			}
+
+			provider.Models = map[string]config.ProviderModelConfig{
+				provider.Model: {Options: map[string]any{"thinking": map[string]any{"type": "disabled"}}},
+			}
+			selection = ResolveForProvider(providerID, provider, provider.Model, "", "")
+			thinking, ok = selection.ProviderOptions["thinking"].(map[string]any)
+			if !ok || thinking["type"] != "disabled" {
+				t.Fatalf("explicit thinking option was overwritten: %#v", selection.ProviderOptions)
+			}
 		})
 	}
 }
@@ -371,18 +401,31 @@ func TestResolveMatchesProviderCompatForAlibabaReasoning(t *testing.T) {
 		},
 	}
 
-	selection := ResolveForProvider("alibaba-cn", provider, provider.Model, "", "")
-	if got := selection.ProviderOptions["enable_thinking"]; got != true {
-		t.Fatalf("enable_thinking = %#v; options=%#v", got, selection.ProviderOptions)
+	for _, providerID := range []string{
+		"alibaba", "alibaba-cn", "alibaba-coding-plan", "alibaba-coding-plan-cn", "alibaba-token-plan", "alibaba-token-plan-cn",
+	} {
+		selection := ResolveForProvider(providerID, provider, provider.Model, "", "")
+		if got := selection.ProviderOptions["enable_thinking"]; got != true {
+			t.Fatalf("%s enable_thinking = %#v; options=%#v", providerID, got, selection.ProviderOptions)
+		}
 	}
 
 	provider.Model = "kimi-k2-thinking"
 	provider.Models = map[string]config.ProviderModelConfig{
 		"kimi-k2-thinking": {Reasoning: &reasoning},
 	}
-	selection = ResolveForProvider("alibaba-cn", provider, provider.Model, "", "")
+	selection := ResolveForProvider("alibaba-cn", provider, provider.Model, "", "")
 	if _, ok := selection.ProviderOptions["enable_thinking"]; ok {
 		t.Fatalf("kimi-k2-thinking should use provider default thinking: %#v", selection.ProviderOptions)
+	}
+
+	provider.Model = "qwen-plus"
+	provider.Models = map[string]config.ProviderModelConfig{
+		"qwen-plus": {Reasoning: &reasoning, Options: map[string]any{"enable_thinking": false}},
+	}
+	selection = ResolveForProvider("alibaba", provider, provider.Model, "", "")
+	if got := selection.ProviderOptions["enable_thinking"]; got != false {
+		t.Fatalf("explicit enable_thinking = %#v; options=%#v", got, selection.ProviderOptions)
 	}
 }
 

--- a/internal/modelvariant/modelvariant_test.go
+++ b/internal/modelvariant/modelvariant_test.go
@@ -6,7 +6,31 @@ import (
 	"testing"
 
 	"github.com/blueberrycongee/wuu/internal/config"
+	"github.com/blueberrycongee/wuu/internal/modelcatalog"
 )
+
+func TestKimiK3UsesExplicitMaxVariant(t *testing.T) {
+	providerName, provider := modelcatalog.EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "k3",
+	}, "k3")
+
+	variants := SummariesForProvider(providerName, provider, "k3")
+	if got := variantIDs(variants); len(got) != 1 || got[0] != "max" {
+		t.Fatalf("K3 variants = %v, want [max]", got)
+	}
+	selection := ResolveForProvider(providerName, provider, "k3", "", "")
+	if selection.Variant != "max" {
+		t.Fatalf("K3 default variant = %q, want max", selection.Variant)
+	}
+	if selection.ProviderOptions["effort"] != "max" || selection.ProviderOptions["allow_empty_signature"] != true || selection.ProviderOptions["thinking_replay"] != "full" {
+		t.Fatalf("unexpected K3 provider options: %+v", selection.ProviderOptions)
+	}
+	thinking, ok := selection.ProviderOptions["thinking"].(map[string]any)
+	if !ok || thinking["type"] != "adaptive" || thinking["display"] != "summarized" {
+		t.Fatalf("unexpected K3 thinking options: %+v", selection.ProviderOptions)
+	}
+}
 
 func TestSummariesInferXiaomiReasoningEfforts(t *testing.T) {
 	provider := config.ProviderConfig{

--- a/internal/modelvariant/provider_compat.go
+++ b/internal/modelvariant/provider_compat.go
@@ -62,28 +62,28 @@ func BaseOptionsForProvider(providerName string, provider config.ProviderConfig,
 
 	applyCompatSamplingDefaults(result, desc)
 	if desc.APINPM == compatNPMVertexAnthropic || (desc.APINPM == compatNPMAnthropic && !strings.Contains(desc.APIID, "claude")) {
-		result["toolStreaming"] = false
+		setOptionDefault(result, "toolStreaming", false)
 	}
 	if desc.ProviderID == "openai" || desc.APINPM == compatNPMOpenAI || desc.APINPM == compatNPMGithubCopilot || desc.APINPM == compatNPMBedrockMantle {
-		result["store"] = false
+		setOptionDefault(result, "store", false)
 	}
 	if desc.APINPM == compatNPMAzure {
-		result["store"] = false
+		setOptionDefault(result, "store", false)
 	}
 	if desc.APINPM == compatNPMOpenRouter || desc.APINPM == compatNPMLLMGateway {
-		result["usage"] = map[string]any{"include": true}
+		setOptionDefault(result, "usage", map[string]any{"include": true})
 		if strings.Contains(desc.APIID, "gemini-3") {
-			result["reasoning"] = map[string]any{"effort": "high"}
+			setOptionDefault(result, "reasoning", map[string]any{"effort": "high"})
 		}
 	}
 	if desc.ProviderID == "baseten" || (desc.ProviderID == "opencode" && (desc.APIID == "kimi-k2-thinking" || desc.APIID == "glm-4.6")) {
-		result["chat_template_args"] = map[string]any{"enable_thinking": true}
+		setOptionDefault(result, "chat_template_args", map[string]any{"enable_thinking": true})
 	}
 	if (strings.Contains(desc.ProviderID, "zai") || strings.Contains(desc.ProviderID, "zhipuai")) && desc.APINPM == compatNPMOpenAICompatible {
-		result["thinking"] = map[string]any{
+		setOptionDefault(result, "thinking", map[string]any{
 			"type":           "enabled",
 			"clear_thinking": false,
-		}
+		})
 	}
 	if desc.APINPM == compatNPMGoogle || desc.APINPM == compatNPMGoogleVertex {
 		if desc.Reasoning {
@@ -91,49 +91,49 @@ func BaseOptionsForProvider(providerName string, provider config.ProviderConfig,
 			if strings.Contains(desc.APIID, "gemini-3") {
 				thinking["thinkingLevel"] = "high"
 			}
-			result["thinkingConfig"] = thinking
+			setOptionDefault(result, "thinkingConfig", thinking)
 		}
 	}
 	if strings.Contains(desc.APIID, "minimax-m3") && desc.APINPM == compatNPMAnthropic {
-		result["thinking"] = map[string]any{"type": "adaptive"}
+		setOptionDefault(result, "thinking", map[string]any{"type": "adaptive"})
 	}
 	if (desc.APINPM == compatNPMAnthropic || desc.APINPM == compatNPMVertexAnthropic) &&
 		(strings.Contains(desc.APIID, "k2p") || strings.Contains(desc.APIID, "kimi-k2.") || strings.Contains(desc.APIID, "kimi-k2p")) {
-		result["thinking"] = map[string]any{
+		setOptionDefault(result, "thinking", map[string]any{
 			"type":         "enabled",
 			"budgetTokens": compatAnthropicHighBudget(desc.OutputLimit),
-		}
+		})
 	}
-	if desc.ProviderID == "alibaba-cn" && desc.Reasoning && desc.APINPM == compatNPMOpenAICompatible && !strings.Contains(desc.APIID, "kimi-k2-thinking") {
-		result["enable_thinking"] = true
+	if strings.HasPrefix(desc.ProviderID, "alibaba") && desc.Reasoning && desc.APINPM == compatNPMOpenAICompatible && !strings.Contains(desc.APIID, "kimi-k2-thinking") {
+		setOptionDefault(result, "enable_thinking", true)
 	}
 	if desc.APINPM == compatNPMAzure && strings.Contains(desc.APIID, "gpt-5.5") {
-		result["reasoningSummary"] = "auto"
+		setOptionDefault(result, "reasoningSummary", "auto")
 		return nilIfEmpty(result)
 	}
 	if strings.Contains(desc.APIID, "gpt-5") && !strings.Contains(desc.APIID, "gpt-5-chat") {
 		if !strings.Contains(desc.APIID, "gpt-5-pro") {
-			result["reasoningEffort"] = "medium"
+			setOptionDefault(result, "reasoningEffort", "medium")
 			if desc.APINPM == compatNPMOpenAI || desc.APINPM == compatNPMAzure || desc.APINPM == compatNPMGithubCopilot || desc.APINPM == compatNPMBedrockMantle {
-				result["reasoningSummary"] = "auto"
+				setOptionDefault(result, "reasoningSummary", "auto")
 			}
 			if desc.APINPM == compatNPMOpenAI || desc.APINPM == compatNPMBedrockMantle {
-				result["include"] = []any{"reasoning.encrypted_content"}
+				setOptionDefault(result, "include", []any{"reasoning.encrypted_content"})
 			}
 		}
 		if strings.Contains(desc.APIID, "gpt-5.") &&
 			!strings.Contains(desc.APIID, "codex") &&
 			!strings.Contains(desc.APIID, "-chat") &&
 			desc.ProviderID != "azure" {
-			result["textVerbosity"] = "low"
+			setOptionDefault(result, "textVerbosity", "low")
 		}
 		if strings.HasPrefix(desc.ProviderID, "opencode") {
-			result["include"] = []any{"reasoning.encrypted_content"}
-			result["reasoningSummary"] = "auto"
+			setOptionDefault(result, "include", []any{"reasoning.encrypted_content"})
+			setOptionDefault(result, "reasoningSummary", "auto")
 		}
 	}
 	if desc.APINPM == compatNPMGateway {
-		result["gateway"] = map[string]any{"caching": "auto"}
+		setOptionDefault(result, "gateway", map[string]any{"caching": "auto"})
 	}
 	return nilIfEmpty(result)
 }

--- a/internal/modelvariant/provider_compat.go
+++ b/internal/modelvariant/provider_compat.go
@@ -67,6 +67,9 @@ func BaseOptionsForProvider(providerName string, provider config.ProviderConfig,
 	if desc.ProviderID == "openai" || desc.APINPM == compatNPMOpenAI || desc.APINPM == compatNPMGithubCopilot || desc.APINPM == compatNPMBedrockMantle {
 		setOptionDefault(result, "store", false)
 	}
+	if desc.ProviderID == "openai" || desc.APINPM == compatNPMOpenAI || desc.APINPM == compatNPMOpenRouter {
+		setOptionDefault(result, "promptCacheKeySupported", true)
+	}
 	if desc.APINPM == compatNPMAzure {
 		setOptionDefault(result, "store", false)
 	}

--- a/internal/modelvariant/provider_compat.go
+++ b/internal/modelvariant/provider_compat.go
@@ -266,6 +266,7 @@ func inferredOptionsForProvider(providerName string, provider config.ProviderCon
 		}
 		if strings.Contains(apiID, "deepseek-v4") {
 			efforts = appendUniqueEffort(efforts, "max")
+			return compatVariantsFromEfforts(efforts, compatDeepSeekVariantOptions)
 		}
 		return compatReasoningEffortVariants(efforts)
 	case compatNPMAzure:

--- a/internal/modelvariant/provider_compat.go
+++ b/internal/modelvariant/provider_compat.go
@@ -182,6 +182,18 @@ func inferredOptionsForProvider(providerName string, provider config.ProviderCon
 	id := desc.ModelID
 	apiID := desc.APIID
 	adaptiveEfforts := compatAnthropicAdaptiveEfforts(apiID)
+	if (desc.APINPM == compatNPMAnthropic || desc.APINPM == compatNPMVertexAnthropic) && forceAdaptiveThinking(provider.Models[model].Options) {
+		efforts := modelReasoningEfforts(provider.Models[model])
+		if len(efforts) == 0 {
+			efforts = compatWidelySupportedEfforts()
+		}
+		return compatVariantsFromEfforts(efforts, func(effort string) map[string]any {
+			return map[string]any{
+				"thinking": map[string]any{"type": "adaptive", "display": "summarized"},
+				"effort":   effort,
+			}
+		})
+	}
 	if strings.Contains(desc.APIID, "minimax-m3") &&
 		(desc.APINPM == compatNPMAnthropic || desc.APINPM == compatNPMOpenAICompatible) {
 		return map[string]map[string]any{
@@ -284,6 +296,15 @@ func inferredOptionsForProvider(providerName string, provider config.ProviderCon
 	default:
 		return nil
 	}
+}
+
+func forceAdaptiveThinking(options map[string]any) bool {
+	for _, key := range []string{"force_adaptive_thinking", "forceAdaptiveThinking"} {
+		if enabled, ok := options[key].(bool); ok {
+			return enabled
+		}
+	}
+	return false
 }
 
 func modelReasoningEfforts(model config.ProviderModelConfig) []string {

--- a/internal/modelvariant/provider_compat.go
+++ b/internal/modelvariant/provider_compat.go
@@ -216,7 +216,11 @@ func inferredOptionsForProvider(providerName string, provider config.ProviderCon
 		return compatReasoningEffortVariants([]string{"low", "high"})
 	}
 	if strings.Contains(id, "grok") {
-		return nil
+		efforts := modelReasoningEfforts(provider.Models[model])
+		if len(efforts) == 0 {
+			return nil
+		}
+		return compatReasoningEffortVariants(efforts)
 	}
 
 	switch desc.APINPM {

--- a/internal/modelvariant/variant_options.go
+++ b/internal/modelvariant/variant_options.go
@@ -65,6 +65,13 @@ func compatReasoningEffortVariants(efforts []string) map[string]map[string]any {
 	})
 }
 
+func compatDeepSeekVariantOptions(effort string) map[string]any {
+	return map[string]any{
+		"thinking":        map[string]any{"type": "enabled"},
+		"reasoningEffort": effort,
+	}
+}
+
 func compatOpenAIProviderVariantOptions(effort string) map[string]any {
 	return map[string]any{
 		"reasoningEffort":  effort,

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -242,6 +242,7 @@ func buildClient(provider config.ProviderConfig, providerName string) (providers
 			APIKey:                          apiKey,
 			AuthToken:                       authToken,
 			Headers:                         provider.Headers,
+			MaxTokens:                       providerModelOutputLimit(provider),
 			StreamConfig:                    providerStreamTransportConfig(provider),
 			Coordinator:                     sharedProviderCoordinator,
 			CacheCreationInputTokensOmitted: provider.CacheCreationInputTokensOmitted,
@@ -254,6 +255,22 @@ func buildClient(provider config.ProviderConfig, providerName string) (providers
 	default:
 		return nil, fmt.Errorf("unsupported provider wire protocol %q", profile.Wire)
 	}
+}
+
+func providerModelOutputLimit(provider config.ProviderConfig) int {
+	model := strings.TrimSpace(provider.Model)
+	if model == "" {
+		return 0
+	}
+	if cfg, ok := provider.Models[model]; ok && cfg.Limit != nil {
+		return cfg.Limit.Output
+	}
+	for _, cfg := range provider.Models {
+		if strings.TrimSpace(cfg.ID) == model && cfg.Limit != nil {
+			return cfg.Limit.Output
+		}
+	}
+	return 0
 }
 
 func providerStreamTransportConfig(provider config.ProviderConfig) *providers.StreamTransportConfig {

--- a/internal/providerfactory/factory_test.go
+++ b/internal/providerfactory/factory_test.go
@@ -111,6 +111,44 @@ func TestBuildClient_Anthropic(t *testing.T) {
 	}
 }
 
+func TestBuildClient_AnthropicUsesConfiguredModelOutputLimit(t *testing.T) {
+	t.Setenv("TEST_ANTHROPIC_KEY", "abc")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			MaxTokens int `json:"max_tokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.MaxTokens != 131_072 {
+			t.Fatalf("max_tokens = %d, want 131072", body.MaxTokens)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := BuildClient(config.ProviderConfig{
+		Type:      "anthropic",
+		BaseURL:   server.URL,
+		APIKeyEnv: "TEST_ANTHROPIC_KEY",
+		Model:     "k3",
+		Models: map[string]config.ProviderModelConfig{
+			"k3": {Limit: &config.ProviderModelLimitConfig{Output: 131_072}},
+		},
+	}, "kimi-for-coding")
+	if err != nil {
+		t.Fatalf("BuildClient returned error: %v", err)
+	}
+	if _, err := client.Chat(context.Background(), providers.ChatRequest{
+		Model:    "k3",
+		Messages: []providers.ChatMessage{{Role: "user", Content: "hello"}},
+	}); err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+}
+
 func TestResolveProviderProfile_OpenAICodex(t *testing.T) {
 	profile, err := resolveProviderProfile(config.ProviderConfig{Type: "openai-codex"})
 	if err != nil {

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -115,6 +115,7 @@ func (c *Client) normalizeInclusiveInput(usage *providers.TokenUsage) {
 // Client sends tool-enabled chat requests to Anthropic APIs.
 type Client struct {
 	baseURL                         string
+	messagesURL                     string
 	apiKey                          string
 	authToken                       string
 	headers                         map[string]string
@@ -152,6 +153,7 @@ func New(cfg ClientConfig) (*Client, error) {
 
 	return &Client{
 		baseURL:                         strings.TrimRight(cfg.BaseURL, "/"),
+		messagesURL:                     anthropicMessagesURL(cfg.BaseURL),
 		apiKey:                          cfg.APIKey,
 		authToken:                       cfg.AuthToken,
 		headers:                         cloneHeaders(cfg.Headers),
@@ -169,6 +171,18 @@ func New(cfg ClientConfig) (*Client, error) {
 		// two identical cache_control requests before enabling.
 		inputTokensIncludeCacheRead: cfg.InputTokensIncludeCacheRead,
 	}, nil
+}
+
+func anthropicMessagesURL(baseURL string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	switch {
+	case strings.HasSuffix(baseURL, "/v1/messages"):
+		return baseURL
+	case strings.HasSuffix(baseURL, "/v1"):
+		return baseURL + "/messages"
+	default:
+		return baseURL + "/v1/messages"
+	}
 }
 
 // Chat performs one Anthropic messages round.
@@ -406,6 +420,13 @@ func buildAnthropicRequestWithSupport(req providers.ChatRequest, maxTokens int, 
 		}
 		break
 	}
+	allowEmptySignature := false
+	for _, key := range []string{"allow_empty_signature", "allowEmptySignature"} {
+		if enabled, ok := providerOptionBool(req.ProviderOptions[key]); ok {
+			allowEmptySignature = enabled
+			break
+		}
+	}
 
 	cacheTTL := ""
 	if ttlVal, ok := req.ProviderOptions["cacheTTL"].(string); ok {
@@ -449,7 +470,7 @@ func buildAnthropicRequestWithSupport(req providers.ChatRequest, maxTokens int, 
 			continue
 		}
 
-		mapped, err := mapMessage(msg, toolSearchEnabled, thinkingReplay)
+		mapped, err := mapMessage(msg, toolSearchEnabled, thinkingReplay, allowEmptySignature)
 		if err != nil {
 			return anthropicRequest{}, err
 		}
@@ -940,7 +961,7 @@ func (c *Client) doSingleMessagesRequest(
 	attempt providers.InferenceAttempt,
 	mode string,
 ) (*http.Response, *providers.ProviderLease, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.messagesURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, nil, fmt.Errorf("build request: %w", err)
 	}
@@ -1319,7 +1340,7 @@ const (
 	thinkingReplayOff  = "off"
 )
 
-func mapMessage(msg providers.ChatMessage, toolSearchEnabled bool, thinkingReplay string) (anthropicMessage, error) {
+func mapMessage(msg providers.ChatMessage, toolSearchEnabled bool, thinkingReplay string, allowEmptySignature bool) (anthropicMessage, error) {
 	switch msg.Role {
 	case "user":
 		blocks := make([]anthropicBlock, 0, len(msg.Images)+len(msg.Files)+1)
@@ -1373,7 +1394,7 @@ func mapMessage(msg providers.ChatMessage, toolSearchEnabled bool, thinkingRepla
 				blocks = append(blocks, anthropicBlock{Type: "text", Text: "<thinking>\n" + reasoning + "\n</thinking>"})
 			}
 		default:
-			blocks = append(blocks, mapReasoningBlocks(reasoningBlocks)...)
+			blocks = append(blocks, mapReasoningBlocks(reasoningBlocks, allowEmptySignature)...)
 		}
 		// Assistant tool-use turns should replay provider-native
 		// thinking blocks before tool_use. Only synthesize a text
@@ -1465,7 +1486,7 @@ func anthropicToolCallKind(name string) providers.ToolCallKind {
 	return ""
 }
 
-func mapReasoningBlocks(blocks []providers.ReasoningBlock) []anthropicBlock {
+func mapReasoningBlocks(blocks []providers.ReasoningBlock, allowEmptySignature bool) []anthropicBlock {
 	if len(blocks) == 0 {
 		return nil
 	}
@@ -1474,10 +1495,15 @@ func mapReasoningBlocks(blocks []providers.ReasoningBlock) []anthropicBlock {
 		switch block.Type {
 		case "thinking":
 			thinking := block.Thinking
+			var signature *string
+			if block.Signature != "" || allowEmptySignature {
+				signatureValue := block.Signature
+				signature = &signatureValue
+			}
 			out = append(out, anthropicBlock{
 				Type:      "thinking",
 				Thinking:  &thinking,
-				Signature: block.Signature,
+				Signature: signature,
 			})
 		case "redacted_thinking":
 			out = append(out, anthropicBlock{Type: "redacted_thinking", Data: block.Data})
@@ -1491,10 +1517,14 @@ func anthropicReasoningBlock(block anthropicBlock) providers.ReasoningBlock {
 	if block.Thinking != nil {
 		thinking = *block.Thinking
 	}
+	signature := ""
+	if block.Signature != nil {
+		signature = *block.Signature
+	}
 	return providers.ReasoningBlock{
 		Type:      block.Type,
 		Thinking:  thinking,
-		Signature: block.Signature,
+		Signature: signature,
 		Data:      block.Data,
 	}
 }
@@ -1632,7 +1662,7 @@ type anthropicBlock struct {
 	Type         string                 `json:"type"`
 	Text         string                 `json:"text,omitempty"`
 	Thinking     *string                `json:"thinking,omitempty"`
-	Signature    string                 `json:"signature,omitempty"`
+	Signature    *string                `json:"signature,omitempty"`
 	Data         string                 `json:"data,omitempty"`
 	Source       *anthropicImageSource  `json:"source,omitempty"`
 	ID           string                 `json:"id,omitempty"`

--- a/internal/providers/anthropic/client.go
+++ b/internal/providers/anthropic/client.go
@@ -213,7 +213,7 @@ func (c *Client) Chat(ctx context.Context, req providers.ChatRequest) (providers
 		return providers.ChatResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
 
-	httpResp, lease, err := c.doSingleMessagesRequest(ctx, c.httpClient, body, payload.Betas, req.Attempt, "unary")
+	httpResp, lease, err := c.doSingleMessagesRequest(ctx, c.httpClient, body, payload.UseDefaultBetas, payload.Betas, req.Attempt, "unary")
 	if err != nil {
 		return providers.ChatResponse{}, err
 	}
@@ -347,7 +347,7 @@ func (c *Client) StreamChat(ctx context.Context, req providers.ChatRequest) (<-c
 		_ = os.WriteFile(dumpPath, body, 0o644)
 		providers.DebugLogf("StreamChat: dumped request body to %s", dumpPath)
 	}
-	resp, lease, err := c.doSingleMessagesRequest(ctx, sseClient, body, payload.Betas, req.Attempt, "stream")
+	resp, lease, err := c.doSingleMessagesRequest(ctx, sseClient, body, payload.UseDefaultBetas, payload.Betas, req.Attempt, "stream")
 	if err != nil {
 		providers.DebugLogf("StreamChat: error: %v", err)
 		return nil, err
@@ -427,6 +427,13 @@ func buildAnthropicRequestWithSupport(req providers.ChatRequest, maxTokens int, 
 			break
 		}
 	}
+	useDefaultBetas := true
+	for _, key := range []string{"anthropic_default_betas", "anthropicDefaultBetas"} {
+		if enabled, ok := providerOptionBool(req.ProviderOptions[key]); ok {
+			useDefaultBetas = enabled
+			break
+		}
+	}
 
 	cacheTTL := ""
 	if ttlVal, ok := req.ProviderOptions["cacheTTL"].(string); ok {
@@ -443,10 +450,11 @@ func buildAnthropicRequestWithSupport(req providers.ChatRequest, maxTokens int, 
 	}
 
 	payload := anthropicRequest{
-		Model:     req.Model,
-		MaxTokens: maxTokens,
-		Messages:  make([]anthropicMessage, 0, len(req.Messages)),
-		Stream:    stream,
+		Model:           req.Model,
+		MaxTokens:       maxTokens,
+		Messages:        make([]anthropicMessage, 0, len(req.Messages)),
+		Stream:          stream,
+		UseDefaultBetas: useDefaultBetas,
 	}
 	if toolSearchEnabled {
 		payload.Betas = append(payload.Betas, toolSearchBetaHeader1P)
@@ -957,6 +965,7 @@ func (c *Client) doSingleMessagesRequest(
 	ctx context.Context,
 	httpClient *http.Client,
 	body []byte,
+	useDefaultBetas bool,
 	extraBetas []string,
 	attempt providers.InferenceAttempt,
 	mode string,
@@ -973,14 +982,16 @@ func (c *Client) doSingleMessagesRequest(
 		httpReq.Header.Set("Authorization", "Bearer "+c.authToken)
 	}
 	httpReq.Header.Set("anthropic-version", defaultAnthropicVersion)
-	// Beta headers required for certain Anthropic API features.
-	// The proxy routes requests based on these headers; missing
-	// ones can cause "Invalid request data" or 503 on certain
-	// Console accounts.
-	betas := []string{
-		"interleaved-thinking-2025-05-14",
-		"prompt-caching-2024-07-31",
-		"token-efficient-tools-2026-03-28",
+	// Keep the established Anthropic feature betas by default. Compatible
+	// endpoints can disable this first-party set through model metadata while
+	// retaining OAuth, request-specific, and explicitly configured betas below.
+	var betas []string
+	if useDefaultBetas {
+		betas = []string{
+			"interleaved-thinking-2025-05-14",
+			"prompt-caching-2024-07-31",
+			"token-efficient-tools-2026-03-28",
+		}
 	}
 	if c.authToken != "" {
 		betas = append(betas, "oauth-2025-04-20")
@@ -996,7 +1007,9 @@ func (c *Client) doSingleMessagesRequest(
 		}
 		httpReq.Header.Set(k, v)
 	}
-	httpReq.Header.Set("anthropic-beta", strings.Join(betas, ","))
+	if len(betas) > 0 {
+		httpReq.Header.Set("anthropic-beta", strings.Join(betas, ","))
+	}
 
 	lease, err := c.coordinator.AcquireForAttempt(ctx, c.providerScope, attempt)
 	if err != nil {
@@ -1625,20 +1638,21 @@ func splitAnthropicBetas(header string) []string {
 }
 
 type anthropicRequest struct {
-	Model        string                 `json:"model"`
-	System       any                    `json:"system,omitempty"`
-	MaxTokens    int                    `json:"max_tokens"`
-	Temperature  *float64               `json:"temperature,omitempty"`
-	TopP         *float64               `json:"top_p,omitempty"`
-	TopK         *int                   `json:"top_k,omitempty"`
-	Messages     []anthropicMessage     `json:"messages"`
-	Tools        []anthropicTool        `json:"tools,omitempty"`
-	ToolChoice   any                    `json:"tool_choice,omitempty"`
-	Stream       bool                   `json:"stream,omitempty"`
-	Speed        string                 `json:"speed,omitempty"`
-	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
-	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
-	Betas        []string               `json:"-"`
+	Model           string                 `json:"model"`
+	System          any                    `json:"system,omitempty"`
+	MaxTokens       int                    `json:"max_tokens"`
+	Temperature     *float64               `json:"temperature,omitempty"`
+	TopP            *float64               `json:"top_p,omitempty"`
+	TopK            *int                   `json:"top_k,omitempty"`
+	Messages        []anthropicMessage     `json:"messages"`
+	Tools           []anthropicTool        `json:"tools,omitempty"`
+	ToolChoice      any                    `json:"tool_choice,omitempty"`
+	Stream          bool                   `json:"stream,omitempty"`
+	Speed           string                 `json:"speed,omitempty"`
+	Thinking        *anthropicThinking     `json:"thinking,omitempty"`
+	OutputConfig    *anthropicOutputConfig `json:"output_config,omitempty"`
+	UseDefaultBetas bool                   `json:"-"`
+	Betas           []string               `json:"-"`
 }
 
 // anthropicThinking configures extended thinking.

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -42,6 +42,12 @@ func TestChat_TextResponse(t *testing.T) {
 		if r.Header.Get("x-api-key") != "test-key" {
 			t.Fatalf("missing api key header")
 		}
+		betas := r.Header.Get("anthropic-beta")
+		for _, expected := range []string{"interleaved-thinking-2025-05-14", "prompt-caching-2024-07-31", "token-efficient-tools-2026-03-28"} {
+			if !strings.Contains(betas, expected) {
+				t.Fatalf("default Anthropic beta header %q missing from %q", expected, betas)
+			}
+		}
 		w.Header().Set("content-type", "application/json")
 		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"hello"}]}`))
 	}))
@@ -168,6 +174,34 @@ func TestChat_ToolSearchNativeMergesConfiguredBetaHeader(t *testing.T) {
 			{Name: "tool_search", InputSchema: map[string]any{"type": "object"}},
 		},
 		ProviderOptions: map[string]any{"anthropicToolSearch": true},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
+func TestChat_DisablingDefaultBetasKeepsConfiguredBetaHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("anthropic-beta"); got != "fast-mode-2026-02-01" {
+			t.Fatalf("configured beta header = %q, want only fast mode", got)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+		Headers: map[string]string{"anthropic-beta": "fast-mode-2026-02-01"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = client.Chat(context.Background(), providers.ChatRequest{
+		Model:           "compatible-model",
+		Messages:        []providers.ChatMessage{{Role: "user", Content: "hello"}},
+		ProviderOptions: map[string]any{"anthropic_default_betas": false},
 	})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
@@ -3042,6 +3076,9 @@ func TestKimiK3MultiRoundToolReplay(t *testing.T) {
 		}
 		if got := r.Header.Get("User-Agent"); got != "KimiCLI/1.5" {
 			t.Fatalf("unexpected K3 User-Agent: %q", got)
+		}
+		if got := r.Header.Get("anthropic-beta"); got != "" {
+			t.Fatalf("Kimi request inherited Anthropic beta headers: %q", got)
 		}
 		var body anthropicRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
+func TestAnthropicMessagesURL(t *testing.T) {
+	tests := map[string]string{
+		"https://api.anthropic.com":           "https://api.anthropic.com/v1/messages",
+		"https://api.kimi.com/coding/":        "https://api.kimi.com/coding/v1/messages",
+		"https://api.kimi.com/coding/v1":      "https://api.kimi.com/coding/v1/messages",
+		"https://proxy.example/v1/messages":   "https://proxy.example/v1/messages",
+		"https://proxy.example/anthropic/v1/": "https://proxy.example/anthropic/v1/messages",
+	}
+	for baseURL, want := range tests {
+		if got := anthropicMessagesURL(baseURL); got != want {
+			t.Errorf("anthropicMessagesURL(%q) = %q, want %q", baseURL, got, want)
+		}
+	}
+}
+
 func TestChat_TextResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" {
@@ -2936,7 +2951,7 @@ func TestThinkingReplayModes(t *testing.T) {
 	if got := kinds(full); len(got) != 3 || got[0] != "thinking" || got[1] != "redacted_thinking" || got[2] != "text" {
 		t.Fatalf("full replay blocks = %v, want [thinking redacted_thinking text]", got)
 	}
-	if full.Messages[1].Content[0].Signature != "sig-abc" {
+	if signature := full.Messages[1].Content[0].Signature; signature == nil || *signature != "sig-abc" {
 		t.Fatalf("full replay must preserve signature")
 	}
 
@@ -2955,6 +2970,55 @@ func TestThinkingReplayModes(t *testing.T) {
 
 	if got := kinds(build("bogus")); got[0] != "thinking" {
 		t.Fatalf("invalid mode must fall back to full, got %v", got)
+	}
+}
+
+func TestEmptyThinkingSignatureCompatibility(t *testing.T) {
+	history := []providers.ChatMessage{
+		{Role: "user", Content: "question"},
+		{Role: "assistant", ReasoningBlocks: []providers.ReasoningBlock{
+			{Type: "thinking", Thinking: "internal reasoning", Signature: ""},
+		}},
+		{Role: "user", Content: "follow-up"},
+	}
+	build := func(options map[string]any) anthropicRequest {
+		req, err := buildAnthropicRequest(providers.ChatRequest{
+			Model: "compatible-model", Messages: history, ProviderOptions: options,
+		}, 1024, false)
+		if err != nil {
+			t.Fatalf("buildAnthropicRequest: %v", err)
+		}
+		return req
+	}
+
+	withoutCompat := build(nil)
+	withoutCompatBlock := withoutCompat.Messages[1].Content[0]
+	if withoutCompatBlock.Type != "thinking" || withoutCompatBlock.Signature != nil {
+		t.Fatalf("default behavior must omit an empty signature, got %+v", withoutCompatBlock)
+	}
+	withoutCompatJSON, err := json.Marshal(withoutCompatBlock)
+	if err != nil {
+		t.Fatalf("marshal default thinking block: %v", err)
+	}
+	if strings.Contains(string(withoutCompatJSON), `"signature"`) {
+		t.Fatalf("default behavior must omit signature from JSON, got %s", withoutCompatJSON)
+	}
+
+	withCompat := build(map[string]any{"allow_empty_signature": true})
+	block := withCompat.Messages[1].Content[0]
+	if block.Type != "thinking" || block.Signature == nil || *block.Signature != "" {
+		t.Fatalf("compatible endpoint must preserve explicit empty signature, got %+v", block)
+	}
+	encoded, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal thinking block: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("decode thinking block: %v", err)
+	}
+	if signature, present := raw["signature"]; !present || signature != "" {
+		t.Fatalf("expected explicit empty signature in JSON, got %s", encoded)
 	}
 }
 

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -12,7 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blueberrycongee/wuu/internal/config"
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
+	"github.com/blueberrycongee/wuu/internal/modelcatalog"
+	"github.com/blueberrycongee/wuu/internal/modelvariant"
 	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
@@ -3019,6 +3022,98 @@ func TestEmptyThinkingSignatureCompatibility(t *testing.T) {
 	}
 	if signature, present := raw["signature"]; !present || signature != "" {
 		t.Fatalf("expected explicit empty signature in JSON, got %s", encoded)
+	}
+}
+
+func TestKimiK3MultiRoundToolReplay(t *testing.T) {
+	providerName, provider := modelcatalog.EnrichProvider("kimi-for-coding", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "k3",
+	}, "k3")
+	selection := modelvariant.ResolveForProvider(providerName, provider, "k3", "", "")
+	model := provider.Models["k3"]
+	if model.Limit == nil {
+		t.Fatal("expected K3 limits")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Fatalf("unexpected K3 path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("User-Agent"); got != "KimiCLI/1.5" {
+			t.Fatalf("unexpected K3 User-Agent: %q", got)
+		}
+		var body anthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode K3 request: %v", err)
+		}
+		if body.Model != "k3" || body.MaxTokens != 131_072 {
+			t.Fatalf("unexpected K3 model request: model=%q max_tokens=%d", body.Model, body.MaxTokens)
+		}
+		if body.Thinking == nil || body.Thinking.Type != "adaptive" || body.Thinking.Display != "summarized" {
+			t.Fatalf("unexpected K3 thinking config: %+v", body.Thinking)
+		}
+		if body.OutputConfig == nil || body.OutputConfig.Effort != "max" {
+			t.Fatalf("unexpected K3 output config: %+v", body.OutputConfig)
+		}
+		if len(body.Messages) != 3 {
+			t.Fatalf("unexpected K3 message count: %+v", body.Messages)
+		}
+		assistant := body.Messages[1]
+		if assistant.Role != "assistant" || len(assistant.Content) != 3 {
+			t.Fatalf("unexpected K3 assistant replay: %+v", assistant)
+		}
+		thinking := assistant.Content[0]
+		if thinking.Type != "thinking" || thinking.Thinking == nil || *thinking.Thinking != "inspect the repository" || thinking.Signature == nil || *thinking.Signature != "" {
+			t.Fatalf("unexpected K3 thinking replay: %+v", thinking)
+		}
+		if redacted := assistant.Content[1]; redacted.Type != "redacted_thinking" || redacted.Data != "opaque-reasoning" {
+			t.Fatalf("unexpected K3 redacted replay: %+v", redacted)
+		}
+		if toolUse := assistant.Content[2]; toolUse.Type != "tool_use" || toolUse.ID != "call_1" || toolUse.Name != "list_files" {
+			t.Fatalf("unexpected K3 tool replay: %+v", toolUse)
+		}
+		if followUp := body.Messages[2].Content; len(followUp) != 2 || followUp[0].Type != "tool_result" || followUp[0].ToolUseID != "call_1" || followUp[1].Type != "text" {
+			t.Fatalf("unexpected K3 tool result sequence: %+v", followUp)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		BaseURL:   server.URL,
+		APIKey:    "test-key",
+		Headers:   provider.Headers,
+		MaxTokens: model.Limit.Output,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	resp, err := client.Chat(context.Background(), providers.ChatRequest{
+		Model: "k3",
+		Messages: []providers.ChatMessage{
+			{Role: "user", Content: "inspect the repository"},
+			{
+				Role: "assistant",
+				ReasoningBlocks: []providers.ReasoningBlock{
+					{Type: "thinking", Thinking: "inspect the repository", Signature: ""},
+					{Type: "redacted_thinking", Data: "opaque-reasoning"},
+				},
+				ToolCalls: []providers.ToolCall{
+					{ID: "call_1", Name: "list_files", Arguments: `{}`},
+				},
+			},
+			{Role: "tool", ToolCallID: "call_1", Content: "README.md"},
+			{Role: "user", Content: "summarize it"},
+		},
+		ProviderOptions: selection.ProviderOptions,
+	})
+	if err != nil {
+		t.Fatalf("K3 chat: %v", err)
+	}
+	if resp.Content != "done" {
+		t.Fatalf("unexpected K3 response: %+v", resp)
 	}
 }
 

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -3154,6 +3154,39 @@ func TestKimiK3MultiRoundToolReplay(t *testing.T) {
 	}
 }
 
+func TestMiniMaxCatalogDefaultDoesNotSendAnthropicBetas(t *testing.T) {
+	providerName, provider := modelcatalog.EnrichProvider("minimax", config.ProviderConfig{
+		Type:  "anthropic",
+		Model: "MiniMax-M3",
+	}, "MiniMax-M3")
+	selection := modelvariant.ResolveForProvider(providerName, provider, "MiniMax-M3", "", "")
+	if got := selection.ProviderOptions["anthropic_default_betas"]; got != false {
+		t.Fatalf("anthropic_default_betas = %#v, want false", got)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("anthropic-beta"); got != "" {
+			t.Fatalf("MiniMax request inherited Anthropic beta headers: %q", got)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{BaseURL: server.URL, APIKey: "test-key", MaxTokens: 1024})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = client.Chat(context.Background(), providers.ChatRequest{
+		Model:           "MiniMax-M3",
+		Messages:        []providers.ChatMessage{{Role: "user", Content: "hello"}},
+		ProviderOptions: selection.ProviderOptions,
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+}
+
 // TestTemperatureGating locks the per-model temperature switch and the
 // thinking mutual exclusion: "temperature": false (arriving as the
 // temperatureSupported option) or an active thinking config must drop the

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -3154,7 +3154,7 @@ func TestKimiK3MultiRoundToolReplay(t *testing.T) {
 	}
 }
 
-func TestMiniMaxCatalogDefaultDoesNotSendAnthropicBetas(t *testing.T) {
+func TestMiniMaxCatalogPreservesDocumentedFeaturesWithoutAnthropicBetas(t *testing.T) {
 	providerName, provider := modelcatalog.EnrichProvider("minimax", config.ProviderConfig{
 		Type:  "anthropic",
 		Model: "MiniMax-M3",
@@ -3168,6 +3168,19 @@ func TestMiniMaxCatalogDefaultDoesNotSendAnthropicBetas(t *testing.T) {
 		if got := r.Header.Get("anthropic-beta"); got != "" {
 			t.Fatalf("MiniMax request inherited Anthropic beta headers: %q", got)
 		}
+		var body anthropicRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode MiniMax request: %v", err)
+		}
+		if body.Thinking == nil || body.Thinking.Type != "adaptive" {
+			t.Fatalf("MiniMax thinking = %+v", body.Thinking)
+		}
+		if len(body.Tools) != 1 || body.Tools[0].Name != "list_files" {
+			t.Fatalf("MiniMax tools = %+v", body.Tools)
+		}
+		if len(body.Messages) != 1 || len(body.Messages[0].Content) != 1 || body.Messages[0].Content[0].CacheControl == nil {
+			t.Fatalf("MiniMax cache_control marker missing: %+v", body.Messages)
+		}
 		w.Header().Set("content-type", "application/json")
 		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}]}`))
 	}))
@@ -3180,6 +3193,8 @@ func TestMiniMaxCatalogDefaultDoesNotSendAnthropicBetas(t *testing.T) {
 	_, err = client.Chat(context.Background(), providers.ChatRequest{
 		Model:           "MiniMax-M3",
 		Messages:        []providers.ChatMessage{{Role: "user", Content: "hello"}},
+		Tools:           []providers.ToolDefinition{{Name: "list_files", InputSchema: map[string]any{"type": "object"}}},
+		CacheHint:       &providers.CacheHint{StablePrefixMessages: 1},
 		ProviderOptions: selection.ProviderOptions,
 	})
 	if err != nil {

--- a/internal/providers/openai/client.go
+++ b/internal/providers/openai/client.go
@@ -109,19 +109,18 @@ type ClientConfig struct {
 
 // Client sends tool-enabled chat requests to OpenAI-compatible APIs.
 type Client struct {
-	baseURL              string
-	wireAPI              string
-	apiKey               string
-	headers              map[string]string
-	httpClient           *http.Client
-	promptCacheKeyFormat promptCacheKeyFormat
-	reasoningFormat      reasoningEffortFormat
-	streamConfig         providers.StreamTransportConfig
-	coordinator          *providers.ProviderCoordinator
-	providerScope        providers.ProviderScope
-	responsesStore       *bool
-	responsesTransport   providers.StreamTransportMode
-	responsesWSCache     *ResponsesWebSocketCache
+	baseURL            string
+	wireAPI            string
+	apiKey             string
+	headers            map[string]string
+	httpClient         *http.Client
+	reasoningFormat    reasoningEffortFormat
+	streamConfig       providers.StreamTransportConfig
+	coordinator        *providers.ProviderCoordinator
+	providerScope      providers.ProviderScope
+	responsesStore     *bool
+	responsesTransport providers.StreamTransportMode
+	responsesWSCache   *ResponsesWebSocketCache
 }
 
 // New creates an OpenAI-compatible client.
@@ -155,19 +154,18 @@ func New(cfg ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		baseURL:              strings.TrimRight(cfg.BaseURL, "/"),
-		wireAPI:              wireAPI,
-		apiKey:               cfg.APIKey,
-		headers:              cloneHeaders(cfg.Headers),
-		httpClient:           hc,
-		promptCacheKeyFormat: detectPromptCacheKeyFormat(cfg.BaseURL, cfg.Headers),
-		reasoningFormat:      detectReasoningEffortFormat(cfg.BaseURL),
-		streamConfig:         streamTransportConfig(cfg.StreamConfig),
-		coordinator:          cfg.Coordinator,
-		providerScope:        providerScope,
-		responsesStore:       cfg.ResponsesStore,
-		responsesTransport:   responsesTransport,
-		responsesWSCache:     cfg.ResponsesWebSocketCache,
+		baseURL:            strings.TrimRight(cfg.BaseURL, "/"),
+		wireAPI:            wireAPI,
+		apiKey:             cfg.APIKey,
+		headers:            cloneHeaders(cfg.Headers),
+		httpClient:         hc,
+		reasoningFormat:    detectReasoningEffortFormat(cfg.BaseURL),
+		streamConfig:       streamTransportConfig(cfg.StreamConfig),
+		coordinator:        cfg.Coordinator,
+		providerScope:      providerScope,
+		responsesStore:     cfg.ResponsesStore,
+		responsesTransport: responsesTransport,
+		responsesWSCache:   cfg.ResponsesWebSocketCache,
 	}, nil
 }
 
@@ -209,7 +207,7 @@ func (c *Client) Chat(ctx context.Context, req providers.ChatRequest) (providers
 		Options:         provideroptions.Clone(req.ProviderOptions),
 	}
 	applyReasoningEffort(&payload, req.Effort, c.reasoningFormat)
-	applyPromptCacheKey(&payload, req.CacheHint, c.promptCacheKeyFormat)
+	applyPromptCacheKey(&payload, req.CacheHint, req.ProviderOptions)
 
 	prepared, err := providers.PrepareMessagesForProviderRequest(req.Provider, req.Model, req.Messages)
 	if err != nil {
@@ -365,7 +363,7 @@ func (c *Client) StreamChat(ctx context.Context, req providers.ChatRequest) (<-c
 		Options:         provideroptions.Clone(req.ProviderOptions),
 	}
 	applyReasoningEffort(&payload, req.Effort, c.reasoningFormat)
-	applyPromptCacheKey(&payload, req.CacheHint, c.promptCacheKeyFormat)
+	applyPromptCacheKey(&payload, req.CacheHint, req.ProviderOptions)
 	prepared, err := providers.PrepareMessagesForProviderRequest(req.Provider, req.Model, req.Messages)
 	if err != nil {
 		return nil, err
@@ -919,7 +917,7 @@ func marshalChatCompletionsRequest(payload chatCompletionsRequest) ([]byte, erro
 		Temperature     float64          `json:"temperature,omitempty"`
 		MaxTokens       int              `json:"max_tokens,omitempty"`
 		Stream          bool             `json:"stream,omitempty"`
-		PromptCacheKey  string           `json:"promptCacheKey,omitempty"`
+		PromptCacheKey  string           `json:"prompt_cache_key,omitempty"`
 		ReasoningEffort string           `json:"reasoning_effort,omitempty"`
 		Reasoning       *reasoningConfig `json:"reasoning,omitempty"`
 	}
@@ -948,58 +946,23 @@ func marshalChatCompletionsRequest(payload chatCompletionsRequest) ([]byte, erro
 	if err := json.Unmarshal(raw, &object); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(payload.AltCacheKey) != "" {
-		object["prompt_cache_key"] = payload.AltCacheKey
-	}
 	mergeChatProviderOptions(object, payload.Options, payload.ReasoningFormat)
 	return json.Marshal(object)
 }
 
-func applyPromptCacheKey(payload *chatCompletionsRequest, hint *providers.CacheHint, format promptCacheKeyFormat) {
+func applyPromptCacheKey(payload *chatCompletionsRequest, hint *providers.CacheHint, options map[string]any) {
 	if payload == nil || hint == nil {
+		return
+	}
+	supported, _ := options["promptCacheKeySupported"].(bool)
+	if !supported {
 		return
 	}
 	key := clampPromptCacheKey(hint.PromptCacheKey)
 	if key == "" {
 		return
 	}
-	switch format {
-	case promptCacheKeySnake:
-		payload.AltCacheKey = key
-	default:
-		payload.PromptCacheKey = key
-	}
-}
-
-type promptCacheKeyFormat int
-
-const (
-	promptCacheKeyCamel promptCacheKeyFormat = iota
-	promptCacheKeySnake
-)
-
-func detectPromptCacheKeyFormat(baseURL string, headers map[string]string) promptCacheKeyFormat {
-	if promptCacheKeyHeaderPrefersSnake(headers) {
-		return promptCacheKeySnake
-	}
-	host := strings.ToLower(strings.TrimSpace(baseURL))
-	if strings.Contains(host, "openrouter.ai") {
-		return promptCacheKeySnake
-	}
-	return promptCacheKeyCamel
-}
-
-func promptCacheKeyHeaderPrefersSnake(headers map[string]string) bool {
-	for k, v := range headers {
-		key := strings.ToLower(strings.TrimSpace(k))
-		value := strings.ToLower(strings.TrimSpace(v))
-		if key == "x-openrouter-provider" || key == "http-referer" || key == "x-title" {
-			if value != "" {
-				return true
-			}
-		}
-	}
-	return false
+	payload.PromptCacheKey = key
 }
 
 func applyReasoningEffort(payload *chatCompletionsRequest, effort string, format reasoningEffortFormat) {
@@ -1044,7 +1007,7 @@ func mergeChatProviderOptions(object map[string]any, options map[string]any, for
 		case "maxOutputTokens":
 			object["max_tokens"] = value
 		case "promptCacheKey":
-			object["promptCacheKey"] = value
+			object["prompt_cache_key"] = value
 		case "temperature":
 			if _, exists := object["temperature"]; !exists {
 				object["temperature"] = value
@@ -1069,7 +1032,7 @@ func mergeChatProviderOptions(object map[string]any, options map[string]any, for
 func chatProviderOptionIsAISDKOnly(key string) bool {
 	switch key {
 	case "toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway",
-		"temperatureSupported", "temperature_supported":
+		"temperatureSupported", "temperature_supported", "promptCacheKeySupported":
 		return true
 	default:
 		return false
@@ -1108,8 +1071,7 @@ type chatCompletionsRequest struct {
 	MaxTokens       int                   `json:"max_tokens,omitempty"`
 	Stream          bool                  `json:"stream,omitempty"`
 	StreamOptions   *streamOptions        `json:"stream_options,omitempty"`
-	PromptCacheKey  string                `json:"promptCacheKey,omitempty"`
-	AltCacheKey     string                `json:"prompt_cache_key,omitempty"`
+	PromptCacheKey  string                `json:"prompt_cache_key,omitempty"`
 	ReasoningEffort string                `json:"reasoning_effort,omitempty"`
 	Reasoning       *reasoningConfig      `json:"reasoning,omitempty"`
 	ReasoningFormat reasoningEffortFormat `json:"-"`

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blueberrycongee/wuu/internal/config"
+	"github.com/blueberrycongee/wuu/internal/modelcatalog"
+	"github.com/blueberrycongee/wuu/internal/modelvariant"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/toolresult"
 )
@@ -317,6 +320,85 @@ func TestChat_OmitsPromptCacheKeyForUnsupportedCompatibleProvider(t *testing.T) 
 	})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
+	}
+}
+
+func TestCatalogOpenAICompatibleWireContracts(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerID   string
+		model        string
+		variant      string
+		wantEffort   string
+		wantThinking string
+	}{
+		{
+			name:         "GLM coding plan",
+			providerID:   "zai-coding-plan",
+			model:        "glm-5.2",
+			wantThinking: "enabled",
+		},
+		{
+			name:         "DeepSeek V4",
+			providerID:   "deepseek",
+			model:        "deepseek-v4-pro",
+			variant:      "high",
+			wantEffort:   "high",
+			wantThinking: "enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			providerName, provider := modelcatalog.EnrichProvider(tc.providerID, config.ProviderConfig{
+				Type:  "openai-compatible",
+				Model: tc.model,
+			}, tc.model)
+			selection := modelvariant.ResolveForProvider(providerName, provider, tc.model, tc.variant, "")
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				if body["model"] != tc.model {
+					t.Fatalf("model = %#v", body["model"])
+				}
+				thinking, ok := body["thinking"].(map[string]any)
+				if !ok || thinking["type"] != tc.wantThinking {
+					t.Fatalf("thinking = %#v; body=%#v", body["thinking"], body)
+				}
+				if got, _ := body["reasoning_effort"].(string); got != tc.wantEffort {
+					t.Fatalf("reasoning_effort = %q, want %q", got, tc.wantEffort)
+				}
+				if _, exists := body["prompt_cache_key"]; exists {
+					t.Fatalf("compatible provider inherited prompt_cache_key: %#v", body)
+				}
+				if tools, ok := body["tools"].([]any); !ok || len(tools) != 1 {
+					t.Fatalf("tools = %#v", body["tools"])
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+			}))
+			defer server.Close()
+
+			client, err := New(ClientConfig{BaseURL: server.URL, APIKey: "test-key"})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			_, err = client.Chat(context.Background(), providers.ChatRequest{
+				Provider:        providerName,
+				Model:           tc.model,
+				Messages:        []providers.ChatMessage{{Role: "user", Content: "inspect the repository"}},
+				Tools:           []providers.ToolDefinition{{Name: "list_files", InputSchema: map[string]any{"type": "object"}}},
+				CacheHint:       &providers.CacheHint{PromptCacheKey: "thread-cache-key"},
+				ProviderOptions: selection.ProviderOptions,
+			})
+			if err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -283,7 +283,7 @@ func TestChat_SendsOpenRouterProviderOptionsShape(t *testing.T) {
 	}
 }
 
-func TestChat_SendsPromptCacheKeyForOpenAICompatible(t *testing.T) {
+func TestChat_OmitsPromptCacheKeyForUnsupportedCompatibleProvider(t *testing.T) {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -291,11 +291,11 @@ func TestChat_SendsPromptCacheKeyForOpenAICompatible(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
-		if body["promptCacheKey"] != "cache-key-1" {
-			t.Fatalf("expected promptCacheKey, got %#v", body["promptCacheKey"])
+		if _, exists := body["promptCacheKey"]; exists {
+			t.Fatalf("did not expect promptCacheKey: %#v", body)
 		}
 		if _, exists := body["prompt_cache_key"]; exists {
-			t.Fatalf("did not expect prompt_cache_key on standard OpenAI payload: %#v", body["prompt_cache_key"])
+			t.Fatalf("did not expect prompt_cache_key: %#v", body)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -328,7 +328,7 @@ func TestChat_FiltersUnsupportedProviderOptions(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
-		for _, key := range []string{"include", "toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway", "temperatureSupported", "temperature_supported"} {
+		for _, key := range []string{"include", "toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway", "temperatureSupported", "temperature_supported", "promptCacheKeySupported"} {
 			if _, exists := body[key]; exists {
 				t.Fatalf("chat payload should filter %s: %#v", key, body)
 			}
@@ -351,15 +351,16 @@ func TestChat_FiltersUnsupportedProviderOptions(t *testing.T) {
 		Model:    "gpt-test",
 		Messages: []providers.ChatMessage{{Role: "user", Content: "hello"}},
 		ProviderOptions: map[string]any{
-			"include":               []any{"reasoning.encrypted_content"},
-			"toolStreaming":         false,
-			"thinkingConfig":        map[string]any{"includeThoughts": true},
-			"reasoningConfig":       map[string]any{"type": "enabled"},
-			"modelParams":           map[string]any{"reasoning_effort": "high"},
-			"gateway":               map[string]any{"caching": "auto"},
-			"temperatureSupported":  false,
-			"temperature_supported": false,
-			"metadata":              map[string]any{"eval": "provider-options"},
+			"include":                 []any{"reasoning.encrypted_content"},
+			"toolStreaming":           false,
+			"thinkingConfig":          map[string]any{"includeThoughts": true},
+			"reasoningConfig":         map[string]any{"type": "enabled"},
+			"modelParams":             map[string]any{"reasoning_effort": "high"},
+			"gateway":                 map[string]any{"caching": "auto"},
+			"promptCacheKeySupported": true,
+			"temperatureSupported":    false,
+			"temperature_supported":   false,
+			"metadata":                map[string]any{"eval": "provider-options"},
 		},
 	})
 	if err != nil {
@@ -470,7 +471,7 @@ func TestChat_SendsSnakeCasePromptCacheKeyForOpenRouter(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := New(ClientConfig{BaseURL: server.URL, APIKey: "test-key", Headers: map[string]string{"HTTP-Referer": "https://openrouter.ai/app"}})
+	client, err := New(ClientConfig{BaseURL: server.URL, APIKey: "test-key"})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -480,7 +481,8 @@ func TestChat_SendsSnakeCasePromptCacheKeyForOpenRouter(t *testing.T) {
 		Messages: []providers.ChatMessage{
 			{Role: "user", Content: "hello"},
 		},
-		CacheHint: &providers.CacheHint{PromptCacheKey: "cache-key-2"},
+		CacheHint:       &providers.CacheHint{PromptCacheKey: "cache-key-2"},
+		ProviderOptions: map[string]any{"promptCacheKeySupported": true},
 	})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
@@ -671,20 +673,20 @@ func TestChat_SendsFileContentParts(t *testing.T) {
 	}
 }
 
-func TestChat_SendsPromptCacheKeyAliases(t *testing.T) {
+func TestChat_SendsSupportedPromptCacheKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			PromptCacheKey string `json:"promptCacheKey"`
-			AltCacheKey    string `json:"prompt_cache_key"`
+			CamelCacheKey  string `json:"promptCacheKey"`
+			PromptCacheKey string `json:"prompt_cache_key"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
 		if body.PromptCacheKey != "cache-key-1" {
-			t.Fatalf("unexpected promptCacheKey: %q", body.PromptCacheKey)
+			t.Fatalf("unexpected prompt_cache_key: %q", body.PromptCacheKey)
 		}
-		if body.AltCacheKey != "" {
-			t.Fatalf("unexpected prompt_cache_key on OpenAI-compatible payload: %q", body.AltCacheKey)
+		if body.CamelCacheKey != "" {
+			t.Fatalf("unexpected promptCacheKey: %q", body.CamelCacheKey)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -702,7 +704,8 @@ func TestChat_SendsPromptCacheKeyAliases(t *testing.T) {
 		Messages: []providers.ChatMessage{
 			{Role: "user", Content: "hello"},
 		},
-		CacheHint: &providers.CacheHint{PromptCacheKey: "cache-key-1"},
+		CacheHint:       &providers.CacheHint{PromptCacheKey: "cache-key-1"},
+		ProviderOptions: map[string]any{"promptCacheKeySupported": true},
 	})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
@@ -2425,7 +2428,7 @@ func TestResponsesChat_FiltersUnsupportedProviderOptions(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode request body: %v", err)
 		}
-		for _, key := range []string{"toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway", "usage", "chat_template_args", "enable_thinking", "thinking", "temperatureSupported", "temperature_supported"} {
+		for _, key := range []string{"toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway", "usage", "chat_template_args", "enable_thinking", "thinking", "temperatureSupported", "temperature_supported", "promptCacheKeySupported"} {
 			if _, exists := body[key]; exists {
 				t.Fatalf("responses payload should filter %s: %#v", key, body)
 			}
@@ -2451,19 +2454,20 @@ func TestResponsesChat_FiltersUnsupportedProviderOptions(t *testing.T) {
 		Model:    "gpt-test",
 		Messages: []providers.ChatMessage{{Role: "user", Content: "hello"}},
 		ProviderOptions: map[string]any{
-			"include":               []any{"reasoning.encrypted_content"},
-			"toolStreaming":         false,
-			"thinkingConfig":        map[string]any{"includeThoughts": true},
-			"reasoningConfig":       map[string]any{"type": "enabled"},
-			"modelParams":           map[string]any{"reasoning_effort": "high"},
-			"gateway":               map[string]any{"caching": "auto"},
-			"usage":                 map[string]any{"include": true},
-			"chat_template_args":    map[string]any{"enable_thinking": true},
-			"enable_thinking":       true,
-			"thinking":              map[string]any{"type": "enabled"},
-			"temperatureSupported":  false,
-			"temperature_supported": false,
-			"metadata":              map[string]any{"eval": "provider-options"},
+			"include":                 []any{"reasoning.encrypted_content"},
+			"toolStreaming":           false,
+			"thinkingConfig":          map[string]any{"includeThoughts": true},
+			"reasoningConfig":         map[string]any{"type": "enabled"},
+			"modelParams":             map[string]any{"reasoning_effort": "high"},
+			"gateway":                 map[string]any{"caching": "auto"},
+			"usage":                   map[string]any{"include": true},
+			"chat_template_args":      map[string]any{"enable_thinking": true},
+			"enable_thinking":         true,
+			"thinking":                map[string]any{"type": "enabled"},
+			"promptCacheKeySupported": true,
+			"temperatureSupported":    false,
+			"temperature_supported":   false,
+			"metadata":                map[string]any{"eval": "provider-options"},
 		},
 	})
 	if err != nil {

--- a/internal/providers/openai/responses.go
+++ b/internal/providers/openai/responses.go
@@ -288,7 +288,7 @@ func responsesProviderOptionUnsupported(key string) bool {
 	switch key {
 	case "toolStreaming", "thinkingConfig", "reasoningConfig", "modelParams", "gateway",
 		"usage", "chat_template_args", "enable_thinking", "thinking",
-		"temperatureSupported", "temperature_supported":
+		"temperatureSupported", "temperature_supported", "promptCacheKeySupported":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

- add Kimi For Coding / K3 as a built-in Anthropic Messages model with 1,048,576 context, 131,072 max output, and a max-only adaptive-thinking variant
- preserve explicit empty thinking signatures for compatible models while keeping the default Anthropic serialization unchanged
- normalize Anthropic Messages endpoints so base URLs with or without a trailing `/v1` resolve to one `/v1/messages` path
- send the Kimi coding `User-Agent` and cover adaptive thinking, redacted thinking, tool-use ordering, and multi-round replay

## Verification

- `go test ./...`
- `make check-go`
- live Kimi endpoint probe not run because `KIMI_API_KEY` is unavailable in this environment

Fixes #71