### PR TITLE
fix(desktop): pause stream follow during text selection

### DIFF
--- a/desktop/src/renderer/AssistantTurnShell.test.tsx
+++ b/desktop/src/renderer/AssistantTurnShell.test.tsx
@@ -328,6 +328,21 @@ function reasoningScroll(fold: HTMLDetailsElement): HTMLElement {
   return scroll;
 }
 
+function selectTextWithin(node: HTMLElement): void {
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+  const text = walker.nextNode();
+  const selection = document.getSelection();
+  if (!text || !selection) {
+    throw new Error("expected selectable text");
+  }
+  const range = document.createRange();
+  range.setStart(text, 0);
+  range.setEnd(text, Math.min(4, text.textContent?.length ?? 0));
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.dispatchEvent(new Event("selectionchange"));
+}
+
 async function openReasoningFold(fold: HTMLDetailsElement): Promise<void> {
   fold.open = true;
   act(() => {
@@ -1076,6 +1091,62 @@ describe("AssistantTurnShell — reasoning fold (rule 3)", () => {
     });
 
     expect(layout.scrollTop).toBe(1300);
+  });
+
+  it("keeps reasoning selection paused after a pointer press without scroll movement", async () => {
+    const turn = makeTurn("completed", [
+      makeReasoning("long internal deliberation ".repeat(50)),
+      makeFinalAnswer("short answer"),
+    ]);
+    const { container } = renderShell(turn);
+    const fold = reasoningFolds(container)[0];
+    const scroll = reasoningScroll(fold);
+    const layout = stubScrollLayout(scroll, {
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    await openReasoningFold(fold);
+
+    act(() => selectTextWithin(scroll));
+    expect(scroll.style.overflowAnchor).toBe("auto");
+    act(() => {
+      scroll.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      window.dispatchEvent(new Event("pointerup"));
+      layout.scrollHeight += 8;
+      layout.scrollTop += 8;
+      scroll.dispatchEvent(new UIEvent("scroll", { bubbles: true }));
+    });
+
+    expect(scroll.style.overflowAnchor).toBe("auto");
+  });
+
+  it("resumes reasoning follow after an active pointer scroll reaches latest", async () => {
+    await withMockResizeObserver(async (flushResizeObservers) => {
+      const turn = makeTurn("completed", [
+        makeReasoning("long internal deliberation ".repeat(50)),
+        makeFinalAnswer("short answer"),
+      ]);
+      const { container } = renderShell(turn);
+      const fold = reasoningFolds(container)[0];
+      const scroll = reasoningScroll(fold);
+      const layout = stubScrollLayout(scroll, {
+        scrollHeight: 1000,
+        clientHeight: 200,
+      });
+      await openReasoningFold(fold);
+
+      act(() => selectTextWithin(scroll));
+      act(() => {
+        scroll.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+        layout.scrollHeight = 1300;
+        flushResizeObservers();
+        layout.scrollTop = 1284.5;
+        scroll.dispatchEvent(new UIEvent("scroll", { bubbles: true }));
+        window.dispatchEvent(new Event("pointerup"));
+      });
+
+      expect(scroll.style.overflowAnchor).toBe("none");
+    });
   });
 
   it("keeps up when many reasoning tokens arrive before the next frame", async () => {

--- a/desktop/src/renderer/AutoFollowScroll.ts
+++ b/desktop/src/renderer/AutoFollowScroll.ts
@@ -18,6 +18,7 @@ export const USER_SCROLL_AWAY_INTENT_WINDOW_MS = 300;
 export const AUTO_FOLLOW_NESTED_SCROLL_ATTR = "data-wuu-nested-scroll";
 export const AUTO_FOLLOW_NESTED_SCROLL_SELECTOR = `[${AUTO_FOLLOW_NESTED_SCROLL_ATTR}]`;
 export const SCROLL_AWAY_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+export const SCROLL_TOWARD_LATEST_KEYS = new Set(["ArrowDown", "PageDown", "End"]);
 
 export function maxScrollTop(node: HTMLElement): number {
   return Math.max(0, node.scrollHeight - node.clientHeight);
@@ -50,6 +51,25 @@ export function eventTargetsNestedAutoFollowScroll(
   }
   const nested = target.closest(AUTO_FOLLOW_NESTED_SCROLL_SELECTOR);
   return Boolean(nested && nested !== root);
+}
+
+export function selectionIntersectsNode(
+  selection: Selection | null,
+  node: Node,
+): boolean {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    try {
+      if (selection.getRangeAt(index).intersectsNode(node)) {
+        return true;
+      }
+    } catch {
+      // Streaming reconciliation can detach a range between event delivery and inspection.
+    }
+  }
+  return false;
 }
 
 export function setAutoFollowOverflowAnchor(
@@ -93,6 +113,7 @@ export function useAutoFollowScrollContainer({
 } {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const autoFollowRef = useRef(true);
+  const selectionPausedAutoFollowRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const programmaticScrollTopRef = useRef<number | undefined>(undefined);
   const userScrollAwayIntentRef = useRef(false);
@@ -150,6 +171,7 @@ export function useAutoFollowScrollContainer({
         return;
       }
       if (options.force) {
+        selectionPausedAutoFollowRef.current = false;
         setAutoFollow(true);
       }
       clearUserScrollAwayIntent();
@@ -198,7 +220,10 @@ export function useAutoFollowScrollContainer({
       setAutoFollow(false);
       return;
     }
-    if (atLatestScrollView(node, bottomThreshold)) {
+    if (
+      atLatestScrollView(node, bottomThreshold) &&
+      !selectionPausedAutoFollowRef.current
+    ) {
       setAutoFollow(true);
       return;
     }
@@ -226,18 +251,29 @@ export function useAutoFollowScrollContainer({
       event.stopPropagation();
       if (event.deltaY < 0) {
         markUserScrollAwayIntent();
+      } else if (event.deltaY > 0) {
+        selectionPausedAutoFollowRef.current = false;
       }
     };
     const handlePointerDown = (event: PointerEvent): void => {
       event.stopPropagation();
       if (event.target === node) {
+        selectionPausedAutoFollowRef.current = false;
         markUserScrollAwayIntent();
+      }
+    };
+    const handleSelectionChange = (): void => {
+      if (selectionIntersectsNode(document.getSelection(), node)) {
+        selectionPausedAutoFollowRef.current = true;
+        setAutoFollow(false);
       }
     };
     const handleKeyDown = (event: KeyboardEvent): void => {
       event.stopPropagation();
       if (SCROLL_AWAY_KEYS.has(event.key)) {
         markUserScrollAwayIntent();
+      } else if (SCROLL_TOWARD_LATEST_KEYS.has(event.key)) {
+        selectionPausedAutoFollowRef.current = false;
       }
     };
     const handleTouchStart = (event: TouchEvent): void => {
@@ -254,6 +290,12 @@ export function useAutoFollowScrollContainer({
         currentY > previousY
       ) {
         markUserScrollAwayIntent();
+      } else if (
+        currentY !== undefined &&
+        previousY !== undefined &&
+        currentY < previousY
+      ) {
+        selectionPausedAutoFollowRef.current = false;
       }
       touchLastYRef.current = currentY;
     };
@@ -265,6 +307,7 @@ export function useAutoFollowScrollContainer({
     node.addEventListener("scroll", handleScroll, { passive: true });
     node.addEventListener("wheel", handleWheel, { passive: true });
     node.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("selectionchange", handleSelectionChange);
     node.addEventListener("touchstart", handleTouchStart, { passive: true });
     node.addEventListener("touchmove", handleTouchMove, { passive: true });
     node.addEventListener("touchend", handleTouchEnd);
@@ -274,13 +317,14 @@ export function useAutoFollowScrollContainer({
       node.removeEventListener("scroll", handleScroll);
       node.removeEventListener("wheel", handleWheel);
       node.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("selectionchange", handleSelectionChange);
       node.removeEventListener("touchstart", handleTouchStart);
       node.removeEventListener("touchmove", handleTouchMove);
       node.removeEventListener("touchend", handleTouchEnd);
       node.removeEventListener("touchcancel", handleTouchEnd);
       node.removeEventListener("keydown", handleKeyDown);
     };
-  }, [handleScrollFrame, markUserScrollAwayIntent]);
+  }, [handleScrollFrame, markUserScrollAwayIntent, setAutoFollow]);
 
   useLayoutEffect(() => {
     const node = scrollRef.current;
@@ -306,6 +350,7 @@ export function useAutoFollowScrollContainer({
     if (!open) {
       return undefined;
     }
+    selectionPausedAutoFollowRef.current = false;
     setAutoFollow(true);
     lastScrollTopRef.current = 0;
     const timer = window.setTimeout(() => {

--- a/desktop/src/renderer/AutoFollowScroll.ts
+++ b/desktop/src/renderer/AutoFollowScroll.ts
@@ -114,6 +114,9 @@ export function useAutoFollowScrollContainer({
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const autoFollowRef = useRef(true);
   const selectionPausedAutoFollowRef = useRef(false);
+  const pointerScrollGestureRef = useRef<
+    { node: HTMLElement; scrollTop: number; scrollHeight: number } | undefined
+  >(undefined);
   const lastScrollTopRef = useRef(0);
   const programmaticScrollTopRef = useRef<number | undefined>(undefined);
   const userScrollAwayIntentRef = useRef(false);
@@ -128,6 +131,15 @@ export function useAutoFollowScrollContainer({
     if (node) {
       setAutoFollowOverflowAnchor(node, next);
     }
+  }, []);
+
+  const refreshPointerScrollGestureLayout = useCallback((node: HTMLElement): void => {
+    const gesture = pointerScrollGestureRef.current;
+    if (gesture?.node !== node) {
+      return;
+    }
+    gesture.scrollTop = clampScrollTop(node, node.scrollTop);
+    gesture.scrollHeight = node.scrollHeight;
   }, []);
 
   const clearUserScrollAwayIntent = useCallback((): void => {
@@ -212,6 +224,16 @@ export function useAutoFollowScrollContainer({
       }
     }
 
+    const pointerGesture = pointerScrollGestureRef.current;
+    if (selectionPausedAutoFollowRef.current && pointerGesture?.node === node) {
+      if (node.scrollHeight !== pointerGesture.scrollHeight) {
+        pointerGesture.scrollTop = clampScrollTop(node, node.scrollTop);
+        pointerGesture.scrollHeight = node.scrollHeight;
+      } else if (node.scrollTop > pointerGesture.scrollTop) {
+        selectionPausedAutoFollowRef.current = false;
+      }
+    }
+
     const scrolledUp = node.scrollTop < lastScrollTopRef.current;
     const userScrollAwayIntent = userScrollAwayIntentRef.current;
     lastScrollTopRef.current = clampScrollTop(node, node.scrollTop);
@@ -258,9 +280,16 @@ export function useAutoFollowScrollContainer({
     const handlePointerDown = (event: PointerEvent): void => {
       event.stopPropagation();
       if (event.target === node) {
-        selectionPausedAutoFollowRef.current = false;
+        pointerScrollGestureRef.current = {
+          node,
+          scrollTop: clampScrollTop(node, node.scrollTop),
+          scrollHeight: node.scrollHeight,
+        };
         markUserScrollAwayIntent();
       }
+    };
+    const handlePointerEnd = (): void => {
+      pointerScrollGestureRef.current = undefined;
     };
     const handleSelectionChange = (): void => {
       if (selectionIntersectsNode(document.getSelection(), node)) {
@@ -307,6 +336,8 @@ export function useAutoFollowScrollContainer({
     node.addEventListener("scroll", handleScroll, { passive: true });
     node.addEventListener("wheel", handleWheel, { passive: true });
     node.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("pointerup", handlePointerEnd);
+    window.addEventListener("pointercancel", handlePointerEnd);
     document.addEventListener("selectionchange", handleSelectionChange);
     node.addEventListener("touchstart", handleTouchStart, { passive: true });
     node.addEventListener("touchmove", handleTouchMove, { passive: true });
@@ -317,6 +348,8 @@ export function useAutoFollowScrollContainer({
       node.removeEventListener("scroll", handleScroll);
       node.removeEventListener("wheel", handleWheel);
       node.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("pointerup", handlePointerEnd);
+      window.removeEventListener("pointercancel", handlePointerEnd);
       document.removeEventListener("selectionchange", handleSelectionChange);
       node.removeEventListener("touchstart", handleTouchStart);
       node.removeEventListener("touchmove", handleTouchMove);
@@ -333,6 +366,7 @@ export function useAutoFollowScrollContainer({
     }
     const windowResizeScroll = createWindowResizeSettleScheduler(scrollToBottom);
     const resizeObserver = new ResizeObserver(() => {
+      refreshPointerScrollGestureLayout(node);
       if (isWindowResizing()) {
         windowResizeScroll.schedule();
         return;
@@ -344,7 +378,7 @@ export function useAutoFollowScrollContainer({
       windowResizeScroll.cancel();
       resizeObserver.disconnect();
     };
-  }, [observeKey, scrollToBottom]);
+  }, [observeKey, refreshPointerScrollGestureLayout, scrollToBottom]);
 
   useEffect(() => {
     if (!open) {

--- a/desktop/src/renderer/ConversationScrollState.stream.test.tsx
+++ b/desktop/src/renderer/ConversationScrollState.stream.test.tsx
@@ -438,6 +438,51 @@ describe("useConversationScrollState — high-frequency stream", () => {
     expect(layout.scrollTop).toBe(layout.scrollHeight - layout.clientHeight);
   });
 
+  it("does not treat a pointer press without scrollbar movement as return intent", () => {
+    mount({ scrollHeight: 2000, clientHeight: 600 });
+    if (!layout || !handle || !node) throw new Error("not mounted");
+    flushScheduledScroll();
+
+    act(() => selectMessageText());
+    act(() => {
+      node!.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      window.dispatchEvent(new Event("pointerup"));
+      layout!.scrollHeight += 8;
+      layout!.scrollTop += 8;
+      node!.dispatchEvent(new Event("scroll", { bubbles: false }));
+      layout!.scrollHeight += 40;
+      handle!.scheduleStreamScroll();
+    });
+    flushScheduledScroll();
+
+    expect(layout.scrollTop).toBe(2000 - 600 + 8);
+    expect(layout.scrollTop).toBeLessThan(layout.scrollHeight - layout.clientHeight);
+  });
+
+  it("resumes after an active pointer gesture actually scrolls toward latest", () => {
+    mount({ scrollHeight: 2000, clientHeight: 600 });
+    if (!layout || !handle || !node) throw new Error("not mounted");
+    flushScheduledScroll();
+
+    act(() => selectMessageText());
+    act(() => {
+      node!.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      layout!.scrollHeight += 80;
+      flushResizeObservers();
+    });
+    rerenderTurns(makeLongTurnsSnapshot(1));
+    act(() => {
+      layout!.scrollTop = layout!.scrollHeight - layout!.clientHeight;
+      node!.dispatchEvent(new Event("scroll", { bubbles: false }));
+      window.dispatchEvent(new Event("pointerup"));
+      layout!.scrollHeight += 40;
+      handle!.scheduleStreamScroll();
+    });
+    flushScheduledScroll();
+
+    expect(layout.scrollTop).toBe(layout.scrollHeight - layout.clientHeight);
+  });
+
   it("keeps following when the conversation selection is collapsed", () => {
     mount({ scrollHeight: 2000, clientHeight: 600 });
     if (!layout || !handle) throw new Error("not mounted");

--- a/desktop/src/renderer/ConversationScrollState.stream.test.tsx
+++ b/desktop/src/renderer/ConversationScrollState.stream.test.tsx
@@ -120,12 +120,16 @@ function Probe({
       onScroll: () => handle.handleConversationScroll(),
       "data-testid": "scroll-container",
     },
-    createElement("div", {
-      ref: (node: HTMLDivElement | null) => {
-        if (node) handle.scrollContentRef.current = node;
+    createElement(
+      "div",
+      {
+        ref: (node: HTMLDivElement | null) => {
+          if (node) handle.scrollContentRef.current = node;
+        },
+        "data-testid": "scroll-content",
       },
-      "data-testid": "scroll-content",
-    }),
+      createElement("span", { "data-testid": "message-text" }, "selectable message text"),
+    ),
     createElement("div", {
       [AUTO_FOLLOW_NESTED_SCROLL_ATTR]: "true",
       "data-testid": "nested-scroll",
@@ -207,6 +211,7 @@ describe("useConversationScrollState — high-frequency stream", () => {
   });
 
   afterEach(() => {
+    document.getSelection()?.removeAllRanges();
     act(() => {
       root?.unmount();
     });
@@ -346,6 +351,18 @@ describe("useConversationScrollState — high-frequency stream", () => {
     return nested;
   }
 
+  function selectMessageText(collapsed = false): void {
+    const text = container.querySelector("[data-testid='message-text']")?.firstChild;
+    const selection = document.getSelection();
+    if (!text || !selection) throw new Error("message text not rendered");
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, collapsed ? 0 : 10);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+  }
+
   it("stays pinned to the bottom across 120 fast stream ticks", () => {
     // Start: 2000px of content in a 600px viewport. We are at the
     // bottom (scrollTop = 1400).
@@ -375,6 +392,65 @@ describe("useConversationScrollState — high-frequency stream", () => {
       // (5) The scroll position must still be at the bottom.
       expect(layout.scrollTop).toBe(bottom);
     }
+  });
+
+  it("stops following streamed growth once message text is selected", () => {
+    mount({ scrollHeight: 2000, clientHeight: 600 });
+    if (!layout || !handle || !node) throw new Error("not mounted");
+    flushScheduledScroll();
+
+    act(() => selectMessageText());
+    act(() => {
+      // Native scroll anchoring can move scrollTop down with content growth.
+      // That passive movement must not count as an explicit return to latest.
+      layout!.scrollHeight += 8;
+      layout!.scrollTop += 8;
+      node!.dispatchEvent(new Event("scroll", { bubbles: false }));
+    });
+    const anchoredAt = layout.scrollTop;
+    act(() => {
+      layout!.scrollHeight += 80;
+      handle!.scheduleStreamScroll();
+    });
+    flushResizeObservers();
+    flushScheduledScroll();
+
+    expect(layout.scrollTop).toBe(anchoredAt);
+    expect(layout.scrollTop).toBeLessThan(layout.scrollHeight - layout.clientHeight);
+  });
+
+  it("resumes following after an explicit downward scroll reaches latest", () => {
+    mount({ scrollHeight: 2000, clientHeight: 600 });
+    if (!layout || !handle || !node) throw new Error("not mounted");
+    flushScheduledScroll();
+
+    act(() => selectMessageText());
+    act(() => {
+      layout!.scrollHeight += 80;
+      node!.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: 80 }));
+      layout!.scrollTop = layout!.scrollHeight - layout!.clientHeight;
+      node!.dispatchEvent(new Event("scroll", { bubbles: false }));
+      layout!.scrollHeight += 40;
+      handle!.scheduleStreamScroll();
+    });
+    flushScheduledScroll();
+
+    expect(layout.scrollTop).toBe(layout.scrollHeight - layout.clientHeight);
+  });
+
+  it("keeps following when the conversation selection is collapsed", () => {
+    mount({ scrollHeight: 2000, clientHeight: 600 });
+    if (!layout || !handle) throw new Error("not mounted");
+    flushScheduledScroll();
+
+    act(() => selectMessageText(true));
+    act(() => {
+      layout!.scrollHeight += 80;
+      handle!.scheduleStreamScroll();
+    });
+    flushScheduledScroll();
+
+    expect(layout.scrollTop).toBe(layout.scrollHeight - layout.clientHeight);
   });
 
   it("re-anchors immediately when streamed content grows after the stream frame", () => {

--- a/desktop/src/renderer/ConversationScrollState.ts
+++ b/desktop/src/renderer/ConversationScrollState.ts
@@ -13,12 +13,14 @@ import {
   AUTO_FOLLOW_BOTTOM_THRESHOLD_PX,
   AUTO_FOLLOW_SCROLLBAR_HIDE_DELAY_MS,
   SCROLL_AWAY_KEYS,
+  SCROLL_TOWARD_LATEST_KEYS,
   USER_SCROLL_AWAY_INTENT_WINDOW_MS,
   atLatestScrollView,
   clampScrollTop,
   eventTargetsNestedAutoFollowScroll,
   maxScrollTop,
   observeAutoFollowResizeTargets,
+  selectionIntersectsNode,
   setAutoFollowOverflowAnchor,
 } from "./AutoFollowScroll";
 import {
@@ -126,6 +128,7 @@ export function useConversationScrollState({
   const lastConversationScrollTopRef = useRef(0);
   const programmaticScrollTopRef = useRef<number | undefined>(undefined);
   const suppressAutoFollowRearmRef = useRef(false);
+  const selectionPausedAutoFollowRef = useRef(false);
   const userScrollAwayIntentRef = useRef(false);
   const userScrollAwayIntentTimerRef = useRef<number | undefined>(undefined);
   const userScrollAwayStartTopRef = useRef<number | undefined>(undefined);
@@ -220,6 +223,7 @@ export function useConversationScrollState({
   ): void {
     clearUserScrollAwayIntent();
     suppressAutoFollowRearmRef.current = false;
+    selectionPausedAutoFollowRef.current = false;
     node.scrollTop = top;
     const actualTop = clampScrollTop(node, node.scrollTop);
     if (Math.abs(node.scrollTop - actualTop) > 1) {
@@ -309,6 +313,7 @@ export function useConversationScrollState({
 
   const enableConversationAutoFollow = useCallback((): void => {
     suppressAutoFollowRearmRef.current = false;
+    selectionPausedAutoFollowRef.current = false;
     setAutoFollow(true);
     const node = conversationViewport();
     if (node) {
@@ -471,7 +476,7 @@ export function useConversationScrollState({
       // auto-follow, the next scroll/layout signal yanks the viewport back to
       // the bottom before the jump reaches its target. Only an actual downward
       // move back to the latest content should clear this jump guard.
-      if (scrolledDown) {
+      if (scrolledDown && !selectionPausedAutoFollowRef.current) {
         suppressAutoFollowRearmRef.current = false;
         nextAutoFollow = true;
         setAutoFollow(true);
@@ -589,6 +594,8 @@ export function useConversationScrollState({
       }
       if (event.deltaY < 0) {
         markUserScrollAwayIntent(clampScrollTop(node, node.scrollTop));
+      } else if (event.deltaY > 0) {
+        selectionPausedAutoFollowRef.current = false;
       }
     };
     const handlePointerDown = (event: PointerEvent): void => {
@@ -596,7 +603,14 @@ export function useConversationScrollState({
         return;
       }
       if (event.target === node) {
+        selectionPausedAutoFollowRef.current = false;
         markUserScrollAwayIntent(clampScrollTop(node, node.scrollTop));
+      }
+    };
+    const handleSelectionChange = (): void => {
+      if (selectionIntersectsNode(document.getSelection(), node)) {
+        selectionPausedAutoFollowRef.current = true;
+        disableConversationAutoFollow();
       }
     };
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -605,6 +619,8 @@ export function useConversationScrollState({
       }
       if (SCROLL_AWAY_KEYS.has(event.key)) {
         markUserScrollAwayIntent(clampScrollTop(node, node.scrollTop));
+      } else if (SCROLL_TOWARD_LATEST_KEYS.has(event.key)) {
+        selectionPausedAutoFollowRef.current = false;
       }
     };
     const handleTouchStart = (event: TouchEvent): void => {
@@ -636,6 +652,12 @@ export function useConversationScrollState({
         currentY > previousY
       ) {
         markUserScrollAwayIntent(clampScrollTop(node, node.scrollTop));
+      } else if (
+        currentY !== undefined &&
+        previousY !== undefined &&
+        currentY < previousY
+      ) {
+        selectionPausedAutoFollowRef.current = false;
       }
       touchLastYRef.current = currentY;
     };
@@ -644,6 +666,7 @@ export function useConversationScrollState({
     };
     node.addEventListener("wheel", handleWheel, { passive: true });
     node.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("selectionchange", handleSelectionChange);
     node.addEventListener("touchstart", handleTouchStart, { passive: true });
     node.addEventListener("touchmove", handleTouchMove, { passive: true });
     node.addEventListener("touchend", handleTouchEnd);
@@ -652,6 +675,7 @@ export function useConversationScrollState({
     return () => {
       node.removeEventListener("wheel", handleWheel);
       node.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("selectionchange", handleSelectionChange);
       node.removeEventListener("touchstart", handleTouchStart);
       node.removeEventListener("touchmove", handleTouchMove);
       node.removeEventListener("touchend", handleTouchEnd);

--- a/desktop/src/renderer/ConversationScrollState.ts
+++ b/desktop/src/renderer/ConversationScrollState.ts
@@ -129,6 +129,9 @@ export function useConversationScrollState({
   const programmaticScrollTopRef = useRef<number | undefined>(undefined);
   const suppressAutoFollowRearmRef = useRef(false);
   const selectionPausedAutoFollowRef = useRef(false);
+  const pointerScrollGestureRef = useRef<
+    { node: HTMLElement; scrollTop: number; scrollHeight: number } | undefined
+  >(undefined);
   const userScrollAwayIntentRef = useRef(false);
   const userScrollAwayIntentTimerRef = useRef<number | undefined>(undefined);
   const userScrollAwayStartTopRef = useRef<number | undefined>(undefined);
@@ -143,6 +146,15 @@ export function useConversationScrollState({
   > | null>(null);
   const conversationScrollbarHideTimerRef = useRef<number | undefined>(undefined);
   const scrollContentRef = useRef<HTMLDivElement | null>(null);
+
+  const refreshPointerScrollGestureLayout = useCallback((node: HTMLElement): void => {
+    const gesture = pointerScrollGestureRef.current;
+    if (gesture?.node !== node) {
+      return;
+    }
+    gesture.scrollTop = clampScrollTop(node, node.scrollTop);
+    gesture.scrollHeight = node.scrollHeight;
+  }, []);
 
   function conversationViewport(): HTMLElement | undefined {
     if (splitConversation) {
@@ -430,6 +442,16 @@ export function useConversationScrollState({
     // the viewport is still at the latest content. Those must keep
     // auto-follow armed; otherwise the next streaming or settle frame will
     // stop sticking to the bottom even though the user never scrolled away.
+    const pointerGesture = pointerScrollGestureRef.current;
+    if (selectionPausedAutoFollowRef.current && pointerGesture?.node === node) {
+      if (node.scrollHeight !== pointerGesture.scrollHeight) {
+        pointerGesture.scrollTop = clampScrollTop(node, node.scrollTop);
+        pointerGesture.scrollHeight = node.scrollHeight;
+      } else if (node.scrollTop > pointerGesture.scrollTop) {
+        selectionPausedAutoFollowRef.current = false;
+      }
+    }
+
     const previousScrollTop = lastConversationScrollTopRef.current;
     const scrolledUp = node.scrollTop < previousScrollTop;
     const scrolledDown = node.scrollTop > previousScrollTop;
@@ -603,9 +625,16 @@ export function useConversationScrollState({
         return;
       }
       if (event.target === node) {
-        selectionPausedAutoFollowRef.current = false;
+        pointerScrollGestureRef.current = {
+          node,
+          scrollTop: clampScrollTop(node, node.scrollTop),
+          scrollHeight: node.scrollHeight,
+        };
         markUserScrollAwayIntent(clampScrollTop(node, node.scrollTop));
       }
+    };
+    const handlePointerEnd = (): void => {
+      pointerScrollGestureRef.current = undefined;
     };
     const handleSelectionChange = (): void => {
       if (selectionIntersectsNode(document.getSelection(), node)) {
@@ -666,6 +695,8 @@ export function useConversationScrollState({
     };
     node.addEventListener("wheel", handleWheel, { passive: true });
     node.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("pointerup", handlePointerEnd);
+    window.addEventListener("pointercancel", handlePointerEnd);
     document.addEventListener("selectionchange", handleSelectionChange);
     node.addEventListener("touchstart", handleTouchStart, { passive: true });
     node.addEventListener("touchmove", handleTouchMove, { passive: true });
@@ -675,6 +706,8 @@ export function useConversationScrollState({
     return () => {
       node.removeEventListener("wheel", handleWheel);
       node.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("pointerup", handlePointerEnd);
+      window.removeEventListener("pointercancel", handlePointerEnd);
       document.removeEventListener("selectionchange", handleSelectionChange);
       node.removeEventListener("touchstart", handleTouchStart);
       node.removeEventListener("touchmove", handleTouchMove);
@@ -697,6 +730,7 @@ export function useConversationScrollState({
       scrollConversationToBottom();
     });
     const resizeObserver = new ResizeObserver(() => {
+      refreshPointerScrollGestureLayout(node);
       if (isWindowResizing()) {
         scheduleLiveResizeScroll();
         windowResizeScroll.schedule();
@@ -720,6 +754,7 @@ export function useConversationScrollState({
     initialized,
     previewingLaunch,
     primaryTurns,
+    refreshPointerScrollGestureLayout,
     secondaryTurns,
     scrollConversationToBottom,
     scheduleLiveResizeScroll,


### PR DESCRIPTION
## Summary

- pause conversation and nested auto-follow when a non-collapsed text selection intersects the message stream
- keep selection-driven pauses armed across passive Chromium scroll anchoring
- resume following only after an explicit move toward latest, a forced/open transition, or a programmatic conversation change
- cover selection, collapsed selection, native anchoring, and explicit resume behavior

## Testing

- `vitest run src/renderer/ConversationScrollState.stream.test.tsx src/renderer/ConversationScrollState.test.tsx src/renderer/AssistantTurnShell.test.tsx src/renderer/ProcessSurface.test.tsx src/renderer/SideThreadPanel.test.tsx` (98 tests)
- `tsc --noEmit`