### PR TITLE
fix(desktop): restore usage heatmap intensity

### DIFF
--- a/desktop/src/renderer/SettingsView.test.tsx
+++ b/desktop/src/renderer/SettingsView.test.tsx
@@ -1015,6 +1015,16 @@ describe("SettingsView About section", () => {
       core: undefined,
       desktop: { version: "0.0.0-test", date: "1970-01-01T00:00:00Z" },
     });
+    const heatmapDates = Array.from({ length: 4 }, (_, index) => {
+      const date = new Date();
+      date.setHours(12, 0, 0, 0);
+      date.setDate(date.getDate() - (3 - index));
+      return [
+        date.getFullYear(),
+        String(date.getMonth() + 1).padStart(2, "0"),
+        String(date.getDate()).padStart(2, "0"),
+      ].join("-");
+    });
     const usage: SettingsUsageResponse = {
       range: "all",
       total_sessions: 1,
@@ -1043,18 +1053,16 @@ describe("SettingsView About section", () => {
           sessions: 1,
         },
       ],
-      days: [
-        {
-          date: "2026-06-18",
-          input_tokens: 1000,
-          output_tokens: 200,
-          cache_creation_tokens: 20,
-          cache_read_tokens: 50,
-          cache_hit_rate: 50 / 1050,
-          turns: 1,
-          agents: 0,
-        },
-      ],
+      days: heatmapDates.map((date, index) => ({
+        date,
+        input_tokens: (index + 1) * 100,
+        output_tokens: 0,
+        cache_creation_tokens: 20,
+        cache_read_tokens: 50,
+        cache_hit_rate: 0.5,
+        turns: 1,
+        agents: 0,
+      })),
       entries: [
         {
           id: "turn:turn-1",
@@ -1088,7 +1096,16 @@ describe("SettingsView About section", () => {
     expect(rootText()).toContain("5%");
     expect(rootText()).toContain("OpenAI API");
     expect(rootText()).not.toContain("最近记录");
-    expect(container.querySelector(".settings-cache-heatmap")).not.toBeNull();
+    const heatmap = container.querySelector(".settings-usage-heatmap");
+    expect(heatmap).not.toBeNull();
+    expect(heatmap?.getAttribute("aria-label")).toBe("每日用量热力图");
+    expect(
+      heatmapDates.map((date) =>
+        heatmap
+          ?.querySelector<HTMLElement>(`[title^="${date}"]`)
+          ?.getAttribute("data-level"),
+      ),
+    ).toEqual(["1", "2", "3", "4"]);
   });
 });
 

--- a/desktop/src/renderer/SettingsView.tsx
+++ b/desktop/src/renderer/SettingsView.tsx
@@ -2092,7 +2092,7 @@ function SettingsUsagePage({
 }): JSX.Element {
   const { locale, t, formatNumber } = useI18n();
   const ranges: SettingsUsageRange[] = ["all", "7d", "30d", "90d"];
-  const heatmap = usage ? buildCacheHeatmap(usage.days) : [];
+  const heatmap = usage ? buildUsageHeatmap(usage.days) : [];
   const heatmapCols = heatmap.length > 0 ? Math.ceil(heatmap.length / 7) : 12;
 
   // Keep grid height = 7 × cell-size so cells stay square as panel resizes
@@ -2191,8 +2191,8 @@ function SettingsUsagePage({
         {/* Grid */}
         <div
           ref={heatmapRef}
-          className="settings-cache-heatmap"
-          aria-label={t("settings.cacheHeatmap")}
+          className="settings-usage-heatmap"
+          aria-label={t("settings.usageHeatmap")}
           role="grid"
           style={{
             "--heatmap-cols": heatmapCols,
@@ -2201,7 +2201,7 @@ function SettingsUsagePage({
         >
           {heatmap.map((day) => (
             <span
-              className="settings-cache-heatmap-cell"
+              className="settings-usage-heatmap-cell"
               data-level={day.level}
               key={day.date}
               role="gridcell"
@@ -2474,7 +2474,7 @@ function isAnthropicProviderType(type: string | undefined): boolean {
   return normalized === "anthropic" || normalized === "claude" || normalized === "anthropic-official";
 }
 
-type CacheHeatmapCell = SettingsUsageDay & {
+type UsageHeatmapCell = SettingsUsageDay & {
   level: number;
 };
 
@@ -2517,11 +2517,18 @@ function hitRateLevel(rate: number | undefined): number {
   return 4;
 }
 
-function buildCacheHeatmap(days: SettingsUsageDay[]): CacheHeatmapCell[] {
+function buildUsageHeatmap(days: SettingsUsageDay[]): UsageHeatmapCell[] {
   const byDate = new Map(days.map((day) => [day.date, day]));
   const end = startOfLocalDay(new Date());
   const start = startOfWeek(addDays(end, -364));
-  const cells: CacheHeatmapCell[] = [];
+  const startKey = localDateKey(start);
+  const endKey = localDateKey(end);
+  const activeTotals = days
+    .filter((day) => day.date >= startKey && day.date <= endKey)
+    .map(usageTokenTotal)
+    .filter((total) => total > 0)
+    .sort((a, b) => a - b);
+  const cells: UsageHeatmapCell[] = [];
   for (let cursor = start; cursor.getTime() <= end.getTime(); cursor = addDays(cursor, 1)) {
     const date = localDateKey(cursor);
     const day = byDate.get(date) ?? {
@@ -2536,17 +2543,28 @@ function buildCacheHeatmap(days: SettingsUsageDay[]): CacheHeatmapCell[] {
     };
     cells.push({
       ...day,
-      level: heatmapLevel(day),
+      level: usageHeatmapLevel(day, activeTotals),
     });
   }
   return cells;
 }
 
-function heatmapLevel(day: SettingsUsageDay): number {
-  if (!hasUsageDayData(day)) {
+function usageHeatmapLevel(day: SettingsUsageDay, activeTotals: number[]): number {
+  const total = usageTokenTotal(day);
+  if (total <= 0 || activeTotals.length === 0) {
     return 0;
   }
-  return hitRateLevel(day.cache_hit_rate);
+  const upperRank = activeTotals.findLastIndex((candidate) => candidate <= total) + 1;
+  return Math.min(4, Math.max(1, Math.ceil((upperRank / activeTotals.length) * 4)));
+}
+
+function usageTokenTotal(day: SettingsUsageDay): number {
+  return (
+    Math.max(0, day.input_tokens) +
+    Math.max(0, day.output_tokens) +
+    Math.max(0, day.cache_creation_tokens) +
+    Math.max(0, day.cache_read_tokens)
+  );
 }
 
 function hasUsageDayData(day: SettingsUsageDay): boolean {
@@ -2561,7 +2579,7 @@ function hasUsageDayData(day: SettingsUsageDay): boolean {
 }
 
 function formatHeatmapTitle(
-  day: CacheHeatmapCell,
+  day: UsageHeatmapCell,
   t: Translate,
   formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string,
 ): string {

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -183,7 +183,7 @@ export const enUS = {
   "settings.cacheHitRate": "Cache hit rate",
   "settings.activeDays": "Active",
   "settings.dayCount": "{count} days",
-  "settings.cacheHeatmap": "Cache hit rate heatmap",
+  "settings.usageHeatmap": "Daily usage heatmap",
   "settings.less": "Less",
   "settings.more": "More",
   "settings.modelUsage": "Model usage",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -181,7 +181,7 @@ export const zhCN = {
   "settings.cacheHitRate": "缓存命中率",
   "settings.activeDays": "活跃",
   "settings.dayCount": "{count} 天",
-  "settings.cacheHeatmap": "缓存命中率热力图",
+  "settings.usageHeatmap": "每日用量热力图",
   "settings.less": "少",
   "settings.more": "多",
   "settings.modelUsage": "模型使用",

--- a/desktop/src/renderer/styles/base.test.ts
+++ b/desktop/src/renderer/styles/base.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 const baseCss = readFileSync(resolve(__dirname, "base.css"), "utf-8");
 const sidebarCss = readFileSync(resolve(__dirname, "sidebar.css"), "utf-8");
 const environmentCss = readFileSync(resolve(__dirname, "environment.css"), "utf-8");
+const settingsCss = readFileSync(resolve(__dirname, "settings.css"), "utf-8");
 const themeCss = readFileSync(resolve(__dirname, "theme.css"), "utf-8");
 
 describe("resize drag over embedded frames", () => {
@@ -51,6 +52,21 @@ describe("dark theme inline code", () => {
     )?.[1] ?? "";
 
     expect(darkTheme).toMatch(/--surface-chip:\s*var\(--surface-4\);/);
+  });
+});
+
+describe("usage heatmap color scale", () => {
+  it("uses dedicated theme-aware colors instead of the neutral gray ramp", () => {
+    for (const level of [1, 2, 3, 4]) {
+      const token = `--settings-heatmap-level-${level}`;
+      const levelRule = settingsCss.match(
+        new RegExp(`\\.settings-usage-heatmap-cell\\[data-level="${level}"\\][\\s\\S]*?\\{[\\s\\S]*?\\}`),
+      )?.[0] ?? "";
+
+      expect(settingsCss).toContain(token);
+      expect(themeCss).toContain(token);
+      expect(levelRule).toContain(`background: var(${token})`);
+    }
   });
 });
 

--- a/desktop/src/renderer/styles/settings.css
+++ b/desktop/src/renderer/styles/settings.css
@@ -26,6 +26,13 @@
  *   .settings-status-pill            semantic status badge
  * ========================================================================= */
 
+:root {
+  --settings-heatmap-level-1: #bad0f0;
+  --settings-heatmap-level-2: #7aaae0;
+  --settings-heatmap-level-3: #3d74cc;
+  --settings-heatmap-level-4: #1a4fa8;
+}
+
 /* --- Shell grid (shared with the main app shell) ------------------------- */
 
 /* Same column vocabulary as .app-shell: `--sidebar-width` is the live grid
@@ -987,8 +994,7 @@
   font-size: var(--font-sm);
 }
 
-/* Heatmap panel: a card whose grid is the content. Levels are the gray
- * ramp — more cache hits = stronger ink, in both themes. */
+/* Heatmap panel: a card whose grid is the content. */
 .settings-heatmap-panel {
   display: flex;
   flex-direction: column;
@@ -1019,7 +1025,7 @@
 }
 
 /* Grid: column = week, row = day-of-week */
-.settings-cache-heatmap {
+.settings-usage-heatmap {
   --heatmap-gap: 3px;
   display: grid;
   grid-template-rows: repeat(7, 1fr);
@@ -1030,7 +1036,7 @@
   /* height set inline via JS to keep cells square */
 }
 
-.settings-cache-heatmap-cell {
+.settings-usage-heatmap-cell {
   min-width: 0;
   min-height: 0;
   border-radius: 2px;
@@ -1039,33 +1045,33 @@
   transition: opacity var(--motion-fast) var(--ease-out);
 }
 
-.settings-cache-heatmap-cell:hover {
+.settings-usage-heatmap-cell:hover {
   opacity: 0.7;
 }
 
-.settings-cache-heatmap-cell[data-level="0"],
+.settings-usage-heatmap-cell[data-level="0"],
 .settings-heatmap-legend-cell[data-level="0"] {
   background: var(--gray-100);
 }
 
-.settings-cache-heatmap-cell[data-level="1"],
+.settings-usage-heatmap-cell[data-level="1"],
 .settings-heatmap-legend-cell[data-level="1"] {
-  background: var(--gray-350);
+  background: var(--settings-heatmap-level-1);
 }
 
-.settings-cache-heatmap-cell[data-level="2"],
+.settings-usage-heatmap-cell[data-level="2"],
 .settings-heatmap-legend-cell[data-level="2"] {
-  background: var(--gray-500);
+  background: var(--settings-heatmap-level-2);
 }
 
-.settings-cache-heatmap-cell[data-level="3"],
+.settings-usage-heatmap-cell[data-level="3"],
 .settings-heatmap-legend-cell[data-level="3"] {
-  background: var(--gray-700);
+  background: var(--settings-heatmap-level-3);
 }
 
-.settings-cache-heatmap-cell[data-level="4"],
+.settings-usage-heatmap-cell[data-level="4"],
 .settings-heatmap-legend-cell[data-level="4"] {
-  background: var(--gray-900);
+  background: var(--settings-heatmap-level-4);
 }
 
 /* Legend row */
@@ -1876,7 +1882,7 @@
   .settings-switch-thumb,
   .settings-usage-range-button,
   .settings-memory-tab,
-  .settings-cache-heatmap-cell {
+  .settings-usage-heatmap-cell {
     transition: none;
   }
 


### PR DESCRIPTION
## Summary

- restore dedicated blue heatmap ramps for light and dark themes
- grade visible days by relative total token usage instead of cache hit rate
- rename the heatmap accessibility label to reflect daily usage
- add behavior and CSS regression coverage

## Testing

- `npx vitest run src/renderer/styles/base.test.ts src/renderer/SettingsView.test.tsx`
- `npm run typecheck`