### PR TITLE
fix(desktop): prevent usage number overflow

### DIFF
--- a/desktop/src/renderer/SettingsUsageLayout.test.ts
+++ b/desktop/src/renderer/SettingsUsageLayout.test.ts
@@ -29,4 +29,12 @@ describe("settings usage responsive layout", () => {
       /\.settings-usage-table tbody td:nth-child\(2\)::before\s*\{[\s\S]*?content:\s*"输入";/,
     );
   });
+
+  it("keeps usage values compact and truncates them as a final fallback", () => {
+    expect(cssRule(".settings-usage-stat-value")).toMatch(/font-size:\s*18px;/);
+    expect(cssRule(".settings-usage-stat-value")).toMatch(/text-overflow:\s*ellipsis;/);
+    expect(cssRule(".settings-usage-stat-value")).toMatch(/white-space:\s*nowrap;/);
+    expect(cssRule(".settings-usage-number")).toMatch(/max-width:\s*100%;/);
+    expect(cssRule(".settings-usage-number")).toMatch(/text-overflow:\s*ellipsis;/);
+  });
 });

--- a/desktop/src/renderer/SettingsView.test.tsx
+++ b/desktop/src/renderer/SettingsView.test.tsx
@@ -1020,10 +1020,10 @@ describe("SettingsView About section", () => {
       total_sessions: 1,
       generated_at: "2026-06-18T12:00:00Z",
       metrics: {
-        prompt_tokens: 1050,
-        context_tokens: 1250,
-        input_tokens: 1000,
-        output_tokens: 200,
+        prompt_tokens: 12_345_700,
+        context_tokens: 999_999,
+        input_tokens: 12_345_678,
+        output_tokens: 1_234,
         cache_read_tokens: 50,
         cache_creation_tokens: 20,
         cache_hit_rate: 50 / 1050,
@@ -1082,7 +1082,13 @@ describe("SettingsView About section", () => {
       usageButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(container.querySelector("[data-testid=\"settings-usage\"]")).not.toBeNull();
-    expect(rootText()).toContain("1,250");
+    expect(rootText()).toContain("12.3M");
+    expect(rootText()).toContain("1M");
+    expect(rootText()).toContain("1.2k");
+    expect(container.querySelector('[title="12,345,678"]')).not.toBeNull();
+    const modelInput = container.querySelector(".settings-usage-number");
+    expect(modelInput?.textContent).toBe("1k");
+    expect(modelInput?.getAttribute("title")).toBe("1,000");
     expect(rootText()).toContain("模型使用");
     expect(rootText()).toContain("缓存命中率");
     expect(rootText()).toContain("5%");

--- a/desktop/src/renderer/SettingsView.tsx
+++ b/desktop/src/renderer/SettingsView.tsx
@@ -2163,9 +2163,21 @@ function SettingsUsagePage({
       </div>
       {usage && (
         <div className="settings-usage-stats">
-          <UsageStat label={t("settings.usageInput")} value={formatNumber(usage.metrics.input_tokens)} />
-          <UsageStat label={t("settings.usageContext")} value={formatNumber(usage.metrics.context_tokens)} />
-          <UsageStat label={t("settings.usageOutput")} value={formatNumber(usage.metrics.output_tokens)} />
+          <UsageStat
+            label={t("settings.usageInput")}
+            value={formatCompactUsageNumber(usage.metrics.input_tokens, locale)}
+            title={formatNumber(usage.metrics.input_tokens)}
+          />
+          <UsageStat
+            label={t("settings.usageContext")}
+            value={formatCompactUsageNumber(usage.metrics.context_tokens, locale)}
+            title={formatNumber(usage.metrics.context_tokens)}
+          />
+          <UsageStat
+            label={t("settings.usageOutput")}
+            value={formatCompactUsageNumber(usage.metrics.output_tokens, locale)}
+            title={formatNumber(usage.metrics.output_tokens)}
+          />
           <UsageStat label={t("settings.cacheHitRate")} value={formatPercent(usage.metrics.cache_hit_rate)} />
           <UsageStat label={t("settings.activeDays")} value={t("settings.dayCount", { count: formatNumber(usage.metrics.active_days) })} />
         </div>
@@ -2242,8 +2254,16 @@ function SettingsUsagePage({
                         <strong>{b.provider || t("settings.unknownProvider")}</strong>
                         <small>{b.model || t("settings.unknownModel")}</small>
                       </td>
-                      <td className="settings-usage-num">{formatNumber(b.input_tokens)}</td>
-                      <td className="settings-usage-num">{formatNumber(b.output_tokens)}</td>
+                      <td className="settings-usage-num">
+                        <span className="settings-usage-number" title={formatNumber(b.input_tokens)}>
+                          {formatCompactUsageNumber(b.input_tokens, locale)}
+                        </span>
+                      </td>
+                      <td className="settings-usage-num">
+                        <span className="settings-usage-number" title={formatNumber(b.output_tokens)}>
+                          {formatCompactUsageNumber(b.output_tokens, locale)}
+                        </span>
+                      </td>
                       <td className="settings-usage-num">
                         <span className={`settings-usage-rate rate-${hitRateLevel(rate)}`}>
                           {formatPercent(rate)}
@@ -2265,13 +2285,38 @@ function SettingsUsagePage({
   );
 }
 
-function UsageStat({ label, value }: { label: string; value: string }): JSX.Element {
+function UsageStat({ label, value, title }: { label: string; value: string; title?: string }): JSX.Element {
   return (
     <div className="settings-usage-stat">
-      <span className="settings-usage-stat-value">{value}</span>
+      <span className="settings-usage-stat-value" title={title}>{value}</span>
       <span className="settings-usage-stat-label">{label}</span>
     </div>
   );
+}
+
+function formatCompactUsageNumber(value: number, locale: string): string {
+  const units = [
+    { threshold: 1_000, suffix: "k" },
+    { threshold: 1_000_000, suffix: "M" },
+    { threshold: 1_000_000_000, suffix: "B" },
+  ];
+  const absoluteValue = Math.abs(value);
+  if (absoluteValue < units[0].threshold) {
+    return new Intl.NumberFormat(locale).format(value);
+  }
+
+  let unitIndex = 0;
+  while (unitIndex < units.length - 1 && absoluteValue >= units[unitIndex + 1].threshold) {
+    unitIndex += 1;
+  }
+
+  let scaled = value / units[unitIndex].threshold;
+  if (Math.abs(Math.round(scaled * 10) / 10) >= 1_000 && unitIndex < units.length - 1) {
+    unitIndex += 1;
+    scaled = value / units[unitIndex].threshold;
+  }
+
+  return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 1 }).format(scaled)}${units[unitIndex].suffix}`;
 }
 
 

--- a/desktop/src/renderer/styles/settings.css
+++ b/desktop/src/renderer/styles/settings.css
@@ -974,11 +974,15 @@
 }
 
 .settings-usage-stat-value {
+  max-width: 100%;
+  overflow: hidden;
   color: var(--ink-strong);
-  font-size: 20px;
+  font-size: 18px;
   font-weight: var(--weight-semibold);
   letter-spacing: -0.02em;
   line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
 
@@ -1150,6 +1154,14 @@
 
 .settings-usage-table .settings-usage-num {
   width: 20%;
+}
+
+.settings-usage-number {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-usage-table td:first-child {


### PR DESCRIPTION
## Summary

Prevent large token counts from overflowing the Settings usage page while keeping exact values available on hover.

## Changes

- Format usage counts with compact `k`, `M`, and `B` suffixes, including boundary promotion such as `999,999` to `1M`
- Reduce summary number size and add ellipsis truncation as a narrow-layout fallback
- Apply compact formatting to both summary cards and model usage rows while preserving full localized values in titles

## Test plan

- [x] Added or updated unit tests for the change
- [ ] `go test ./...` passes (not run; desktop-only change)
- [ ] `cd desktop && npm test` passes (full suite not run)
- [ ] Manually verified the behavior in the desktop shell (not run)
- [x] `cd desktop && npm run typecheck`
- [x] `cd desktop && vitest run src/renderer/SettingsView.test.tsx src/renderer/SettingsUsageLayout.test.ts`

## Risk and rollback

- Risk level: low
- Roll back by reverting this PR.

## Linked issues / docs

None.