### PR TITLE
fix(recovery): stop terminal quota replays

### DIFF
--- a/internal/appserver/resident_turn_failure.go
+++ b/internal/appserver/resident_turn_failure.go
@@ -23,6 +23,9 @@ func isRetryableTurnFailure(turn Turn) bool {
 	if turn.Status != TurnStatusFailed || turn.Error == nil {
 		return false
 	}
+	if providers.IsTerminalUsageLimit(turn.Error.Code, turn.Error.Message) {
+		return false
+	}
 	switch strings.TrimSpace(turn.Error.Category) {
 	case "network", "provider":
 		return true

--- a/internal/appserver/turn_error_test.go
+++ b/internal/appserver/turn_error_test.go
@@ -54,6 +54,27 @@ func TestBuildTurnError_InvalidRequestIsNotRetryable(t *testing.T) {
 	}
 }
 
+func TestBuildTurnError_TerminalUsageLimitIsNotRetryable(t *testing.T) {
+	tests := []error{
+		&providers.HTTPError{
+			StatusCode: 429,
+			Body:       `{"error":{"code":"insufficient_quota","message":"You exceeded your current quota."}}`,
+		},
+		providers.NewProviderStreamError("usage_limit_reached", "The usage limit has been reached"),
+		&providers.HTTPError{
+			StatusCode: 403,
+			Body:       `{"error":{"type":"permission_error","message":"The usage limit has been reached"}}`,
+		},
+	}
+	for _, err := range tests {
+		out := BuildTurnError(err, "kimi-code")
+		turn := Turn{Status: TurnStatusFailed, Error: &out}
+		if isRetryableTurnFailure(turn) {
+			t.Fatalf("%T terminal usage limit must not be retried: %+v", err, out)
+		}
+	}
+}
+
 // TestBuildTurnError_Nil covers the no-error path. BuildTurnError
 // must not panic on nil and must still surface the provider so the
 // front-end can show "Provider: openai" even when the body is empty.

--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -2243,6 +2243,53 @@ func TestStreamChat_ServerError(t *testing.T) {
 	}
 }
 
