### PR TITLE
fix(desktop): settle conversation layout before reveal

### DIFF
--- a/desktop/src/renderer/CachedConversationPanes.test.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.test.tsx
@@ -20,6 +20,7 @@ afterEach(() => {
   for (const root of roots) {
     act(() => root.unmount());
   }
+  vi.restoreAllMocks();
   roots = [];
   turnListRenders.clear();
   document.body.innerHTML = "";
@@ -141,6 +142,32 @@ describe("CachedConversationPanes Thread wiring", () => {
 });
 
 describe("CachedConversationPanes session switching", () => {
+  it("waits for the mounted message DOM to settle before entering", () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    const { container } = renderPane(chatThread("thread-a", {}));
+    const pane = container.querySelector<HTMLElement>(".cached-conversation-pane");
+
+    expect(pane?.hasAttribute("data-layout-settled")).toBe(false);
+    expect(frameCallbacks).toHaveLength(1);
+
+    act(() => {
+      frameCallbacks.shift()?.(0);
+    });
+    expect(pane?.hasAttribute("data-layout-settled")).toBe(false);
+    expect(frameCallbacks).toHaveLength(1);
+
+    act(() => {
+      frameCallbacks.shift()?.(16);
+    });
+    expect(pane?.hasAttribute("data-layout-settled")).toBe(true);
+  });
+
   it("does not re-render an unrelated hidden conversation", () => {
     const threads = [
       chatThread("thread-a", {}),

--- a/desktop/src/renderer/CachedConversationPanes.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useLayoutEffect, useState } from "react";
 import type {
   Agent,
   ConversationSubthread,
@@ -208,6 +208,7 @@ const CachedConversationPane = memo(function CachedConversationPane({
   subthreadsByAnchor,
   pendingChatMessagesByThread,
 }: CachedConversationPaneProps): JSX.Element {
+  const [layoutSettled, setLayoutSettled] = useState(false);
   const threadTurns = thread.turns ?? [];
   const threadLatestAgentMessageID = latestAgentMessageItemID(threadTurns);
   const threadContextEntries = contextCompositionEntries.filter(
@@ -252,10 +253,31 @@ const CachedConversationPane = memo(function CachedConversationPane({
   const isGroupChat = isGroupThread(thread);
   const isChatStyleThread = isDMThread(thread) || isGroupChat;
 
+  useLayoutEffect(() => {
+    if (!isActive) {
+      setLayoutSettled(false);
+      return undefined;
+    }
+
+    let settleFrame: number | undefined;
+    const layoutFrame = window.requestAnimationFrame(() => {
+      settleFrame = window.requestAnimationFrame(() => {
+        setLayoutSettled(true);
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(layoutFrame);
+      if (settleFrame !== undefined) {
+        window.cancelAnimationFrame(settleFrame);
+      }
+    };
+  }, [isActive, thread.id]);
+
   return (
     <div
       className="cached-conversation-pane"
       data-active={isActive}
+      data-layout-settled={isActive && layoutSettled ? "" : undefined}
       data-thread-id={thread.id}
       style={isActive ? undefined : { display: "none" }}
     >

--- a/desktop/src/renderer/styles/conversation-shell.css
+++ b/desktop/src/renderer/styles/conversation-shell.css
@@ -194,7 +194,11 @@
   grid-column: 1;
 }
 
-.cached-conversation-pane[data-active="true"] > .conversation-width {
+.cached-conversation-pane[data-active="true"]:not([data-layout-settled]) > .conversation-width {
+  opacity: 0;
+}
+
+.cached-conversation-pane[data-active="true"][data-layout-settled] > .conversation-width {
   animation: content-swap-enter var(--content-swap-duration) var(--content-swap-easing) both;
 }
 
@@ -256,7 +260,11 @@
     transition: none;
   }
 
-  .cached-conversation-pane[data-active="true"] > .conversation-width {
+  .cached-conversation-pane[data-active="true"]:not([data-layout-settled]) > .conversation-width {
+    opacity: 1;
+  }
+
+  .cached-conversation-pane[data-active="true"][data-layout-settled] > .conversation-width {
     animation: none;
   }
 }

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -108,15 +108,17 @@
 }
 
 /*
- * The last few turns fill the initial viewport when a conversation opens
- * pinned to the bottom. Render them for real from the FIRST layout pass:
+ * The last few turns usually fill the initial viewport when a conversation
+ * opens pinned to the bottom. Render them for real from the FIRST layout pass:
  * if they carry the 260px estimate instead, the pre-paint scroll-to-bottom
  * measures a wrong scrollHeight, their true heights resolve at first paint
  * (overflow-anchor is disabled while auto-following, so the browser does
  * not compensate), and the ResizeObserver re-pin lands one frame later —
  * a visible vertical jolt right after opening a session. Turns further up
- * keep the cheap estimate; they only resolve under a reading scroll, where
- * the correction is imperceptible.
+ * keep the cheap estimate. When a viewport reaches past this tail (for
+ * example because the recent turns are short and an older turn contains a
+ * tall diff card), the pane's data-layout-settled gate keeps that correction
+ * hidden until the scroll anchor has caught up.
  */
 .turn:nth-last-child(-n + 5 of .turn) {
   content-visibility: visible;


### PR DESCRIPTION
## Summary

- hide a newly activated conversation pane for two layout frames before running its entrance animation
- let offscreen turn intrinsic heights and scroll anchoring settle without a visible correction, including tall file-diff summary turns
- preserve reduced-motion behavior and cancel pending animation frames on rapid tab switches or unmount

## Root cause

Conversation turns use `content-visibility: auto` with a 260px intrinsic estimate. Only the final five turns are forced into real layout. When those turns are short, the initial viewport reaches an older turn whose real height can differ substantially—especially when it includes a file-change summary. Recreating the pane on a session-tab switch briefly paints the estimated layout before Chromium resolves the real height and the scroll observer re-anchors it.

## Verification

- 32 targeted renderer tests passed
- `tsc --noEmit`
- `electron-vite build`
- PR range verified as one commit changing only the four pane/test/style files