### PR TITLE
fix(desktop): surface chat stream recovery

### DIFF
--- a/desktop/src/renderer/AppState.test.ts
+++ b/desktop/src/renderer/AppState.test.ts
@@ -2811,7 +2811,7 @@ describe("chatMessagesFromTurns", () => {
     ]);
   });
 
-  it("coalesces consecutive envelope rows into one visible chat row", () => {
+  it("does not coalesce consecutive envelope rows across turns", () => {
     const first: ThreadItem = {
       id: "item-1",
       type: "user_message",
@@ -2833,7 +2833,13 @@ describe("chatMessagesFromTurns", () => {
         kind: "envelope",
         id: "turn-1:item-1",
         turnID: "turn-1",
-        items: [first, second],
+        items: [first],
+      },
+      {
+        kind: "envelope",
+        id: "turn-2:item-2",
+        turnID: "turn-2",
+        items: [second],
       },
     ]);
   });
@@ -2927,6 +2933,47 @@ describe("chatMessagesFromTurns", () => {
         item: notification,
       },
       { kind: "user", id: "turn-1:item-2", turnID: "turn-1", item: realMessage },
+    ]);
+  });
+
+  it("coalesces equivalent system events only within the same turn", () => {
+    const first: ThreadItem = {
+      id: "handoff-1",
+      type: "user_message",
+      text: handoffText(),
+    };
+    const second: ThreadItem = {
+      id: "handoff-2",
+      type: "user_message",
+      text: handoffText(),
+    };
+    const third: ThreadItem = {
+      id: "handoff-3",
+      type: "user_message",
+      text: handoffText(),
+    };
+
+    expect(
+      chatMessagesFromTurns([
+        turn("turn-1", [first, second]),
+        turn("turn-2", [third]),
+      ]),
+    ).toEqual([
+      {
+        kind: "system",
+        id: "turn-1:handoff-1",
+        turnID: "turn-1",
+        text: "subagent 完成了任务",
+        item: first,
+        count: 2,
+      },
+      {
+        kind: "system",
+        id: "turn-2:handoff-3",
+        turnID: "turn-2",
+        text: "subagent 完成了任务",
+        item: third,
+      },
     ]);
   });
 

--- a/desktop/src/renderer/AppState.ts
+++ b/desktop/src/renderer/AppState.ts
@@ -2102,7 +2102,14 @@ export type ChatMessageRow =
   | { kind: "user"; id: string; turnID: string; item: ThreadItem }
   | { kind: "envelope"; id: string; turnID: string; items: ThreadItem[] }
   | { kind: "participant"; id: string; turnID: string; item: ThreadItem }