+func TestReliableStreamChat_KimiUsageLimit403StopsWithoutReconnect(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"error":{"type":"permission_error","message":"The usage limit has been reached"}}`)
+	}))
+	defer server.Close()
+
+	rawClient, err := New(ClientConfig{BaseURL: server.URL, APIKey: "kimi-key"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	client := providers.NewReliableStreamClient(rawClient, nil)
+	ch, err := client.StreamChat(context.Background(), providers.ChatRequest{
+		Model: "kimi-for-coding",
+		Messages: []providers.ChatMessage{
+			{Role: "user", Content: "hi"},
+		},
+		Operation: providers.NewInferenceOperation(
+			providers.InferenceOperationAgentRound,
+			providers.InferenceProfileInteractive,
+		),
+	})
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+
+	var reconnects, finalErrors int
+	for event := range ch {
+		if event.Type == providers.EventLifecycle && event.Lifecycle != nil && event.Lifecycle.Phase == providers.StreamPhaseReconnecting {
+			reconnects++
+		}
+		if event.Type == providers.EventError {
+			finalErrors++
+		}
+	}
+
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("physical requests = %d, want 1", got)
+	}
+	if reconnects != 0 || finalErrors != 1 {
+		t.Fatalf("reconnects/final errors = %d/%d, want 0/1", reconnects, finalErrors)
+	}
+}
+
 func TestStreamChat_RejectsInvalidMessageSequenceBeforeRequest(t *testing.T) {
 	var hits atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/recovery.go
+++ b/internal/providers/recovery.go
@@ -215,10 +215,10 @@ func normalizeFailure(err error) NormalizedFailure {
 		switch {
 		case httpErr.ContextOverflow:
 			failure.Category = FailureContextOverflow
+		case (httpErr.StatusCode == 403 || httpErr.StatusCode == 429) && isTerminalUsageLimit(httpErr.ProviderCode, httpErr.Body):
+			failure.Category = FailureQuota
 		case httpErr.StatusCode == 401 || httpErr.StatusCode == 403:
 			failure.Category = FailureAuthentication
-		case httpErr.StatusCode == 429 && isTerminalUsageLimit(httpErr.ProviderCode, httpErr.Body):
-			failure.Category = FailureQuota
 		case httpErr.StatusCode == 429:
 			failure.Category = FailureRateLimit
 		case httpErr.StatusCode == 529:

--- a/internal/providers/recovery_test.go
+++ b/internal/providers/recovery_test.go
@@ -18,6 +18,9 @@ func TestPlanRecoveryHTTPStatusSemantics(t *testing.T) {
 		{name: "anthropic 404", err: &HTTPError{ProviderFamily: "anthropic", StatusCode: 404, Body: "not found"}, action: RecoveryStop},
 		{name: "temporary rate limit", err: &HTTPError{StatusCode: 429, Body: "retry later", RetryAfter: 3 * time.Second}, action: RecoveryWaitThenReplay},
 		{name: "terminal quota", err: &HTTPError{StatusCode: 429, Body: "insufficient_quota"}, action: RecoveryStop},
+		{name: "terminal 403 quota", err: &HTTPError{StatusCode: 403, Body: "The usage limit has been reached", AuthRefreshable: true}, action: RecoveryStop},
+		{name: "terminal 403 permission", err: &HTTPError{StatusCode: 403, Body: "forbidden"}, action: RecoveryStop},
+		{name: "billing service 503", err: &HTTPError{StatusCode: 503, Body: "billing service temporarily unavailable"}, action: RecoveryReplaySame},
 		{name: "context transform", err: &HTTPError{StatusCode: 413, Body: "context_length_exceeded", ContextOverflow: true}, action: RecoveryTransformPayload},
 		{name: "body too large", err: &HTTPError{StatusCode: 413, Body: "nginx client_max_body_size"}, action: RecoveryStop},
 	}

--- a/internal/providers/reliable_stream_test.go
+++ b/internal/providers/reliable_stream_test.go
@@ -327,6 +327,39 @@ func TestReliableStreamClientDoesNotRetryNonRetryableError(t *testing.T) {
 	}
 }
 
+func TestReliableStreamClientAppliesBackoffBeforeReconnect(t *testing.T) {
+	inner := &reliableStreamMockClient{attempts: []reliableStreamAttempt{
+		{err: &HTTPError{StatusCode: 500, Body: "upstream"}},
+		{events: []StreamEvent{{Type: EventDone}}},
+	}}
+	var delays []time.Duration
+	var callsObservedAtWait []int
+	client := NewReliableStreamClient(
+		inner,
+		nil,
+		WithStreamRetryWait(func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			callsObservedAtWait = append(callsObservedAtWait, inner.callCount)
+			return nil
+		}),
+	)
+	ch, err := client.StreamChat(context.Background(), reliableTestRequest())
+	if err != nil {
+		t.Fatalf("StreamChat: %v", err)
+	}
+	_ = collectReliableEvents(t, ch)
+
+	if inner.callCount != 2 {
+		t.Fatalf("stream calls = %d, want 2", inner.callCount)
+	}
+	if !reflect.DeepEqual(callsObservedAtWait, []int{1}) {
+		t.Fatalf("calls observed when waiting = %v, want [1]", callsObservedAtWait)
+	}
+	if len(delays) != 1 || delays[0] < time.Second || delays[0] > 1250*time.Millisecond {
+		t.Fatalf("first reconnect delay = %v, want exponential backoff in [1s, 1.25s]", delays)
+	}
+}
+
 func TestReliableStreamClientDoesNotReplayLocalBackpressure(t *testing.T) {
 	inner := &reliableStreamMockClient{attempts: []reliableStreamAttempt{
 		{events: []StreamEvent{{Type: EventError, Error: &LocalBackpressureError{Component: "test reader"}}}},

--- a/internal/providers/retry.go
+++ b/internal/providers/retry.go
@@ -289,6 +289,14 @@ func IsRetryable(err error) bool {
 	return PlanRecovery(NormalizeFailure(err)).Retryable()
 }
 
+// IsTerminalUsageLimit reports whether a provider code/message describes a
+// durable quota or billing limit. Workflow layers use the same classifier as
+// inference recovery so a terminal provider failure cannot gain a fresh retry
+// budget after the underlying request has already stopped.
+func IsTerminalUsageLimit(code, message string) bool {
+	return isTerminalUsageLimit(code, message)
+}
+
 // IsAuthError returns true if the error is an authentication failure.
 func IsAuthError(err error) bool {
 	var httpErr *HTTPError
@@ -373,7 +381,6 @@ func isTerminalUsageLimit(code, message string) bool {
 		"quota exceeded",
 		"out of budget",
 		"available balance",
-		"billing",
 	}
 	for _, marker := range terminal {
 		if strings.Contains(needle, marker) {


### PR DESCRIPTION
## Summary
- classify provider usage-limit responses as terminal quota failures
- prevent resident turn retries from granting terminal quota errors a fresh retry budget
- preserve retries and backoff for transient provider failures

## Tests
- `go test ./internal/providers ./internal/providers/anthropic ./internal/appserver`
- `go test ./...`