### PR TITLE
fix(tools): stop synchronous shell process trees

### DIFF
--- a/internal/process/command.go
+++ b/internal/process/command.go
@@ -1,0 +1,149 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+const DefaultStopGracePeriod = 2 * time.Second
+
+// ProcessTree identifies the platform-specific process tree rooted at a
+// command started by Wuu. On Unix the id is a process group id; on Windows it
+// is the root pid used by taskkill /T.
+type ProcessTree struct {
+	id int
+}
+
+// PrepareCommand isolates cmd so its complete descendant tree can be
+// signalled without affecting Wuu itself.
+func PrepareCommand(cmd *exec.Cmd) {
+	configureProcessGroup(cmd)
+}
+
+// ProcessTreeForPID resolves the tree created for a newly started command.
+func ProcessTreeForPID(pid int) ProcessTree {
+	return ProcessTree{id: lookupProcessGroup(pid)}
+}
+
+// ProcessTreeFromID restores a tree reference from a recorded platform id.
+func ProcessTreeFromID(id int) ProcessTree {
+	return ProcessTree{id: id}
+}
+
+func (t ProcessTree) ID() int {
+	return t.id
+}
+
+func (t ProcessTree) Terminate() error {
+	if err := t.validate(); err != nil {
+		return err
+	}
+	return terminateProcessGroup(t.id)
+}
+
+func (t ProcessTree) Kill() error {
+	if err := t.validate(); err != nil {
+		return err
+	}
+	return killProcessGroup(t.id)
+}
+
+func (t ProcessTree) validate() error {
+	if t.id <= 1 {
+		return fmt.Errorf("unsafe process tree id %d", t.id)
+	}
+	return nil
+}
+
+// CommandHandle owns a non-durable command and its complete process tree.
+// Durable background metadata and output remain the Manager's responsibility.
+type CommandHandle struct {
+	tree     ProcessTree
+	done     chan struct{}
+	waitErr  error
+	stopOnce sync.Once
+	stopErr  error
+}
+
+func StartCommand(cmd *exec.Cmd) (*CommandHandle, error) {
+	if cmd == nil {
+		return nil, errors.New("command is required")
+	}
+	PrepareCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	h := &CommandHandle{
+		tree: ProcessTreeForPID(cmd.Process.Pid),
+		done: make(chan struct{}),
+	}
+	go func() {
+		h.waitErr = cmd.Wait()
+		close(h.done)
+	}()
+	return h, nil
+}
+
+func (h *CommandHandle) Done() <-chan struct{} {
+	if h == nil {
+		done := make(chan struct{})
+		close(done)
+		return done
+	}
+	return h.done
+}
+
+func (h *CommandHandle) Wait() error {
+	if h == nil {
+		return errors.New("command handle is nil")
+	}
+	<-h.done
+	return h.waitErr
+}
+
+// Stop gives the full tree a bounded graceful shutdown window, then always
+// sends a force-kill to remove descendants that ignored SIGTERM after their
+// direct parent exited.
+func (h *CommandHandle) Stop(grace time.Duration) error {
+	if h == nil {
+		return errors.New("command handle is nil")
+	}
+	if grace <= 0 {
+		grace = DefaultStopGracePeriod
+	}
+	h.stopOnce.Do(func() {
+		select {
+		case <-h.done:
+			return
+		default:
+		}
+
+		terminateErr := h.tree.Terminate()
+		stopped := waitForCommand(h.done, grace)
+		killErr := h.tree.Kill()
+		if !stopped && !waitForCommand(h.done, grace) {
+			h.stopErr = errors.Join(
+				terminateErr,
+				killErr,
+				fmt.Errorf("process tree %d did not stop after force-kill", h.tree.ID()),
+			)
+			return
+		}
+		h.stopErr = errors.Join(terminateErr, killErr)
+	})
+	return h.stopErr
+}
+
+func waitForCommand(done <-chan struct{}, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}

