### PR TITLE
fix(desktop): show first query before thread creation

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -23,6 +23,7 @@ import type {
   ServerEvent,
   Thread,
   ThreadItem,
+  Turn,
 } from "../shared/protocol";
 import {
   awaitComposerImages,
@@ -189,7 +190,7 @@ import {
   rawErrorMessage,
   statusMessageForError,
 } from "./UserFacingErrors";
-import { scrollToUserMessage } from "./TurnView";
+import { scrollToUserMessage, TurnView } from "./TurnView";
 import { ConversationTurnRail } from "./ConversationTurnRail";
 import {
   WorkspaceRightPanel,
@@ -1809,6 +1810,14 @@ export function App(): JSX.Element {
     activeProjectName: activeProject?.name,
   });
   const emptyThreadTitle = greetingFor(currentHour, greetingContext);
+  const [pendingNewThreadTurn, setPendingNewThreadTurn] = useState<{
+    sessionTabID: string;
+    turn: Turn;
+  }>();
+  const activePendingNewThreadTurn =
+    pendingNewThreadTurn?.sessionTabID === state.activeSessionTabID
+      ? pendingNewThreadTurn.turn
+      : undefined;
   const turns = activeThread?.turns ?? [];
   const activeContextCompositionEntries = activeThreadID
     ? contextCompositionEntries.filter((entry) => entry.threadID === activeThreadID)
@@ -1816,6 +1825,7 @@ export function App(): JSX.Element {
   const emptyConversation =
     !showingSkillsCatalog &&
     !showingTaskBoard &&
+    !activePendingNewThreadTurn &&
     turns.length === 0 &&
     activeContextCompositionEntries.length === 0;
 
@@ -3568,6 +3578,15 @@ export function App(): JSX.Element {
     }));
     let optimisticTurnID: string | undefined;
     let optimisticThreadID: string | undefined;
+    // Render a tab-scoped optimistic turn before a new thread exists. Once
+    // thread/start returns, the same turn moves into normal thread state.
+    const optimisticTurn = createOptimisticTurn(message, sendClickedAtMs);
+    if (!targetThread && currentState.activeSessionTabID) {
+      setPendingNewThreadTurn({
+        sessionTabID: currentState.activeSessionTabID,
+        turn: optimisticTurn,
+      });
+    }
     try {
       const thread =
         targetThread ??
@@ -3613,12 +3632,6 @@ export function App(): JSX.Element {
             : current.activeSessionTabID,
         threads: upsertThread(current.threads, thread),
       }));
-      // Insert an optimistic in_progress turn before the IPC round-trip so
-      // the live "正在回复/处理" timer starts at the user's click moment
-      // instead of waiting for the server's first turn notification. The
-      // placeholder is replaced (or dropped on error) once the real turn
-      // arrives or the request fails.
-      const optimisticTurn = createOptimisticTurn(message, sendClickedAtMs);
       optimisticTurnID = optimisticTurn.id;
       optimisticThreadID = thread.id;
       appStateRef.current = updateThreadByID(
@@ -3632,6 +3645,9 @@ export function App(): JSX.Element {
           thread.id,
           (currentThread) => upsertTurn(currentThread, optimisticTurn),
         ),
+      );
+      setPendingNewThreadTurn((current) =>
+        current?.turn.id === optimisticTurn.id ? undefined : current,
       );
       const encodedImages = await awaitComposerImages(message.images);
       const images = inputImagesFromComposer(encodedImages);
@@ -3704,6 +3720,9 @@ export function App(): JSX.Element {
         running: false,
         status: errorMessage,
       }));
