### PR TITLE
Fix quota retry loops and surface stream recovery

### DIFF
--- a/desktop/src/renderer/AppState.test.ts
+++ b/desktop/src/renderer/AppState.test.ts
@@ -2930,6 +2930,53 @@ describe("chatMessagesFromTurns", () => {
     ]);
   });
 
+  it("coalesces adjacent equivalent system events without crossing user messages", () => {
+    const first: ThreadItem = {
+      id: "handoff-1",
+      type: "user_message",
+      text: handoffText(),
+    };
+    const second: ThreadItem = {
+      id: "handoff-2",
+      type: "user_message",
+      text: handoffText(),
+    };
+    const query: ThreadItem = {
+      id: "query",
+      type: "user_message",
+      text: "继续",
+    };
+    const third: ThreadItem = {
+      id: "handoff-3",
+      type: "user_message",
+      text: handoffText(),
+    };
+
+    const rows = chatMessagesFromTurns([
+      turn("turn-1", [first]),
+      turn("turn-2", [second, query, third]),
+    ]);
+
+    expect(rows).toEqual([
+      {
+        kind: "system",
+        id: "turn-1:handoff-1",
+        turnID: "turn-1",
+        text: "subagent 完成了任务",
+        item: first,
+        count: 2,
+      },
+      { kind: "user", id: "turn-2:query", turnID: "turn-2", item: query },
+      {
+        kind: "system",
+        id: "turn-2:handoff-3",
+        turnID: "turn-2",
+        text: "subagent 完成了任务",
+        item: third,
+      },
+    ]);
+  });
+
   it("hides named and legacy process notifications from chat rows", () => {
     const named: ThreadItem = {
       id: "process-named",

--- a/desktop/src/renderer/AppState.ts
+++ b/desktop/src/renderer/AppState.ts
@@ -2102,7 +2102,14 @@ export type ChatMessageRow =
   | { kind: "user"; id: string; turnID: string; item: ThreadItem }
   | { kind: "envelope"; id: string; turnID: string; items: ThreadItem[] }
   | { kind: "participant"; id: string; turnID: string; item: ThreadItem }
-  | { kind: "system"; id: string; turnID: string; text: string; item: ThreadItem }
+  | {
+      kind: "system";
+      id: string;
+      turnID: string;
+      text: string;
+      item: ThreadItem;
+      count?: number;
+    }
   | { kind: "focus"; id: string; turnID: string; item: ThreadItem };
 
 /**
@@ -2196,13 +2203,18 @@ export function chatMessagesFromTurns(
         // why `name` is the reliable signal and `text` sniff is a fallback).
         const handoff = agentHandoffDisplayItem(item);
         if (handoff) {
-          rows.push({
-            kind: "system",
-            id,
-            turnID: turn.id,
-            text: handoff.label,
-            item,
-          });
+          const previous = rows[rows.length - 1];
+          if (previous?.kind === "system" && previous.text === handoff.label) {
+            previous.count = (previous.count ?? 1) + 1;
+          } else {
+            rows.push({
+              kind: "system",
+              id,
+              turnID: turn.id,
+              text: handoff.label,
+              item,
+            });
+          }
           continue;
         }
         if (isInternalUserNotificationItem(item)) {

--- a/desktop/src/renderer/CachedConversationPanes.test.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.test.tsx
@@ -2,6 +2,7 @@ import { act, createElement, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Thread } from "../shared/protocol";
+import type { TurnStreamStatus } from "./AppState";
 import { CachedConversationPanes } from "./CachedConversationPanes";
 import { ImagePreviewProvider } from "./ImagePreview";
 
@@ -60,6 +61,7 @@ function chatThread(
 function renderPane(
   thread: Thread,
   onOpenSubthread = vi.fn(),
+  turnStreamStatus: Record<string, TurnStreamStatus> = {},
 ): { container: HTMLElement; onOpenSubthread: ReturnType<typeof vi.fn> } {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -85,7 +87,7 @@ function renderPane(
     onCancelEditMessage: () => {},
     onSubmitEditMessage: () => {},
     onOpenFileDiff: () => {},
-    turnStreamStatus: {},
+    turnStreamStatus,
     busyParticipantIDs: new Set(),
     activeThreadMarks: [],
     resolveParticipantName: (id) => id,
@@ -105,6 +107,76 @@ function renderPane(
 }
 
 describe("CachedConversationPanes Thread wiring", () => {
+  it("surfaces reconnect progress and terminal failures inside DM streams", () => {
+    const running = chatThread("dm-running", {
+      workspace_kind: "dm",
+      dm_participant_id: "prt-a",
+      turns: [
+        {
+          id: "turn-running",
+          status: "in_progress",
+          items_view: "full",
+          items: [{ id: "human-running", type: "user_message", text: "继续" }],
+        },
+      ],
+    });
+    const reconnecting = renderPane(running, vi.fn(), {
+      "turn-running": {
+        text: "消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）",
+        liveProgress: true,
+      },
+    }).container;
+    expect(
+      reconnecting.querySelector(".chat-row--reconnecting .turn-event-title")
+        ?.textContent,
+    ).toContain("消息流暂时中断");
+
+    const failed = chatThread("dm-failed", {
+      workspace_kind: "dm",
+      dm_participant_id: "prt-a",
+      turns: [
+        {
+          id: "turn-failed",
+          status: "failed",
+          items_view: "full",
+          items: [{ id: "human-failed", type: "user_message", text: "继续" }],
+          error: { message: "stream request failed: context deadline exceeded" },
+        },
+      ],
+    });
+    const terminal = renderPane(failed).container;
+    expect(
+      terminal.querySelector(".chat-row--turn-event .turn-event-title")?.textContent,
+    ).toBe("请求超时");
+  });
+
+  it("keeps a terminal network event after a later turn completes", () => {
+    const thread = chatThread("dm-history", {
+      workspace_kind: "dm",
+      dm_participant_id: "prt-a",
+      turns: [
+        {
+          id: "turn-failed",
+          status: "failed",
+          items_view: "full",
+          items: [{ id: "human-failed", type: "user_message", text: "第一次" }],
+          error: { message: "stream request failed: context deadline exceeded" },
+        },
+        {
+          id: "turn-completed",
+          status: "completed",
+          items_view: "full",
+          items: [{ id: "human-next", type: "user_message", text: "第二次" }],
+        },
+      ],
+    });
+
+    const container = renderPane(thread).container;
+    expect(
+      container.querySelector(".chat-row--turn-event .turn-event-title")?.textContent,
+    ).toBe("请求超时");
+  });
+
   it("does not expose Thread entry points in a DM", () => {
     const { container, onOpenSubthread } = renderPane(
       chatThread("dm-1", {

--- a/desktop/src/renderer/CachedConversationPanes.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.tsx
@@ -33,7 +33,9 @@ import {
   TurnView,
   latestAgentMessageItemID,
 } from "./TurnView";
+import { turnEventForTurn } from "./TurnEvents";
 import type { TurnFileDiffSelection } from "./TurnFileDiffTypes";
+import { turnHasAssistantOutput } from "./TurnViewHelpers";
 import type { HistoryMessageEditState } from "./ConversationHistoryActions";
 
 const CONVERSATION_GRID_COLUMNS = 12;
@@ -251,6 +253,11 @@ const CachedConversationPane = memo(function CachedConversationPane({
     ) : null;
   const isGroupChat = isGroupThread(thread);
   const isChatStyleThread = isDMThread(thread) || isGroupChat;
+  const latestTurn = threadTurns[threadTurns.length - 1];
+  const turnEvents = threadTurns.flatMap((turn) => {
+    const event = turnEventForTurn(turn, turnHasAssistantOutput(turn));
+    return event ? [{ turnID: turn.id, event }] : [];
+  });
 
   return (
     <div
@@ -272,6 +279,8 @@ const CachedConversationPane = memo(function CachedConversationPane({
             readerCount={chatReaderCountForThread(thread, chatReaderCount)}
             threadOwnerCandidates={isGroupChat ? thread.members : undefined}
             subthreadsByAnchor={isGroupChat ? subthreadsByAnchor : undefined}
+            streamStatus={latestTurn ? turnStreamStatus[latestTurn.id] : undefined}
+            turnEvents={turnEvents}
             onOpenSubthread={
               isGroupChat
                 ? (item, ownerID, existingSubthreadID) =>

--- a/desktop/src/renderer/ChatThreadView.test.tsx
+++ b/desktop/src/renderer/ChatThreadView.test.tsx
@@ -463,6 +463,113 @@ describe("ChatThreadView reply / task affordances", () => {
     ).toBe("subagent 完成了任务");
   });
 
+  it("renders reconnect progress and terminal network events in chat threads", () => {
+    const reconnecting = mount(
+      createElement(ChatThreadView, {
+        turns: turns([
+          { id: "item-1", type: "user_message", text: "继续处理" },
+        ]),
+        streamStatus: {
+          text: "消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）",
+          liveProgress: true,
+        },
+      }),
+    );
+    expect(
+      reconnecting.querySelector(".chat-row--reconnecting .turn-event-title")
+        ?.textContent,
+    ).toBe("消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）");
+
+    const failed = mount(
+      createElement(ChatThreadView, {
+        turns: turns([
+          { id: "item-1", type: "user_message", text: "继续处理" },
+        ]),
+        turnEvents: [
+          {
+            turnID: "turn-1",
+            event: {
+              kind: "network_lost",
+              source: "turn",
+              presentation: "notice",
+              notice: {
+                category: "network",
+                tone: "error",
+                title: "网络异常",
+                detail: "请检查网络连接后重试。",
+              },
+            },
+          },
+        ],
+      }),
+    );
+    expect(
+      failed.querySelector(".chat-row--turn-event .turn-event-title")?.textContent,
+    ).toBe("网络异常");
+  });
+
+  it("shows the count for coalesced adjacent system events", () => {
+    const notification = (id: string): ThreadItem => ({
+      id,
+      type: "user_message",
+      text: JSON.stringify({
+        author: "/root/explore",
+        recipient: "/root",
+        content: `<subagent_notification>\n${JSON.stringify({
+          agent_path: "/root/explore",
+          status: {
+            type: "agent_result",
+            agent_id: "worker-1",
+            task_name: "explore",
+            status: "completed",
+          },
+        })}\n</subagent_notification>`,
+        trigger_turn: true,
+      }),
+    });
+    const container = mount(
+      createElement(ChatThreadView, {
+        turns: turns([notification("item-1"), notification("item-2")]),
+      }),
+    );
+
+    expect(container.querySelectorAll(".chat-system-divider")).toHaveLength(1);
+    expect(
+      container.querySelector(".chat-system-divider .turn-event-title")?.textContent,
+    ).toBe("subagent 完成了任务 ×2");
+  });
+
+  it("coalesces adjacent equivalent terminal turn events", () => {
+    const event = {
+      kind: "network_lost" as const,
+      source: "turn" as const,
+      presentation: "notice" as const,
+      notice: {
+        category: "network" as const,
+        tone: "error" as const,
+        title: "网络异常",
+        detail: "请检查网络连接后重试。",
+      },
+    };
+    const container = mount(
+      createElement(ChatThreadView, {
+        turns: [
+          { id: "turn-1", items: [] },
+          { id: "turn-2", items: [] },
+        ],
+        turnEvents: [
+          { turnID: "turn-1", event },
+          { turnID: "turn-2", event },
+        ],
+      }),
+    );
+
+    expect(container.querySelectorAll(".chat-row--turn-event")).toHaveLength(1);
+    expect(container.querySelector(".chat-row--turn-event .turn-event-title")?.textContent).toBe(
+      "网络异常 ×2",
+    );
+  });
+
   it("hangs a 'N 条回复' badge under a message that anchors a plain reply", () => {
     const map = new Map<string, ConversationSubthread>([
       ["item-1", subthread({ reply_count: 4 })],
@@ -1339,12 +1446,105 @@ describe("ChatThreadView windowing", () => {
       scrollAncestor,
     );
 
+    scrollAncestor.scrollTop = 0;
+    scrollAncestor.dispatchEvent(new Event("scroll"));
     triggerSentinelIntersection(mountPoint);
 
     // 80 rows before -> scrollHeight 3600; 160 rows after -> 6800. The
     // reader was pinned at scrollTop 0, so the compensation must add
     // exactly the height inserted above the viewport.
     expect(scrollAncestor.scrollTop).toBe(3200);
+  });
+
+  it("auto-follows a new turn event on the real scroll ancestor", () => {
+    const scrollAncestor = document.createElement("div");
+    scrollAncestor.style.overflowY = "auto";
+    const mountPoint = document.createElement("div");
+    scrollAncestor.appendChild(mountPoint);
+    document.body.appendChild(scrollAncestor);
+    Object.defineProperty(scrollAncestor, "clientHeight", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scrollAncestor, "scrollHeight", {
+      get: () =>
+        1000 +
+        mountPoint.querySelectorAll(".chat-row").length * 40 +
+        mountPoint.querySelectorAll(".chat-row--reconnecting").length * 160 +
+        mountPoint.querySelectorAll(".chat-row--turn-event").length * 360,
+      configurable: true,
+    });
+
+    const root = createRoot(mountPoint);
+    act(() => {
+      root.render(
+        createElement(
+          ImagePreviewProvider,
+          null,
+          createElement(ChatThreadView, {
+            turns: turns([
+              { id: "item-1", type: "user_message", text: "继续处理" },
+            ]),
+          }),
+        ),
+      );
+    });
+    mountedRoots.push(root);
+    mountedContainers.push(scrollAncestor);
+
+    scrollAncestor.scrollTop = 620;
+    scrollAncestor.dispatchEvent(new Event("scroll"));
+    act(() => {
+      root.render(
+        createElement(
+          ImagePreviewProvider,
+          null,
+          createElement(ChatThreadView, {
+            turns: turns([
+              { id: "item-1", type: "user_message", text: "继续处理" },
+            ]),
+            streamStatus: {
+              text: "消息流暂时中断，正在恢复（第 2/4 次尝试）",
+              liveProgress: true,
+            },
+          }),
+        ),
+      );
+    });
+
+    expect(scrollAncestor.scrollTop).toBe(scrollAncestor.scrollHeight);
+
+    act(() => {
+      root.render(
+        createElement(
+          ImagePreviewProvider,
+          null,
+          createElement(ChatThreadView, {
+            turns: turns([
+              { id: "item-1", type: "user_message", text: "继续处理" },
+            ]),
+            turnEvents: [
+              {
+                turnID: "turn-1",
+                event: {
+                  kind: "network_lost",
+                  source: "turn",
+                  presentation: "notice",
+                  notice: {
+                    category: "network",
+                    tone: "error",
+                    title: "网络异常",
+                    detail: "请检查网络连接后重试。",
+                  },
+                },
+              },
+            ],
+          }),
+        ),
+      );
+    });
+
+    expect(scrollAncestor.scrollTop).toBe(scrollAncestor.scrollHeight);
   });
 });
 

--- a/desktop/src/renderer/ChatThreadView.tsx
+++ b/desktop/src/renderer/ChatThreadView.tsx
@@ -20,6 +20,7 @@ import {
   chatMessagesFromTurns,
   replyCountBadge,
   type ChatMessageRow,
+  type TurnStreamStatus,
 } from "./AppState";
 import type { QueuedComposerMessage } from "./ComposerMessages";
 import { DefaultAvatarMark } from "./DefaultAvatar";
@@ -41,7 +42,12 @@ import {
 } from "./MessageMarks";
 import { ReadReceiptRing } from "./ReadReceiptRing";
 import { RichContent } from "./RichContent";
-import { SystemEventDivider } from "./TurnNotice";
+import {
+  StreamReconnectNotice,
+  SystemEventDivider,
+  TurnEventNotice,
+} from "./TurnNotice";
+import type { TurnEventDisplay } from "./TurnEvents";
 import { translateCurrent as translate, useI18n } from "./i18n";
 
 // Distance (px) from the bottom of the scroll container within which the
@@ -134,6 +140,8 @@ export function ChatThreadView({
   resolveParticipantName,
   threadOwnerCandidates = [],
   subthreadsByAnchor,
+  streamStatus,
+  turnEvents = [],
   onOpenSubthread,
   onReact,
 }: {
@@ -169,6 +177,8 @@ export function ChatThreadView({
    * been (人点击)升级为 task。Absent = subthreads not loaded / not a group thread.
    */
   subthreadsByAnchor?: ReadonlyMap<string, ConversationSubthread>;
+  streamStatus?: TurnStreamStatus;
+  turnEvents?: ReadonlyArray<{ turnID: string; event: TurnEventDisplay }>;
   /**
    * Open the reply/subthread panel for a message. Wired to the same
    * create-or-find-by-anchor path the agent-brain transcript uses. Optional:
@@ -186,7 +196,49 @@ export function ChatThreadView({
    */
   onReact?: (item: ThreadItem, reaction: string) => void;
 }): JSX.Element {
-  const rows = useMemo(() => chatMessagesFromTurns(turns), [turns]);
+  const rows = useMemo(() => {
+    const messageRows = chatMessagesFromTurns(turns);
+    if (turnEvents.length === 0) {
+      return messageRows;
+    }
+    const eventsByTurn = new Map(turnEvents.map(({ turnID, event }) => [turnID, event]));
+    const merged: Array<
+      | ChatMessageRow
+      | {
+          kind: "turn-event";
+          id: string;
+          turnID: string;
+          event: TurnEventDisplay;
+          count?: number;
+        }
+    > = [];
+    let messageIndex = 0;
+    for (const turn of turns) {
+      while (messageRows[messageIndex]?.turnID === turn.id) {
+        merged.push(messageRows[messageIndex]!);
+        messageIndex += 1;
+      }
+      const event = eventsByTurn.get(turn.id);
+      if (event) {
+        const previous = merged[merged.length - 1];
+        if (
+          previous?.kind === "turn-event" &&
+          JSON.stringify(previous.event) === JSON.stringify(event)
+        ) {
+          previous.count = (previous.count ?? 1) + 1;
+        } else {
+          merged.push({
+            kind: "turn-event",
+            id: `${turn.id}:turn-event`,
+            turnID: turn.id,
+            event,
+          });
+        }
+      }
+    }
+    merged.push(...messageRows.slice(messageIndex));
+    return merged;
+  }, [turnEvents, turns]);
   // 贴表情 and 开 Thread are one-click affordances on each group bubble's toolbar
   // (ChatBubbleToolbar) — no right-click menu, no hoisted popup state. A bubble
   // inside a cth reply panel receives onReact but not onOpenSubthread, so its
@@ -195,6 +247,9 @@ export function ChatThreadView({
   // never wires the reply handler).
   const containerRef = useRef<HTMLDivElement | null>(null);
   const topSentinelRef = useRef<HTMLDivElement | null>(null);
+  const autoFollowRef = useRef(true);
+  const autoFollowParentRef = useRef<HTMLElement | null>(null);
+  const autoFollowListenerRef = useRef<(() => void) | null>(null);
   const [ownerSelectionItem, setOwnerSelectionItem] = useState<ThreadItem>();
   const namedOwnerCandidates = useMemo(
     () =>
@@ -234,7 +289,15 @@ export function ChatThreadView({
   const closeOwnerSelection = useCallback(() => {
     setOwnerSelectionItem(undefined);
   }, []);
-  const rowCount = rows.length + pendingMessages.length;
+  const autoFollowVersion = [
+    ...rows.map((row) =>
+      row.kind === "turn-event"
+        ? `${row.id}:${row.event.kind}:${row.event.presentation}`
+        : row.id,
+    ),
+    ...pendingMessages.map((message) => `pending:${message.id}`),
+    streamStatus?.liveProgress ? `stream:${streamStatus.text}` : "",
+  ].join("\u0000");
 
   // Count of the oldest rows currently withheld from the DOM. 0 means the
   // whole history is rendered (either it was never longer than the
@@ -335,19 +398,54 @@ export function ChatThreadView({
   }, [hiddenOlderCount, revealOlder]);
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
+    const scrollParent = findScrollParent(containerRef.current);
+    if (!scrollParent) {
+      if (autoFollowParentRef.current && autoFollowListenerRef.current) {
+        autoFollowParentRef.current.removeEventListener(
+          "scroll",
+          autoFollowListenerRef.current,
+        );
+      }
+      autoFollowParentRef.current = null;
+      autoFollowListenerRef.current = null;
       return;
     }
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    if (distanceFromBottom <= AUTO_FOLLOW_THRESHOLD_PX) {
-      container.scrollTop = container.scrollHeight;
+    if (autoFollowParentRef.current !== scrollParent) {
+      if (autoFollowParentRef.current && autoFollowListenerRef.current) {
+        autoFollowParentRef.current.removeEventListener(
+          "scroll",
+          autoFollowListenerRef.current,
+        );
+      }
+      const updateAutoFollow = (): void => {
+        autoFollowRef.current =
+          scrollParent.scrollHeight - scrollParent.scrollTop - scrollParent.clientHeight <=
+          AUTO_FOLLOW_THRESHOLD_PX;
+      };
+      scrollParent.addEventListener("scroll", updateAutoFollow, { passive: true });
+      autoFollowParentRef.current = scrollParent;
+      autoFollowListenerRef.current = updateAutoFollow;
     }
-    // rowCount changes whenever a real chat row is added or removed; that is
-    // the only signal that should trigger auto-follow.
+    if (autoFollowRef.current) {
+      scrollParent.scrollTop = scrollParent.scrollHeight;
+    }
+    autoFollowListenerRef.current?.();
+    // Identity/state changes, rather than only row count, also cover replacing
+    // a reconnect notice with a terminal event in the same render slot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowCount]);
+  }, [autoFollowVersion]);
+
+  useEffect(
+    () => () => {
+      if (autoFollowParentRef.current && autoFollowListenerRef.current) {
+        autoFollowParentRef.current.removeEventListener(
+          "scroll",
+          autoFollowListenerRef.current,
+        );
+      }
+    },
+    [],
+  );
 
   const visibleRows = hiddenOlderCount > 0 ? rows.slice(hiddenOlderCount) : rows;
   const firstVisibleBubbleRowID = visibleRows.find(
@@ -366,36 +464,59 @@ export function ChatThreadView({
         />
       ) : null}
       {visibleRows.map((row) => (
-        <ChatRow
-          key={row.id}
-          isTopBubble={row.id === firstVisibleBubbleRowID}
-          row={row}
-          cwd={cwd}
-          busyParticipantIDs={busyParticipantIDs}
-          marks={
-            row.kind !== "envelope" && typeof row.item.seq === "number"
-              ? marksBySeq?.get(row.item.seq)
-              : undefined
-          }
-          readerCount={readerCount}
-          resolveParticipantName={resolveParticipantName}
-          subthread={
-            row.kind === "user" || row.kind === "participant"
-              ? subthreadsByAnchor?.get(row.item.id) ??
-                (row.item.seq
-                  ? subthreadsByAnchor?.get(`seq:${row.item.seq}`)
-                  : undefined)
-              : undefined
-          }
-          onOpenSubthread={
-            onOpenSubthread ? requestOpenSubthread : undefined
-          }
-          onReact={onReact}
-        />
+        row.kind === "turn-event" ? (
+          <div key={row.id} className="chat-row chat-row--system chat-row--turn-event">
+            <TurnEventNotice
+              event={
+                row.count && row.count > 1 && row.event.presentation === "notice"
+                  ? {
+                      ...row.event,
+                      notice: {
+                        ...row.event.notice,
+                        title: `${row.event.notice.title} ×${row.count}`,
+                      },
+                    }
+                  : row.event
+              }
+            />
+          </div>
+        ) : (
+          <ChatRow
+            key={row.id}
+            isTopBubble={row.id === firstVisibleBubbleRowID}
+            row={row}
+            cwd={cwd}
+            busyParticipantIDs={busyParticipantIDs}
+            marks={
+              row.kind !== "envelope" && typeof row.item.seq === "number"
+                ? marksBySeq?.get(row.item.seq)
+                : undefined
+            }
+            readerCount={readerCount}
+            resolveParticipantName={resolveParticipantName}
+            subthread={
+              row.kind === "user" || row.kind === "participant"
+                ? subthreadsByAnchor?.get(row.item.id) ??
+                  (row.item.seq
+                    ? subthreadsByAnchor?.get(`seq:${row.item.seq}`)
+                    : undefined)
+                : undefined
+            }
+            onOpenSubthread={
+              onOpenSubthread ? requestOpenSubthread : undefined
+            }
+            onReact={onReact}
+          />
+        )
       ))}
       {pendingMessages.map((message) => (
         <PendingChatRow key={`pending-${message.id}`} message={message} cwd={cwd} />
       ))}
+      {streamStatus?.liveProgress ? (
+        <div className="chat-row chat-row--system chat-row--reconnecting">
+          <StreamReconnectNotice text={streamStatus.text} />
+        </div>
+      ) : null}
       {ownerSelectionItem ? (
         <ThreadOwnerDialog
           candidates={namedOwnerCandidates}
@@ -741,10 +862,11 @@ function ChatRow({
     ? ` chat-bubble--long-card ${expanded ? "expanded" : "collapsed"}`
     : "";
   if (row.kind === "system") {
+    const text = row.count && row.count > 1 ? `${row.text} ×${row.count}` : row.text;
     return (
       <div className={`chat-row chat-row--system${topBubbleClass}`}>
         <SystemEventDivider
-          text={row.text}
+          text={text}
           className="chat-system-divider"
         />
       </div>

--- a/desktop/src/renderer/ChatThreadViewContainer.tsx
+++ b/desktop/src/renderer/ChatThreadViewContainer.tsx
@@ -5,9 +5,11 @@ import type {
   ThreadItem,
   Turn,
 } from "../shared/protocol";
+import type { TurnStreamStatus } from "./AppState";
 import { ChatThreadView } from "./ChatThreadView";
 import type { QueuedComposerMessage } from "./ComposerMessages";
 import { aggregateMarksBySeq } from "./MessageMarks";
+import type { TurnEventDisplay } from "./TurnEvents";
 import { useThreadMarks } from "./useThreadMarks";
 
 // Feeds ChatThreadView its live read receipts + reactions. Split out because
@@ -25,6 +27,8 @@ export function ChatThreadViewContainer({
   resolveParticipantName,
   threadOwnerCandidates,
   subthreadsByAnchor,
+  streamStatus,
+  turnEvents,
   onOpenSubthread,
   onReact,
 }: {
@@ -40,6 +44,8 @@ export function ChatThreadViewContainer({
     import("../shared/protocol").ParticipantSummary
   >;
   subthreadsByAnchor?: ReadonlyMap<string, ConversationSubthread>;
+  streamStatus?: TurnStreamStatus;
+  turnEvents?: ReadonlyArray<{ turnID: string; event: TurnEventDisplay }>;
   onOpenSubthread?: (
     item: ThreadItem,
     threadOwnerParticipantID?: string,
@@ -64,6 +70,8 @@ export function ChatThreadViewContainer({
       resolveParticipantName={resolveParticipantName}
       threadOwnerCandidates={threadOwnerCandidates}
       subthreadsByAnchor={subthreadsByAnchor}
+      streamStatus={streamStatus}
+      turnEvents={turnEvents}
       onOpenSubthread={onOpenSubthread}
       onReact={onReact}
     />

--- a/internal/appserver/resident_turn_failure.go
+++ b/internal/appserver/resident_turn_failure.go
@@ -23,6 +23,9 @@ func isRetryableTurnFailure(turn Turn) bool {
 	if turn.Status != TurnStatusFailed || turn.Error == nil {
 		return false
 	}
+	if providers.IsTerminalUsageLimit(turn.Error.Code, turn.Error.Message) {
+		return false
+	}
 	switch strings.TrimSpace(turn.Error.Category) {
 	case "network", "provider":
 		return true

--- a/internal/appserver/turn_error_test.go
+++ b/internal/appserver/turn_error_test.go
@@ -54,6 +54,27 @@ func TestBuildTurnError_InvalidRequestIsNotRetryable(t *testing.T) {
 	}
 }
 
+func TestBuildTurnError_TerminalUsageLimitIsNotRetryable(t *testing.T) {
+	tests := []error{
+		&providers.HTTPError{
+			StatusCode: 429,
+			Body:       `{"error":{"code":"insufficient_quota","message":"You exceeded your current quota."}}`,
+		},
+		providers.NewProviderStreamError("usage_limit_reached", "The usage limit has been reached"),
+		&providers.HTTPError{
+			StatusCode: 403,
+			Body:       `{"error":{"type":"permission_error","message":"The usage limit has been reached"}}`,
+		},
+	}
+	for _, err := range tests {
+		out := BuildTurnError(err, "kimi-code")
+		turn := Turn{Status: TurnStatusFailed, Error: &out}
+		if isRetryableTurnFailure(turn) {
+			t.Fatalf("%T terminal usage limit must not be retried: %+v", err, out)
+		}
+	}
+}
+
 // TestBuildTurnError_Nil covers the no-error path. BuildTurnError
 // must not panic on nil and must still surface the provider so the
 // front-end can show "Provider: openai" even when the body is empty.

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -2243,6 +2243,53 @@ func TestStreamChat_ServerError(t *testing.T) {
 	}
 }
 
+func TestReliableStreamChat_KimiUsageLimit403StopsWithoutReconnect(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"error":{"type":"permission_error","message":"The usage limit has been reached"}}`)
+	}))
+	defer server.Close()
+
+	rawClient, err := New(ClientConfig{BaseURL: server.URL, APIKey: "kimi-key"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	client := providers.NewReliableStreamClient(rawClient, nil)
+	ch, err := client.StreamChat(context.Background(), providers.ChatRequest{
+		Model: "kimi-for-coding",
+		Messages: []providers.ChatMessage{
+			{Role: "user", Content: "hi"},
+		},
+		Operation: providers.NewInferenceOperation(
+			providers.InferenceOperationAgentRound,
+			providers.InferenceProfileInteractive,
+		),
+	})
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+
+	var reconnects, finalErrors int
+	for event := range ch {
+		if event.Type == providers.EventLifecycle && event.Lifecycle != nil && event.Lifecycle.Phase == providers.StreamPhaseReconnecting {
+			reconnects++
+		}
+		if event.Type == providers.EventError {
+			finalErrors++
+		}
+	}
+
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("physical requests = %d, want 1", got)
+	}
+	if reconnects != 0 || finalErrors != 1 {
+		t.Fatalf("reconnects/final errors = %d/%d, want 0/1", reconnects, finalErrors)
+	}
+}
+
 func TestStreamChat_RejectsInvalidMessageSequenceBeforeRequest(t *testing.T) {
 	var hits atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/recovery.go
+++ b/internal/providers/recovery.go
@@ -215,10 +215,10 @@ func normalizeFailure(err error) NormalizedFailure {
 		switch {
 		case httpErr.ContextOverflow:
 			failure.Category = FailureContextOverflow
+		case (httpErr.StatusCode == 403 || httpErr.StatusCode == 429) && isTerminalUsageLimit(httpErr.ProviderCode, httpErr.Body):
+			failure.Category = FailureQuota
 		case httpErr.StatusCode == 401 || httpErr.StatusCode == 403:
 			failure.Category = FailureAuthentication
-		case httpErr.StatusCode == 429 && isTerminalUsageLimit(httpErr.ProviderCode, httpErr.Body):
-			failure.Category = FailureQuota
 		case httpErr.StatusCode == 429:
 			failure.Category = FailureRateLimit
 		case httpErr.StatusCode == 529:

--- a/internal/providers/recovery_test.go
+++ b/internal/providers/recovery_test.go
@@ -18,6 +18,9 @@ func TestPlanRecoveryHTTPStatusSemantics(t *testing.T) {
 		{name: "anthropic 404", err: &HTTPError{ProviderFamily: "anthropic", StatusCode: 404, Body: "not found"}, action: RecoveryStop},
 		{name: "temporary rate limit", err: &HTTPError{StatusCode: 429, Body: "retry later", RetryAfter: 3 * time.Second}, action: RecoveryWaitThenReplay},
 		{name: "terminal quota", err: &HTTPError{StatusCode: 429, Body: "insufficient_quota"}, action: RecoveryStop},
+		{name: "terminal 403 quota", err: &HTTPError{StatusCode: 403, Body: "The usage limit has been reached", AuthRefreshable: true}, action: RecoveryStop},
+		{name: "terminal 403 permission", err: &HTTPError{StatusCode: 403, Body: "forbidden"}, action: RecoveryStop},
+		{name: "billing service 503", err: &HTTPError{StatusCode: 503, Body: "billing service temporarily unavailable"}, action: RecoveryReplaySame},
 		{name: "context transform", err: &HTTPError{StatusCode: 413, Body: "context_length_exceeded", ContextOverflow: true}, action: RecoveryTransformPayload},
 		{name: "body too large", err: &HTTPError{StatusCode: 413, Body: "nginx client_max_body_size"}, action: RecoveryStop},
 	}

--- a/internal/providers/reliable_stream_test.go
+++ b/internal/providers/reliable_stream_test.go
@@ -327,6 +327,39 @@ func TestReliableStreamClientDoesNotRetryNonRetryableError(t *testing.T) {
 	}
 }
 
+func TestReliableStreamClientAppliesBackoffBeforeReconnect(t *testing.T) {
+	inner := &reliableStreamMockClient{attempts: []reliableStreamAttempt{
+		{err: &HTTPError{StatusCode: 500, Body: "upstream"}},
+		{events: []StreamEvent{{Type: EventDone}}},
+	}}
+	var delays []time.Duration
+	var callsObservedAtWait []int
+	client := NewReliableStreamClient(
+		inner,
+		nil,
+		WithStreamRetryWait(func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			callsObservedAtWait = append(callsObservedAtWait, inner.callCount)
+			return nil
+		}),
+	)
+	ch, err := client.StreamChat(context.Background(), reliableTestRequest())
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+	_ = collectReliableEvents(t, ch)
+
+	if inner.callCount != 2 {
+		t.Fatalf("stream calls = %d, want 2", inner.callCount)
+	}
+	if !reflect.DeepEqual(callsObservedAtWait, []int{1}) {
+		t.Fatalf("calls observed when waiting = %v, want [1]", callsObservedAtWait)
+	}
+	if len(delays) != 1 || delays[0] < time.Second || delays[0] > 1250*time.Millisecond {
+		t.Fatalf("first reconnect delay = %v, want exponential backoff in [1s, 1.25s]", delays)
+	}
+}
+
 func TestReliableStreamClientDoesNotReplayLocalBackpressure(t *testing.T) {
 	inner := &reliableStreamMockClient{attempts: []reliableStreamAttempt{
 		{events: []StreamEvent{{Type: EventError, Error: &LocalBackpressureError{Component: "test reader"}}}},

--- a/internal/providers/retry.go
+++ b/internal/providers/retry.go
@@ -289,6 +289,14 @@ func IsRetryable(err error) bool {
 	return PlanRecovery(NormalizeFailure(err)).Retryable()
 }
 
+// IsTerminalUsageLimit reports whether a provider code/message describes a
+// durable quota or billing limit. Workflow layers use the same classifier as
+// inference recovery so a terminal provider failure cannot gain a fresh retry
+// budget after the underlying request has already stopped.
+func IsTerminalUsageLimit(code, message string) bool {
+	return isTerminalUsageLimit(code, message)
+}
+
 // IsAuthError returns true if the error is an authentication failure.
 func IsAuthError(err error) bool {
 	var httpErr *HTTPError
@@ -373,7 +381,6 @@ func isTerminalUsageLimit(code, message string) bool {
 		"quota exceeded",
 		"out of budget",
 		"available balance",
-		"billing",
 	}
 	for _, marker := range terminal {
 		if strings.Contains(needle, marker) {


### PR DESCRIPTION
## Summary
- classify terminal 403/429 quota failures in the shared recovery layer and prevent resident task retries from minting a fresh retry budget
- verify shared stream backoff happens before the next physical request, including a Kimi-style 403 regression with one request, no reconnect, and one terminal error
- surface reconnect progress and terminal failures in DM/group chat history, coalesce adjacent identical system events, and keep auto-follow bound to the real scroll ancestor

## Scope
These production changes are provider-agnostic for clients using Wuu’s shared inference recovery and reliable stream path. Kimi is the end-to-end regression case, not a provider-specific branch.

## Validation
- `go test ./internal/providers ./internal/providers/anthropic ./internal/appserver`
- `npx vitest run src/renderer/AppState.test.ts src/renderer/ChatThreadView.test.tsx src/renderer/CachedConversationPanes.test.tsx` (226 tests)
- `npm run typecheck`
- `git diff --check origin/main...HEAD`