--- a/internal/process/command_test.go
+++ b/internal/process/command_test.go
@@ -1,0 +1,108 @@
+//go:build !windows
+
+package process
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestCommandHandleStopAllowsCleanupAndKillsDescendants(t *testing.T) {
+	readyMarker := t.TempDir() + "/ready"
+	cleanupMarker := t.TempDir() + "/cleanup"
+	descendantMarker := t.TempDir() + "/descendant"
+	cmd := exec.Command("/bin/sh", "-c", `
+(trap '' TERM; while :; do sleep 1; done) &
+printf '%s' "$!" > "$DESCENDANT_MARKER"
+trap 'printf cleaned > "$CLEANUP_MARKER"; exit 0' TERM
+printf ready > "$READY_MARKER"
+while :; do sleep 1; done
+`)
+	cmd.Env = append(os.Environ(),
+		"READY_MARKER="+readyMarker,
+		"CLEANUP_MARKER="+cleanupMarker,
+		"DESCENDANT_MARKER="+descendantMarker,
+	)
+
+	handle, err := StartCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = handle.Stop(100 * time.Millisecond) })
+	waitForTestFile(t, readyMarker)
+
+	descendantText, err := os.ReadFile(descendantMarker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descendantPID, err := strconv.Atoi(strings.TrimSpace(string(descendantText)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := handle.Stop(200 * time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Wait(); err != nil {
+		t.Fatalf("TERM-aware parent did not exit cleanly: %v", err)
+	}
+	cleanup, err := os.ReadFile(cleanupMarker)
+	if err != nil {
+		t.Fatalf("SIGTERM cleanup did not run: %v", err)
+	}
+	if string(cleanup) != "cleaned" {
+		t.Fatalf("cleanup marker = %q, want cleaned", cleanup)
+	}
+	waitForProcessExit(t, descendantPID)
+}
+
+func TestCommandHandleWaitsForNaturalExit(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 7")
+	handle, err := StartCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = handle.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("wait error = %v, want exit code 7", err)
+	}
+}
+
+func TestProcessTreeRejectsUnsafeID(t *testing.T) {
+	if err := ProcessTreeFromID(1).Kill(); err == nil || !strings.Contains(err.Error(), "unsafe process tree id") {
+		t.Fatalf("Kill error = %v, want unsafe process tree id", err)
+	}
+}
+
+func waitForTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	t.Fatalf("descendant process %d is still alive", pid)
+}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -275,7 +275,7 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 		}
 		cmd.Stdout = logf
 		cmd.Stderr = logf
-		configureProcessGroup(cmd)
+		PrepareCommand(cmd)
 		if err := cmd.Start(); err != nil {
 			_ = stdin.Close()
 			_ = logf.Close()
@@ -288,11 +288,11 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 		}
 	}
 	p.PID = cmd.Process.Pid
-	p.PGID = lookupProcessGroup(p.PID)
+	p.PGID = ProcessTreeForPID(p.PID).ID()
 	p.ProcessStartTime, _, _, err = readProcessIdentity(p.PID)
 	if err != nil {
 		if p.PGID > 1 {
-			_ = killProcessGroup(p.PGID)
+			_ = ProcessTreeFromID(p.PGID).Kill()
 		}
 		if stdin != nil {
 			_ = stdin.Close()
@@ -693,7 +693,7 @@ func (m *Manager) Stop(id string) (*Process, error) {
 		return p, fmt.Errorf("persist stopping process: %w", err)
 	}
 	m.mu.Unlock()
-	if err := terminateProcessGroup(p.PGID); err != nil {
+	if err := ProcessTreeFromID(p.PGID).Terminate(); err != nil {
 		return p, fmt.Errorf("terminate process group %d: %w", p.PGID, err)
 	}
 	cur, stopped, err := m.waitForStop(id, time.Now().Add(2*time.Second))
@@ -715,7 +715,7 @@ func (m *Manager) Stop(id string) (*Process, error) {
 		}
 		return cur, err
 	}
-	if err := killProcessGroup(cur.PGID); err != nil {
+	if err := ProcessTreeFromID(cur.PGID).Kill(); err != nil {
 		return cur, fmt.Errorf("kill process group %d: %w", cur.PGID, err)
 	}
 	cur, stopped, err = m.waitForStop(id, time.Now().Add(2*time.Second))

--- a/internal/tools/tool_shell.go
+++ b/internal/tools/tool_shell.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	proc "github.com/blueberrycongee/wuu/internal/process"
 	"github.com/blueberrycongee/wuu/internal/shellpath"
 	"github.com/blueberrycongee/wuu/internal/stringutil"
 )
@@ -138,7 +139,7 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 		}
 		executedCommand = prefix + executedCommand
 	}