-  | { kind: "system"; id: string; turnID: string; text: string; item: ThreadItem }
+  | {
+      kind: "system";
+      id: string;
+      turnID: string;
+      text: string;
+      item: ThreadItem;
+      count?: number;
+    }
   | { kind: "focus"; id: string; turnID: string; item: ThreadItem };
 
 /**
@@ -2196,13 +2203,22 @@ export function chatMessagesFromTurns(
         // why `name` is the reliable signal and `text` sniff is a fallback).
         const handoff = agentHandoffDisplayItem(item);
         if (handoff) {
-          rows.push({
-            kind: "system",
-            id,
-            turnID: turn.id,
-            text: handoff.label,
-            item,
-          });
+          const previous = rows[rows.length - 1];
+          if (
+            previous?.kind === "system" &&
+            previous.turnID === turn.id &&
+            previous.text === handoff.label
+          ) {
+            previous.count = (previous.count ?? 1) + 1;
+          } else {
+            rows.push({
+              kind: "system",
+              id,
+              turnID: turn.id,
+              text: handoff.label,
+              item,
+            });
+          }
           continue;
         }
         if (isInternalUserNotificationItem(item)) {
@@ -2210,7 +2226,7 @@ export function chatMessagesFromTurns(
         }
         if (item.envelope_meta && item.envelope_meta.length > 0) {
           const previous = rows[rows.length - 1];
-          if (previous?.kind === "envelope") {
+          if (previous?.kind === "envelope" && previous.turnID === turn.id) {
             previous.items.push(item);
           } else {
             rows.push({ kind: "envelope", id, turnID: turn.id, items: [item] });

--- a/desktop/src/renderer/CachedConversationPanes.test.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.test.tsx
@@ -2,6 +2,7 @@ import { act, createElement, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Thread } from "../shared/protocol";
+import type { TurnStreamStatus } from "./AppState";
 import { CachedConversationPanes } from "./CachedConversationPanes";
 import { ImagePreviewProvider } from "./ImagePreview";
 
@@ -61,6 +62,7 @@ function chatThread(
 function renderPane(
   thread: Thread,
   onOpenSubthread = vi.fn(),
+  turnStreamStatus: Record<string, TurnStreamStatus> = {},
 ): { container: HTMLElement; onOpenSubthread: ReturnType<typeof vi.fn> } {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -86,7 +88,7 @@ function renderPane(
     onCancelEditMessage: () => {},
     onSubmitEditMessage: () => {},
     onOpenFileDiff: () => {},
-    turnStreamStatus: {},
+    turnStreamStatus,
     busyParticipantIDs: new Set(),
     activeThreadMarks: [],
     resolveParticipantName: (id) => id,
@@ -106,6 +108,49 @@ function renderPane(
 }
 
 describe("CachedConversationPanes Thread wiring", () => {
+  it("surfaces reconnect progress and terminal failures inside DM streams", () => {
+    const running = chatThread("dm-running", {
+      workspace_kind: "dm",
+      dm_participant_id: "prt-a",
+      turns: [
+        {
+          id: "turn-running",
+          status: "in_progress",
+          items_view: "full",
+          items: [{ id: "human-running", type: "user_message", text: "继续" }],
+        },
+      ],
+    });
+    const reconnecting = renderPane(running, vi.fn(), {
+      "turn-running": {
+        text: "消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）",
+        liveProgress: true,
+      },
+    }).container;
+    expect(
+      reconnecting.querySelector(".chat-row--reconnecting .turn-event-title")
+        ?.textContent,
+    ).toContain("消息流暂时中断");
+
+    const failed = chatThread("dm-failed", {
+      workspace_kind: "dm",
+      dm_participant_id: "prt-a",
+      turns: [
+        {
+          id: "turn-failed",
+          status: "failed",
+          items_view: "full",
+          items: [{ id: "human-failed", type: "user_message", text: "继续" }],
+          error: { message: "stream request failed: context deadline exceeded" },
+        },
+      ],
+    });
+    const terminal = renderPane(failed).container;
+    expect(
+      terminal.querySelector(".chat-row--turn-event .turn-event-title")?.textContent,
+    ).toBe("请求超时");
+  });
+
   it("does not expose Thread entry points in a DM", () => {
     const { container, onOpenSubthread } = renderPane(
       chatThread("dm-1", {

--- a/desktop/src/renderer/CachedConversationPanes.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.tsx
@@ -33,7 +33,9 @@ import {
   TurnView,
   latestAgentMessageItemID,
 } from "./TurnView";
+import { turnEventForTurn } from "./TurnEvents";
 import type { TurnFileDiffSelection } from "./TurnFileDiffTypes";
+import { turnHasAssistantOutput } from "./TurnViewHelpers";
 import type { HistoryMessageEditState } from "./ConversationHistoryActions";
 
 const CONVERSATION_GRID_COLUMNS = 12;
@@ -252,6 +254,11 @@ const CachedConversationPane = memo(function CachedConversationPane({
     ) : null;
   const isGroupChat = isGroupThread(thread);
   const isChatStyleThread = isDMThread(thread) || isGroupChat;
+  const latestTurn = threadTurns[threadTurns.length - 1];
+  const turnEvents = threadTurns.flatMap((turn) => {
+    const event = turnEventForTurn(turn, turnHasAssistantOutput(turn));
+    return event ? [{ turnID: turn.id, event }] : [];
+  });
 
   useLayoutEffect(() => {
     if (!isActive) {
@@ -294,6 +301,9 @@ const CachedConversationPane = memo(function CachedConversationPane({
             readerCount={chatReaderCountForThread(thread, chatReaderCount)}
             threadOwnerCandidates={isGroupChat ? thread.members : undefined}
             subthreadsByAnchor={isGroupChat ? subthreadsByAnchor : undefined}
+            isActive={isActive}
+            streamStatus={latestTurn ? turnStreamStatus[latestTurn.id] : undefined}
+            turnEvents={turnEvents}
             onOpenSubthread={
               isGroupChat
                 ? (item, ownerID, existingSubthreadID) =>

--- a/desktop/src/renderer/ChatThreadView.test.tsx
+++ b/desktop/src/renderer/ChatThreadView.test.tsx
@@ -276,7 +276,7 @@ describe("ChatThreadView", () => {
     expect(container.querySelector(".envelope-notice")).not.toBeNull();
   });
 
-  it("renders consecutive envelope rows as one collapsed notice", () => {
+  it("keeps consecutive envelope rows from different turns separate", () => {
     const container = mount(
       createElement(ChatThreadView, {
         turns: [
@@ -320,20 +320,9 @@ describe("ChatThreadView", () => {
       }),
     );
     const notices = container.querySelectorAll(".envelope-notice");
-    expect(notices).toHaveLength(1);
-    const toggle = container.querySelector<HTMLButtonElement>(
-      ".envelope-notice-toggle",
-    );
-    expect(toggle?.textContent).toContain("收到来自「all」的 2 条消息");
-    expect(toggle?.textContent).toContain("点名");
-    expect(toggle?.textContent).toContain("转发×1");
-
-    act(() => {
-      toggle?.click();
-    });
-    const body = container.querySelector(".envelope-notice-body");
-    expect(body?.textContent).toContain("第一条群聊消息");
-    expect(body?.textContent).toContain("第二条群聊消息");
+    expect(notices).toHaveLength(2);
+    expect(notices[0]?.textContent).not.toContain("点名");
+    expect(notices[1]?.textContent).toContain("点名");
   });
 
   it("starts a new envelope notice after a user query", () => {
@@ -461,6 +450,102 @@ describe("ChatThreadView reply / task affordances", () => {
       container.querySelector(".chat-system-divider .turn-event-title")
         ?.textContent,
     ).toBe("subagent 完成了任务");
+  });
+
+  it("renders reconnect progress and terminal network events in chat threads", () => {
+    const reconnecting = mount(
+      createElement(ChatThreadView, {
+        turns: turns([
+          { id: "item-1", type: "user_message", text: "继续处理" },
+        ]),
+        streamStatus: {
+          text: "消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）",
+          liveProgress: true,
+        },
+      }),
+    );
+    expect(
+      reconnecting.querySelector(".chat-row--reconnecting .turn-event-title")
+        ?.textContent,
+    ).toBe("消息流暂时中断，约 2 秒后继续（第 2/4 次尝试）");
+
+    const failed = mount(
+      createElement(ChatThreadView, {
+        turns: turns([
+          { id: "item-1", type: "user_message", text: "继续处理" },
+        ]),
+        turnEvents: [
+          {
+            turnID: "turn-1",
+            event: {
+              kind: "network_lost",
+              source: "turn",
+              presentation: "notice",
+              notice: {
+                category: "network",
+                tone: "error",
+                title: "网络异常",
+                detail: "请检查网络连接后重试。",
+              },
+            },
+          },
+        ],
+      }),
+    );
+    expect(
+      failed.querySelector(".chat-row--turn-event .turn-event-title")?.textContent,
+    ).toBe("网络异常");
+  });
+
+  it("keeps each turn's system rows on the correct side of its terminal event", () => {
+    const notification = (id: string): ThreadItem => ({
+      id,
+      type: "user_message",
+      text: JSON.stringify({
+        author: "/root/explore",
+        recipient: "/root",
+        content: `<subagent_notification>\n${JSON.stringify({
+          agent_path: "/root/explore",
+          status: {
+            type: "agent_result",
+            agent_id: "worker-1",
+            task_name: "explore",
+            status: "completed",
+          },
+        })}\n</subagent_notification>`,
+        trigger_turn: true,
+      }),
+    });
+    const container = mount(
+      createElement(ChatThreadView, {
+        turns: [
+          { id: "turn-1", items: [notification("item-1")] },
+          { id: "turn-2", items: [notification("item-2")] },
+        ],
+        turnEvents: [
+          {
+            turnID: "turn-1",
+            event: {
+              kind: "network_lost",
+              source: "turn",
+              presentation: "notice",
+              notice: {
+                category: "network",
+                tone: "error",
+                title: "网络异常",
+                detail: "请检查网络连接后重试。",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const rows = [...container.querySelectorAll(".chat-row")];
+    expect(rows).toHaveLength(3);
+    expect(rows[0]?.textContent).toContain("subagent 完成了任务");
+    expect(rows[1]?.classList.contains("chat-row--turn-event")).toBe(true);
+    expect(rows[2]?.textContent).toContain("subagent 完成了任务");
   });
 
   it("hangs a 'N 条回复' badge under a message that anchors a plain reply", () => {
@@ -1339,12 +1424,114 @@ describe("ChatThreadView windowing", () => {
       scrollAncestor,
     );
 
+    scrollAncestor.scrollTop = 0;
+    scrollAncestor.dispatchEvent(new Event("scroll"));
     triggerSentinelIntersection(mountPoint);
 
     // 80 rows before -> scrollHeight 3600; 160 rows after -> 6800. The
     // reader was pinned at scrollTop 0, so the compensation must add
     // exactly the height inserted above the viewport.
     expect(scrollAncestor.scrollTop).toBe(3200);
+  });
+
+  it("does not auto-follow updates while the pane is inactive", () => {
+    const scrollAncestor = document.createElement("div");
+    scrollAncestor.style.overflowY = "auto";
+    const mountPoint = document.createElement("div");
+    scrollAncestor.appendChild(mountPoint);
+    document.body.appendChild(scrollAncestor);
+    Object.defineProperty(scrollAncestor, "clientHeight", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scrollAncestor, "scrollHeight", {
+      value: 1200,
+      configurable: true,
+    });
+    scrollAncestor.scrollTop = 300;
+
+    const root = createRoot(mountPoint);
+    act(() => {
+      root.render(
+        createElement(
+          ImagePreviewProvider,
+          null,
+          createElement(ChatThreadView, {
+            isActive: false,
+            turns: turns([{ id: "item-1", type: "user_message", text: "继续" }]),
+            streamStatus: {
+              text: "消息流暂时中断，正在恢复（第 2/4 次尝试）",
+              liveProgress: true,
+            },
+          }),
+        ),
+      );
+    });
+    mountedRoots.push(root);
+    mountedContainers.push(scrollAncestor);
+
+    expect(scrollAncestor.scrollTop).toBe(300);
+  });
+
+  it("keeps recovery auto-follow paused while chat text is selected", () => {
+    const scrollAncestor = document.createElement("div");
+    scrollAncestor.style.overflowY = "auto";
+    const mountPoint = document.createElement("div");
+    scrollAncestor.appendChild(mountPoint);
+    document.body.appendChild(scrollAncestor);
+    Object.defineProperty(scrollAncestor, "clientHeight", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scrollAncestor, "scrollHeight", {
+      value: 1200,
+      configurable: true,
+    });
+
+    const renderThread = (statusText: string): React.ReactElement =>
+      createElement(
+        ImagePreviewProvider,
+        null,
+        createElement(ChatThreadView, {
+          turns: turns([{ id: "item-1", type: "user_message", text: "保留这段选择" }]),
+          streamStatus: { text: statusText, liveProgress: true },
+        }),
+      );
+    const root = createRoot(mountPoint);
+    act(() => {
+      root.render(renderThread("消息流暂时中断，正在恢复（第 1/4 次尝试）"));
+    });
+    mountedRoots.push(root);
+    mountedContainers.push(scrollAncestor);
+
+    scrollAncestor.scrollTop = 700;
+    scrollAncestor.dispatchEvent(new Event("scroll"));
+    const textNode = mountPoint.querySelector(".chat-row--user")?.firstChild;
+    const selection = document.getSelection();
+    expect(textNode).not.toBeNull();
+    expect(selection).not.toBeNull();
+    const range = document.createRange();
+    range.selectNodeContents(textNode!);
+    selection!.removeAllRanges();
+    selection!.addRange(range);
+
+    act(() => {
+      root.render(renderThread("消息流暂时中断，正在恢复（第 2/4 次尝试）"));
+    });
+    expect(scrollAncestor.scrollTop).toBe(700);
+
+    selection!.removeAllRanges();
+    act(() => {
+      root.render(renderThread("消息流暂时中断，正在恢复（第 3/4 次尝试）"));
+    });
+    expect(scrollAncestor.scrollTop).toBe(700);
+
+    scrollAncestor.scrollTop = 800;
+    scrollAncestor.dispatchEvent(new Event("scroll"));
+    act(() => {
+      root.render(renderThread("消息流暂时中断，正在恢复（第 4/4 次尝试）"));
+    });
+    expect(scrollAncestor.scrollTop).toBe(1200);
   });
 });
 

--- a/desktop/src/renderer/ChatThreadView.tsx
+++ b/desktop/src/renderer/ChatThreadView.tsx
@@ -20,7 +20,9 @@ import {
   chatMessagesFromTurns,
   replyCountBadge,
   type ChatMessageRow,
+  type TurnStreamStatus,
 } from "./AppState";
+import { selectionIntersectsNode } from "./AutoFollowScroll";
 import type { QueuedComposerMessage } from "./ComposerMessages";
 import { DefaultAvatarMark } from "./DefaultAvatar";
 import { reactionArt } from "./MessageReactionArt";
@@ -41,7 +43,12 @@ import {
 } from "./MessageMarks";
 import { ReadReceiptRing } from "./ReadReceiptRing";
 import { RichContent } from "./RichContent";
-import { SystemEventDivider } from "./TurnNotice";
+import {
+  StreamReconnectNotice,
+  SystemEventDivider,
+  TurnEventNotice,
+} from "./TurnNotice";
+import type { TurnEventDisplay } from "./TurnEvents";
 import { translateCurrent as translate, useI18n } from "./i18n";
 
 // Distance (px) from the bottom of the scroll container within which the
@@ -134,6 +141,9 @@ export function ChatThreadView({
   resolveParticipantName,
   threadOwnerCandidates = [],
   subthreadsByAnchor,
+  isActive = true,
+  streamStatus,
+  turnEvents = [],
   onOpenSubthread,
   onReact,
 }: {
@@ -169,6 +179,9 @@ export function ChatThreadView({
    * been (人点击)升级为 task。Absent = subthreads not loaded / not a group thread.
    */
   subthreadsByAnchor?: ReadonlyMap<string, ConversationSubthread>;