+      setPendingNewThreadTurn((current) =>
+        current?.turn.id === optimisticTurn.id ? undefined : current,
+      );
       if (restoreDraftOnError) {
         setPrompt(message.text);
         setComposerImages(message.images);
@@ -4581,6 +4600,15 @@ export function App(): JSX.Element {
                     onStreamFrame={scheduleStreamScroll}
                     onOpenFileDiff={openTurnFileDiffPanel}
                   />
+                ) : activePendingNewThreadTurn ? (
+                  <div className="conversation-width session-flow">
+                    <TurnView
+                      turn={activePendingNewThreadTurn}
+                      cwd={state.activeContext?.cwd}
+                      onStreamFrame={scheduleStreamScroll}
+                      isLatestTurn
+                    />
+                  </div>
                 ) : emptyConversation ? (
               <EmptyConversationHome
                 title={emptyThreadTitle}

--- a/desktop/src/renderer/AppComposerFocus.test.tsx
+++ b/desktop/src/renderer/AppComposerFocus.test.tsx
@@ -83,6 +83,7 @@ let container: HTMLDivElement;
 let root: Root | null = null;
 let serverEventHandlers: Array<(event: ServerEvent) => void> = [];
 let releaseProjectSelection: (() => void) | null = null;
+let releaseThreadStart: (() => void) | null = null;
 
 function initialized(cwd: string): InitializeResult {
   return {
@@ -183,6 +184,8 @@ function installWuuApi(
     deferProjectSelection?: boolean;
     rejectProjectSelection?: boolean;
     rejectNoProjectSelection?: boolean;
+    deferThreadStart?: boolean;
+    rejectThreadStart?: boolean;
     rejectTurnStart?: boolean;
   } = {},
 ): void {
@@ -226,7 +229,17 @@ function installWuuApi(
     ),
     listArchivedThreads: vi.fn().mockResolvedValue({ threads: [] }),
     resumeThread: vi.fn().mockResolvedValue({ thread }),
-    startThread: vi.fn().mockResolvedValue({ thread: newThread() }),
+    startThread: vi.fn().mockImplementation(async () => {
+      if (options.deferThreadStart) {
+        await new Promise<void>((resolve) => {
+          releaseThreadStart = resolve;
+        });
+      }
+      if (options.rejectThreadStart) {
+        throw new Error("thread start failed");
+      }
+      return { thread: newThread() };
+    }),
     startTurn: options.rejectTurnStart
       ? vi.fn().mockRejectedValue(new Error("turn start failed"))
       : vi.fn().mockResolvedValue({
@@ -282,6 +295,8 @@ async function renderApp(
     deferProjectSelection?: boolean;
     rejectProjectSelection?: boolean;
     rejectNoProjectSelection?: boolean;
+    deferThreadStart?: boolean;
+    rejectThreadStart?: boolean;
     rejectTurnStart?: boolean;
   } = {},
 ): Promise<void> {
@@ -348,6 +363,7 @@ describe("main composer focus continuity", () => {
     installWindowStubs();
     serverEventHandlers = [];
     releaseProjectSelection = null;
+    releaseThreadStart = null;
     container = document.createElement("div");
     document.body.appendChild(container);
     window.localStorage.clear();
@@ -510,6 +526,36 @@ describe("main composer focus continuity", () => {
     await enterCommand(hero, "first query");
 
     await waitForMainComposerFocus("dock");
+  });
+
+  it("shows the first query while thread creation is still pending", async () => {
+    await renderApp(false, { deferThreadStart: true });
+    const hero = mainComposer("hero");
+
+    await enterCommand(hero, "first query before thread start");
+
+    expect(container.textContent).toContain("first query before thread start");
+    expect(container.querySelector(".turn-process-title")?.textContent).toBe(
+      "正在处理",
+    );
+    expect(mainComposer("dock")).not.toBeNull();
+    expect(window.wuu.startTurn).not.toHaveBeenCalled();
+
+    if (!releaseThreadStart) {
+      throw new Error("thread start was not deferred");
+    }
+    releaseThreadStart();
+    await flushAsync();
+  });
+
+  it("removes the pending query and restores the hero draft when thread creation fails", async () => {
+    await renderApp(false, { rejectThreadStart: true });
+    const hero = mainComposer("hero");
+
+    await enterCommand(hero, "query that fails before thread start");
+
+    expect(mainComposer("hero").value).toBe("query that fails before thread start");
+    expect(container.querySelector(".turn-process-title")).toBeNull();
   });
 
   it("restores focus to the hero when the first query fails", async () => {


### PR DESCRIPTION
## Summary
- render a tab-scoped optimistic first turn before `thread/start` returns
- move the same turn into the real thread on success and clear it while restoring the draft on failure
- cover deferred and rejected thread creation in the composer focus regression suite

## Tests
- `cd desktop && npm run typecheck`
- `cd desktop && npm run test:unit` (184 files, 2122 tests)