-	cmd := exec.CommandContext(runCtx, shell.Path, shell.CommandArgs(executedCommand)...)
+	cmd := exec.Command(shell.Path, shell.CommandArgs(executedCommand)...)
 	cmd.Dir = workDir
 	cmd.Env = shellpath.CommandEnv(shellCommandEnv(os.Environ()))
 
@@ -148,15 +149,29 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 	cmd.Stderr = &stderr
 
 	startedAt := time.Now()
-	err = cmd.Run()
+	handle, err := proc.StartCommand(cmd)
+	if err != nil {
+		return shellExecutionResult{}, fmt.Errorf("run command: %w", err)
+	}
+	interrupted := false
+	select {
+	case <-handle.Done():
+		err = handle.Wait()
+	case <-runCtx.Done():
+		interrupted = true
+		if stopErr := handle.Stop(proc.DefaultStopGracePeriod); stopErr != nil {
+			return shellExecutionResult{}, fmt.Errorf("stop command: %w", stopErr)
+		}
+		err = handle.Wait()
+	}
 	durationMS := time.Since(startedAt).Milliseconds()
 	exitCode := 0
-	if err != nil {
+	if interrupted {
+		exitCode = -1
+	} else if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
-		} else if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-			exitCode = 124
 		} else {
 			return shellExecutionResult{}, fmt.Errorf("run command: %w", err)
 		}
@@ -172,7 +187,7 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 	stdoutTail, stdoutTailTruncated := tailString(redactedStdout, maxShellTailBytes)
 	stderrTail, stderrTailTruncated := tailString(redactedStderr, maxShellTailBytes)
 	classification := classifyShellCommand(command)
