### PR TITLE
fix(openai): extend Responses WebSocket cache TTL

### DIFF
--- a/internal/providers/openai/responses_websocket_stream.go
+++ b/internal/providers/openai/responses_websocket_stream.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultResponsesWebSocketCacheTTL = 5 * time.Minute
+	defaultResponsesWebSocketCacheTTL = 30 * time.Minute
 	// Fallback pins prevent every request in a hot session from immediately
 	// retrying a broken websocket path. Transient failures re-probe quickly,
 	// connection pressure backs off longer, and stable compatibility/auth

--- a/internal/providers/openai/responses_websocket_test.go
+++ b/internal/providers/openai/responses_websocket_test.go
@@ -22,6 +22,13 @@ import (
 
 func immediateStreamRetryWait(context.Context, time.Duration) error { return nil }
 
+func TestNewResponsesWebSocketCache_DefaultIdleTTL(t *testing.T) {
+	cache := NewResponsesWebSocketCache()
+	if cache.idleTTL != 30*time.Minute {
+		t.Fatalf("idle TTL = %s, want 30m", cache.idleTTL)
+	}
+}
+
 func TestResolveCodexWebSocketURL(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Summary

- extend the default Responses WebSocket idle cache TTL from 5 minutes to 30 minutes
- add a regression test for the default TTL

## Tests

- `go test ./internal/providers/openai`
- `go test ./...`