+  isActive?: boolean;
+  streamStatus?: TurnStreamStatus;
+  turnEvents?: ReadonlyArray<{ turnID: string; event: TurnEventDisplay }>;
   /**
    * Open the reply/subthread panel for a message. Wired to the same
    * create-or-find-by-anchor path the agent-brain transcript uses. Optional:
@@ -186,7 +199,49 @@ export function ChatThreadView({
    */
   onReact?: (item: ThreadItem, reaction: string) => void;
 }): JSX.Element {
-  const rows = useMemo(() => chatMessagesFromTurns(turns), [turns]);
+  const rows = useMemo(() => {
+    const messageRows = chatMessagesFromTurns(turns);
+    if (turnEvents.length === 0) {
+      return messageRows;
+    }
+    const eventsByTurn = new Map(turnEvents.map(({ turnID, event }) => [turnID, event]));
+    const merged: Array<
+      | ChatMessageRow
+      | {
+          kind: "turn-event";
+          id: string;
+          turnID: string;
+          event: TurnEventDisplay;
+          count?: number;
+        }
+    > = [];
+    let messageIndex = 0;
+    for (const turn of turns) {
+      while (messageRows[messageIndex]?.turnID === turn.id) {
+        merged.push(messageRows[messageIndex]!);
+        messageIndex += 1;
+      }
+      const event = eventsByTurn.get(turn.id);
+      if (event) {
+        const previous = merged[merged.length - 1];
+        if (
+          previous?.kind === "turn-event" &&
+          JSON.stringify(previous.event) === JSON.stringify(event)
+        ) {
+          previous.count = (previous.count ?? 1) + 1;
+        } else {
+          merged.push({
+            kind: "turn-event",
+            id: `${turn.id}:turn-event`,
+            turnID: turn.id,
+            event,
+          });
+        }
+      }
+    }
+    merged.push(...messageRows.slice(messageIndex));
+    return merged;
+  }, [turnEvents, turns]);
   // 贴表情 and 开 Thread are one-click affordances on each group bubble's toolbar
   // (ChatBubbleToolbar) — no right-click menu, no hoisted popup state. A bubble
   // inside a cth reply panel receives onReact but not onOpenSubthread, so its
@@ -195,6 +250,10 @@ export function ChatThreadView({
   // never wires the reply handler).
   const containerRef = useRef<HTMLDivElement | null>(null);
   const topSentinelRef = useRef<HTMLDivElement | null>(null);
+  const autoFollowRef = useRef(true);
+  const selectionPausedAutoFollowRef = useRef(false);
+  const autoFollowParentRef = useRef<HTMLElement | null>(null);
+  const autoFollowListenerRef = useRef<(() => void) | null>(null);
   const [ownerSelectionItem, setOwnerSelectionItem] = useState<ThreadItem>();
   const namedOwnerCandidates = useMemo(
     () =>
@@ -234,7 +293,15 @@ export function ChatThreadView({
   const closeOwnerSelection = useCallback(() => {
     setOwnerSelectionItem(undefined);
   }, []);
-  const rowCount = rows.length + pendingMessages.length;
+  const autoFollowVersion = [
+    ...rows.map((row) =>
+      row.kind === "turn-event"
+        ? `${row.id}:${row.event.kind}:${row.event.presentation}`
+        : row.id,
+    ),
+    ...pendingMessages.map((message) => `pending:${message.id}`),
+    streamStatus?.liveProgress ? `stream:${streamStatus.text}` : "",
+  ].join("\u0000");
 
   // Count of the oldest rows currently withheld from the DOM. 0 means the
   // whole history is rendered (either it was never longer than the
@@ -335,19 +402,69 @@ export function ChatThreadView({
   }, [hiddenOlderCount, revealOlder]);
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
+    const detachAutoFollow = (): void => {
+      if (autoFollowParentRef.current && autoFollowListenerRef.current) {
+        autoFollowParentRef.current.removeEventListener(
+          "scroll",
+          autoFollowListenerRef.current,
+        );
+      }
+      autoFollowParentRef.current = null;
+      autoFollowListenerRef.current = null;
+    };
+    if (!isActive) {
+      detachAutoFollow();
+      selectionPausedAutoFollowRef.current = false;
       return;
     }
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    if (distanceFromBottom <= AUTO_FOLLOW_THRESHOLD_PX) {
-      container.scrollTop = container.scrollHeight;
+    const scrollParent = findScrollParent(containerRef.current);
+    if (!scrollParent) {
+      detachAutoFollow();
+      return;
     }
-    // rowCount changes whenever a real chat row is added or removed; that is
-    // the only signal that should trigger auto-follow.
+    if (autoFollowParentRef.current !== scrollParent) {
+      detachAutoFollow();
+      const updateAutoFollow = (): void => {
+        if (selectionIntersectsNode(document.getSelection(), scrollParent)) {
+          selectionPausedAutoFollowRef.current = true;
+          autoFollowRef.current = false;
+          return;
+        }
+        selectionPausedAutoFollowRef.current = false;
+        autoFollowRef.current =
+          scrollParent.scrollHeight - scrollParent.scrollTop - scrollParent.clientHeight <=
+          AUTO_FOLLOW_THRESHOLD_PX;
+      };
+      scrollParent.addEventListener("scroll", updateAutoFollow, { passive: true });
+      autoFollowParentRef.current = scrollParent;
+      autoFollowListenerRef.current = updateAutoFollow;
+    }
+    if (selectionIntersectsNode(document.getSelection(), scrollParent)) {
+      selectionPausedAutoFollowRef.current = true;
+      autoFollowRef.current = false;
+    }
+    if (autoFollowRef.current) {
+      scrollParent.scrollTop = scrollParent.scrollHeight;
+    }
+    if (!selectionPausedAutoFollowRef.current) {
+      autoFollowListenerRef.current?.();
+    }
+    // Identity/state changes, rather than only row count, also cover replacing
+    // a reconnect notice with a terminal event in the same render slot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowCount]);
+  }, [autoFollowVersion, isActive]);
+
+  useEffect(
+    () => () => {
+      if (autoFollowParentRef.current && autoFollowListenerRef.current) {
+        autoFollowParentRef.current.removeEventListener(
+          "scroll",
+          autoFollowListenerRef.current,
+        );
+      }
+    },
+    [],
+  );
 
   const visibleRows = hiddenOlderCount > 0 ? rows.slice(hiddenOlderCount) : rows;
   const firstVisibleBubbleRowID = visibleRows.find(
@@ -366,36 +483,59 @@ export function ChatThreadView({
         />
       ) : null}
       {visibleRows.map((row) => (
-        <ChatRow
-          key={row.id}
-          isTopBubble={row.id === firstVisibleBubbleRowID}
-          row={row}
-          cwd={cwd}
-          busyParticipantIDs={busyParticipantIDs}
-          marks={
-            row.kind !== "envelope" && typeof row.item.seq === "number"
-              ? marksBySeq?.get(row.item.seq)
-              : undefined
-          }
-          readerCount={readerCount}
-          resolveParticipantName={resolveParticipantName}
-          subthread={
-            row.kind === "user" || row.kind === "participant"
-              ? subthreadsByAnchor?.get(row.item.id) ??
-                (row.item.seq
-                  ? subthreadsByAnchor?.get(`seq:${row.item.seq}`)
-                  : undefined)
-              : undefined
-          }
-          onOpenSubthread={
-            onOpenSubthread ? requestOpenSubthread : undefined
-          }
-          onReact={onReact}
-        />
+        row.kind === "turn-event" ? (
+          <div key={row.id} className="chat-row chat-row--system chat-row--turn-event">
+            <TurnEventNotice
+              event={
+                row.count && row.count > 1 && row.event.presentation === "notice"
+                  ? {
+                      ...row.event,
+                      notice: {
+                        ...row.event.notice,
+                        title: `${row.event.notice.title} ×${row.count}`,
+                      },
+                    }
+                  : row.event
+              }
+            />
+          </div>
+        ) : (
+          <ChatRow
+            key={row.id}
+            isTopBubble={row.id === firstVisibleBubbleRowID}
+            row={row}
+            cwd={cwd}
+            busyParticipantIDs={busyParticipantIDs}
+            marks={
+              row.kind !== "envelope" && typeof row.item.seq === "number"
+                ? marksBySeq?.get(row.item.seq)
+                : undefined
+            }
+            readerCount={readerCount}
+            resolveParticipantName={resolveParticipantName}
+            subthread={
+              row.kind === "user" || row.kind === "participant"
+                ? subthreadsByAnchor?.get(row.item.id) ??
+                  (row.item.seq
+                    ? subthreadsByAnchor?.get(`seq:${row.item.seq}`)
+                    : undefined)
+                : undefined
+            }
+            onOpenSubthread={
+              onOpenSubthread ? requestOpenSubthread : undefined
+            }
+            onReact={onReact}
+          />
+        )
       ))}
       {pendingMessages.map((message) => (
         <PendingChatRow key={`pending-${message.id}`} message={message} cwd={cwd} />
       ))}
+      {streamStatus?.liveProgress ? (
+        <div className="chat-row chat-row--system chat-row--reconnecting">
+          <StreamReconnectNotice text={streamStatus.text} />
+        </div>
+      ) : null}
       {ownerSelectionItem ? (
         <ThreadOwnerDialog
           candidates={namedOwnerCandidates}
@@ -741,10 +881,11 @@ function ChatRow({
     ? ` chat-bubble--long-card ${expanded ? "expanded" : "collapsed"}`
     : "";
   if (row.kind === "system") {
+    const text = row.count && row.count > 1 ? `${row.text} ×${row.count}` : row.text;
     return (
       <div className={`chat-row chat-row--system${topBubbleClass}`}>
         <SystemEventDivider
-          text={row.text}
+          text={text}
           className="chat-system-divider"
         />
       </div>

--- a/desktop/src/renderer/ChatThreadViewContainer.tsx
+++ b/desktop/src/renderer/ChatThreadViewContainer.tsx
@@ -5,9 +5,11 @@ import type {
   ThreadItem,
   Turn,
 } from "../shared/protocol";
+import type { TurnStreamStatus } from "./AppState";
 import { ChatThreadView } from "./ChatThreadView";
 import type { QueuedComposerMessage } from "./ComposerMessages";
 import { aggregateMarksBySeq } from "./MessageMarks";
+import type { TurnEventDisplay } from "./TurnEvents";
 import { useThreadMarks } from "./useThreadMarks";
 
 // Feeds ChatThreadView its live read receipts + reactions. Split out because
@@ -25,6 +27,9 @@ export function ChatThreadViewContainer({
   resolveParticipantName,
   threadOwnerCandidates,
   subthreadsByAnchor,
+  isActive,
+  streamStatus,
+  turnEvents,
   onOpenSubthread,
   onReact,
 }: {
@@ -40,6 +45,9 @@ export function ChatThreadViewContainer({
     import("../shared/protocol").ParticipantSummary
   >;
   subthreadsByAnchor?: ReadonlyMap<string, ConversationSubthread>;
+  isActive?: boolean;
+  streamStatus?: TurnStreamStatus;
+  turnEvents?: ReadonlyArray<{ turnID: string; event: TurnEventDisplay }>;
   onOpenSubthread?: (
     item: ThreadItem,
     threadOwnerParticipantID?: string,
@@ -64,6 +72,9 @@ export function ChatThreadViewContainer({
       resolveParticipantName={resolveParticipantName}
       threadOwnerCandidates={threadOwnerCandidates}
       subthreadsByAnchor={subthreadsByAnchor}
+      isActive={isActive}
+      streamStatus={streamStatus}
+      turnEvents={turnEvents}
       onOpenSubthread={onOpenSubthread}
       onReact={onReact}
     />

--- a/desktop/src/renderer/UserFacingErrors.test.ts
+++ b/desktop/src/renderer/UserFacingErrors.test.ts
@@ -92,12 +92,12 @@ describe("userFacingErrorForMessage", () => {
         "turn",
       );
 
-      expect(display.title).toBe("404 资源不存在");
+      expect(display.title).toBe("请求失败 · HTTP 404");
       expect(display).not.toHaveProperty("code");
       expect(display).not.toHaveProperty("recommendedActions");
     });
 
-    it("keeps an untranslatable structured code out of the visible model", () => {
+    it("keeps a provider code visible when the stream failed after HTTP 200", () => {
       const display = userFacingErrorForMessage(
         {
           message: "some raw provider body",
@@ -106,7 +106,7 @@ describe("userFacingErrorForMessage", () => {
         },
         "turn",
       );
-      expect(display.title).toBe("模型服务异常");
+      expect(display.title).toBe("请求失败 · insufficient_quota");
       expect(display).not.toHaveProperty("code");
       expect(display.category).toBe("provider");
     });
@@ -122,7 +122,37 @@ describe("userFacingErrorForMessage", () => {
       );
 
       expect(display.category).toBe("provider");
-      expect(display.title).toBe("429 触发限流");
+      expect(display.title).toBe("请求失败 · HTTP 429");
+    });
+
+    it("prefers the exact HTTP status over an inferred quota classification", () => {
+      const display = userFacingErrorForMessage(
+        {
+          message: "usage limit reached",
+          code: "usage_limit_reached",
+          category: "auth",
+          provider: "anthropic",
+          status_code: 403,
+        },
+        "turn",
+      );
+
+      expect(display.title).toBe("请求失败 · HTTP 403");
+      expect(display.category).toBe("auth");
+    });
+
+    it("shows the provider code for a post-200 stream failure", () => {
+      const display = userFacingErrorForMessage(
+        {
+          message: "usage limit reached",
+          code: "usage_limit_reached",
+          category: "provider",
+          provider: "anthropic",
+        },
+        "turn",
+      );
+
+      expect(display.title).toBe("请求失败 · usage_limit_reached");
     });
 
     it("uses structured partial-stream facts without exposing the code", () => {
@@ -157,7 +187,7 @@ describe("userFacingErrorForMessage", () => {
 
       expect(display.category).toBe("invalid_request");
       expect(display.tone).toBe("error");
-      expect(display.title).toBe("400 请求无效");
+      expect(display.title).toBe("请求失败 · HTTP 400");
       expect(display.detail).toBe("Provider 认为这次请求参数无效。原始错误已留在调试信息中。");
     });
 

--- a/desktop/src/renderer/UserFacingErrors.ts
+++ b/desktop/src/renderer/UserFacingErrors.ts
@@ -68,12 +68,17 @@ function httpTitle(code: string): string {
   return key ? `${code} ${t(key)}` : code;
 }
 
-function structuredStatusTitle(structured: TurnError | undefined): string | undefined {
+function structuredStatusFact(structured: TurnError | undefined): string | undefined {
   const statusCode = structured?.status_code;
   if (typeof statusCode !== "number" || !Number.isFinite(statusCode) || statusCode <= 0) {
     return undefined;
   }
-  return httpTitle(String(Math.trunc(statusCode)));
+  return `HTTP ${Math.trunc(statusCode)}`;
+}
+
+function structuredProviderCode(structured: TurnError | undefined): string | undefined {
+  const code = structured?.code?.trim();
+  return code && /^[A-Za-z0-9._-]{1,128}$/.test(code) ? code : undefined;
 }
 
 type SpecificDisplay = {
@@ -213,21 +218,24 @@ export function userFacingErrorForMessage(
         : "internal"
       : classifyUserFacingError(message, context);
 
-  // Title: always a localized label — keyword extraction from the raw
-  // message (or from the structured code, when the code itself is a
-  // known identifier), then the HTTP status phrase, then the category
-  // default. Raw machine identifiers remain on the structured error for
-  // diagnostics and never become a second visible label.
-  const structuredCode = structured?.code?.trim() || undefined;
+  // Structured transport facts take precedence over inferred category
+  // labels. A post-200 provider failure has no HTTP status, so retain its
+  // provider code when no more specific localized state is available.
+  const structuredCode = structuredProviderCode(structured);
   const specific = extractSpecificDisplay(message, category);
   const specificFromCode = structuredCode
     ? extractSpecificDisplay(structuredCode, category)
     : {};
-  const statusTitle = structuredStatusTitle(structured);
+  const statusFact = structuredStatusFact(structured);
+  const traceableFailureTitle = statusFact
+    ? `${t("error.requestFailedTitle")} · ${statusFact}`
+    : category === "provider" && structuredCode && !specific.title && !specificFromCode.title
+      ? `${t("error.requestFailedTitle")} · ${structuredCode}`
+      : undefined;
   const title =
+    traceableFailureTitle ||
     specific.title ||
     specificFromCode.title ||
-    statusTitle ||
     defaultTitleForCategory(category);
   // Detail is hover and accessibility copy, not a visible second line.
   const detail =

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -335,6 +335,7 @@ export const enUS = {
   "tools.notConnected": "Not connected",
   "tools.counts": "{visible} available, {hidden} hidden",
   "tools.moreCapabilities": "{shown} and {count} total",
+  "error.requestFailedTitle": "Request failed",
   "error.http400": "Invalid request",
   "error.http401": "Unauthorized",
   "error.http403": "Forbidden",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -333,6 +333,7 @@ export const zhCN = {
   "tools.notConnected": "未连接",
   "tools.counts": "{visible} 个可用，{hidden} 个已隐藏",
   "tools.moreCapabilities": "{shown} 等 {count} 项",
+  "error.requestFailedTitle": "请求失败",
   "error.http400": "请求无效",
   "error.http401": "未授权",
   "error.http403": "无访问权限",


### PR DESCRIPTION
## Summary
- show reconnect progress and terminal stream events in chat-style threads
- keep turn-scoped rows and inactive cached panes isolated
- preserve exact structured HTTP/provider error facts and selection-paused stream follow behavior

## Tests
- `VITE_ENABLE_COLLABORATION=true npx vitest run --exclude=src/renderer/StreamingMarkdown.perf.test.tsx --maxWorkers=2 --minWorkers=1`
- `npm run typecheck`