-	timedOut := errors.Is(runCtx.Err(), context.DeadlineExceeded)
+	timedOut := interrupted && errors.Is(runCtx.Err(), context.DeadlineExceeded)
 
 	return shellExecutionResult{
 		Action:              "run",

--- a/internal/tools/tool_shell_process_test.go
+++ b/internal/tools/tool_shell_process_test.go
@@ -1,0 +1,152 @@
+//go:build !windows
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExecuteShellCommandCancellationStopsProcessTree(t *testing.T) {
+	root := t.TempDir()
+	readyMarker := root + "/ready"
+	cleanupMarker := root + "/cleanup"
+	descendantMarker := root + "/descendant"
+	t.Setenv("WUU_TEST_READY_MARKER", readyMarker)
+	t.Setenv("WUU_TEST_CLEANUP_MARKER", cleanupMarker)
+	t.Setenv("WUU_TEST_DESCENDANT_MARKER", descendantMarker)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resultCh := make(chan shellTestResult, 1)
+	go func() {
+		result, err := executeShellCommandInDir(ctx, &Env{RootDir: root}, `
+(trap '' TERM; while :; do sleep 1; done) &
+printf '%s' "$!" > "$WUU_TEST_DESCENDANT_MARKER"
+trap 'printf cleaned > "$WUU_TEST_CLEANUP_MARKER"; exit 0' TERM
+printf ready > "$WUU_TEST_READY_MARKER"
+while :; do sleep 1; done
+`, 30, root)
+		resultCh <- shellTestResult{result: result, err: err}
+	}()
+
+	waitForShellTestFile(t, readyMarker)
+	descendantPID := readShellTestPID(t, descendantMarker)
+	t.Cleanup(func() { _ = syscall.Kill(descendantPID, syscall.SIGKILL) })
+	cancel()
+
+	got := waitForShellTestResult(t, resultCh)
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.result.TimedOut {
+		t.Fatal("cancelled command was reported as timed out")
+	}
+	if got.result.ExitCode == 0 {
+		t.Fatal("cancelled command was reported as successful")
+	}
+	cleanup, err := os.ReadFile(cleanupMarker)
+	if err != nil {
+		t.Fatalf("SIGTERM cleanup did not run: %v", err)
+	}
+	if string(cleanup) != "cleaned" {
+		t.Fatalf("cleanup marker = %q, want cleaned", cleanup)
+	}
+	waitForShellTestProcessExit(t, descendantPID)
+}
+
+func TestExecuteShellCommandTimeoutStopsProcessTree(t *testing.T) {
+	root := t.TempDir()
+	readyMarker := root + "/ready"
+	descendantMarker := root + "/descendant"
+	t.Setenv("WUU_TEST_READY_MARKER", readyMarker)
+	t.Setenv("WUU_TEST_DESCENDANT_MARKER", descendantMarker)
+
+	resultCh := make(chan shellTestResult, 1)
+	go func() {
+		result, err := executeShellCommandInDir(context.Background(), &Env{RootDir: root}, `
+trap '' TERM
+(trap '' TERM; while :; do sleep 1; done) &
+printf '%s' "$!" > "$WUU_TEST_DESCENDANT_MARKER"
+printf ready > "$WUU_TEST_READY_MARKER"
+while :; do sleep 1; done
+`, 1, root)
+		resultCh <- shellTestResult{result: result, err: err}
+	}()
+
+	waitForShellTestFile(t, readyMarker)
+	descendantPID := readShellTestPID(t, descendantMarker)
+	t.Cleanup(func() { _ = syscall.Kill(descendantPID, syscall.SIGKILL) })
+	got := waitForShellTestResult(t, resultCh)
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if !got.result.TimedOut {
+		t.Fatal("timed-out command was not reported as timed out")
+	}
+	if got.result.ExitCode == 0 {
+		t.Fatal("timed-out command was reported as successful")
+	}
+	waitForShellTestProcessExit(t, descendantPID)
+}
+
+type shellTestResult struct {
+	result shellExecutionResult
+	err    error
+}
+
+func waitForShellTestResult(t *testing.T, resultCh <-chan shellTestResult) shellTestResult {
+	t.Helper()
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for shell execution result")
+		return shellTestResult{}
+	}
+}
+
+func waitForShellTestFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func readShellTestPID(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pid
+}
+
+func waitForShellTestProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	t.Fatalf("descendant process %d is still alive", pid)
+}


### PR DESCRIPTION
## Summary

- isolate synchronous shell commands in a dedicated platform process tree
- reuse shared process lifecycle primitives for synchronous and managed commands
- terminate with a bounded graceful phase, force-kill remaining descendants, and reap the direct child
- add real cancellation and timeout tests with TERM-aware and TERM-ignoring descendants

Fixes #106

## Test plan

- `go test ./internal/process ./internal/tools -count=1`
- `go test -race ./internal/process ./internal/tools -run 'TestCommandHandle|TestProcessTree|TestExecuteShellCommand(Cancellation|Timeout)StopsProcessTree' -count=1`\n- `go vet ./internal/process ./internal/tools`\n- Windows cross-compile of `internal/process` and `internal/tools` test binaries\n- repository `make release-check`: version, Go format/vet, Darwin/Windows builds and vet, and all Go tests passed; desktop unit tests reached 2058/2059, with the remaining `AppWorkspaceFileTabs` focus assertion reproduced unchanged on `main`\n- `npm run test:perf`\n- `npm run test:cua-mac`