### PR TITLE
fix(appserver): hide zero-usage model buckets from settings usage panel

### DIFF
--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -759,6 +759,13 @@ func systemPromptSectionSummaries(sections []SystemPromptSectionInfo) []provider
 	return out
 }
 
+// NewStreamStep returns a Step that consumes a provider stream to completion
+// without publishing its intermediate events. It lets auxiliary tool loops use
+// the same streaming transport and recovery semantics as StreamRunner.
+func NewStreamStep(client providers.StreamClient) Step {
+	return &streamStep{client: client}
+}
+
 // streamStep adapts providers.StreamClient (with recovery) to the
 // transport-agnostic Step interface. One Execute call opens an SSE
 // stream and consumes it to completion. Recoverable failures create distinct

--- a/internal/appserver/memory_panel_agent.go
+++ b/internal/appserver/memory_panel_agent.go
@@ -207,7 +207,7 @@ func (s *Server) runMemoryOverviewAgent(scope, dir string) (string, error) {
 	cfg.MaxSteps = memoryOverviewMaxSteps
 	cfg.InferenceOperationKind = providers.InferenceOperationMemory
 	cfg.InferenceWorkloadProfile = providers.InferenceProfileBestEffort
-	result, err := agent.RunToolLoop(ctx, messages, cfg, memoryPanelStep{client: client})
+	result, err := agent.RunToolLoop(ctx, messages, cfg, agent.NewStreamStep(client))
 	if err != nil {
 		return "", fmt.Errorf("memory overview agent: %w", err)
 	}
@@ -220,7 +220,7 @@ func (s *Server) runMemoryOverviewAgent(scope, dir string) (string, error) {
 
 // memoryPanelModel resolves the client/model both panel agents run on: the
 // session's live stream runner (per M2 scope: client/model 取 s.rt.StreamRunner).
-func (s *Server) memoryPanelModel() (providers.Client, string, agent.LoopConfig, error) {
+func (s *Server) memoryPanelModel() (providers.StreamClient, string, agent.LoopConfig, error) {
 	runner := s.rt.StreamRunner
 	if runner == nil || runner.Client == nil {
 		return nil, "", agent.LoopConfig{}, errors.New("model runtime is not available")
@@ -341,7 +341,7 @@ func (s *Server) runMemoryChatAgent(scope, targetDir, userDir string, roots []st
 	cfg.MaxSteps = memoryChatMaxSteps
 	cfg.InferenceOperationKind = providers.InferenceOperationMemory
 	cfg.InferenceWorkloadProfile = providers.InferenceProfileInteractive
-	result, err := agent.RunToolLoop(ctx, messages, cfg, memoryPanelStep{client: client})
+	result, err := agent.RunToolLoop(ctx, messages, cfg, agent.NewStreamStep(client))
 	if err != nil {
 		return "", fmt.Errorf("memory manager agent: %w", err)
 	}
@@ -373,29 +373,6 @@ func memoryChatSystemPrompt(scope, targetDir, userDir string) string {
 		"",
 		"回复要求：完成后用中文一句话说明你做了什么（保存/修改/删除了哪条记忆）；如果没有需要修改的内容或指令不清楚，也用一句话说明原因。不要输出多余的解释或文件内容。",
 	}, "\n")
-}
-
-// memoryPanelStep is the one-round-trip Step for the panel agents: a plain
-// blocking Chat call (same shape as runtime's profileMemoryReviewStep).
-type memoryPanelStep struct {
-	client providers.Client
-}
-
-func (s memoryPanelStep) Execute(ctx context.Context, req providers.ChatRequest) (agent.StepResult, error) {
-	resp, err := providers.ExecuteChat(ctx, s.client, req, providers.InferenceOperationMemory, providers.InferenceProfileInteractive)
-	if err != nil {
-		return agent.StepResult{}, err
-	}
-	return agent.StepResult{
-		Content:          resp.Content,
-		ReasoningContent: resp.ReasoningContent,
-		ReasoningBlocks:  append([]providers.ReasoningBlock(nil), resp.ReasoningBlocks...),
-		ToolCalls:        append([]providers.ToolCall(nil), resp.ToolCalls...),
-		FinishReason:     resp.FinishReason,
-		Truncated:        resp.Truncated,
-		StopReason:       resp.StopReason,
-		Usage:            resp.Usage,
-	}, nil
 }
 
 // memoryPanelExecutor is the restricted tool executor for both panel

--- a/internal/appserver/memory_panel_test.go
+++ b/internal/appserver/memory_panel_test.go
@@ -254,6 +254,50 @@ func requestMessagesContain(req providers.ChatRequest, needle string) bool {
 	return false
 }
 
+type memoryStreamOnlyClient struct {
+	content        string
+	chatCalls      int
+	streamRequests []providers.ChatRequest
+}
+
+func (c *memoryStreamOnlyClient) Chat(context.Context, providers.ChatRequest) (providers.ChatResponse, error) {
+	c.chatCalls++
+	return providers.ChatResponse{}, fmt.Errorf("unexpected non-streaming request")
+}
+
+func (c *memoryStreamOnlyClient) StreamChat(_ context.Context, req providers.ChatRequest) (<-chan providers.StreamEvent, error) {
+	c.streamRequests = append(c.streamRequests, req)
+	events := make(chan providers.StreamEvent, 2)
+	events <- providers.StreamEvent{Type: providers.EventContentDelta, Content: c.content}
+	events <- providers.StreamEvent{
+		Type:         providers.EventDone,
+		StopReason:   "stop",
+		FinishReason: providers.FinishReasonStop,
+	}
+	close(events)
+	return events, nil
+}
+
+func TestMemoryOverviewUsesStreamingProviderPath(t *testing.T) {
+	essay := "## 身份背景\n后端工程师。"
+	client := &memoryStreamOnlyClient{content: essay}
+	srv, home := newMemoryPanelServer(t, &fakeClient{})
+	srv.rt.StreamRunner.Client = client
+	writeMemoryFile(t, memdir.UserMemdir(home), "MEMORY.md", "")
+
+	resp := callMemoryRPC(t, srv, "ov-stream", MethodMemoryOverview, `{"scope":"user"}`)
+	result := remarshal[MemoryOverviewResult](t, resp["result"])
+	if result.EssayMD != essay {
+		t.Fatalf("essay = %q, want %q", result.EssayMD, essay)
+	}
+	if client.chatCalls != 0 {
+		t.Fatalf("memory overview made %d non-streaming requests", client.chatCalls)
+	}
+	if len(client.streamRequests) != 1 {
+		t.Fatalf("memory overview made %d streaming requests, want 1", len(client.streamRequests))
+	}
+}
+
 func TestMemoryOverviewCachesForTwelveHoursAndSupportsForcedRefresh(t *testing.T) {
 	essay := "## 身份背景\n后端工程师。\n\n## 协作偏好\n喜欢简短回复。\n\n## 沟通风格\n直接。\n\n## 当前关注\n记忆系统重构。"
 	client := &fakeClient{response: providersResponse(essay)}

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -9744,6 +9744,70 @@ func TestSettingsUsageAggregatesAcrossSessions(t *testing.T) {
 	}
 }
 
+func TestSettingsUsageModelBreakdownsSkipZeroUsageBuckets(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	now := time.Now().UTC()
+
+	sess1, err := session.CreateWithMetadata(rt.SessionDir, "usage-real", rt.RootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "real session"},
+		{
+			Role: "meta", Content: "token_usage", Provider: "openai", Model: "gpt-4o",
+			At: now.Add(-time.Hour), InputTokens: 200, OutputTokens: 100, CacheReadTokens: 50,
+		},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess1.ID, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Providers that never report usage (and compaction markers) persist
+	// token_usage rows with all-zero usage but a nonzero context size. A
+	// bucket made only of such rows must not surface as a 0/0 card.
+	sess2, err := session.CreateWithMetadata(rt.SessionDir, "usage-zero", rt.RootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "zero session"},
+		{
+			Role: "meta", Content: "token_usage", Provider: "test", Model: "gpt-test",
+			At: now.Add(-time.Hour), ContextTokens: 4096,
+		},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess2.ID, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	raw, err := json.Marshal(map[string]any{
+		"id":     "1",
+		"method": MethodSettingsUsage,
+		"params": map[string]any{"range": string(SettingsUsageRangeAll)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.handleLine(context.Background(), raw); err != nil {
+		t.Fatalf("handleLine: %v", err)
+	}
+
+	msgs := parseOutput(t, out.String())
+	result := remarshal[SettingsUsageResponse](t, responseByID(t, msgs, "1")["result"])
+
+	if len(result.ModelBreakdowns) != 1 {
+		t.Fatalf("expected 1 breakdown, got %d (%+v)", len(result.ModelBreakdowns), result.ModelBreakdowns)
+	}
+	if result.ModelBreakdowns[0].Provider != "openai" || result.ModelBreakdowns[0].InputTokens != 200 {
+		t.Fatalf("expected only the openai breakdown, got %+v", result.ModelBreakdowns[0])
+	}
+}
+
 func TestSettingsUsageModelBreakdownsRespectRange(t *testing.T) {
 	rt := newTestRuntime(t, &fakeClient{})
 	now := time.Now().UTC()

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -4241,6 +4241,13 @@ func buildUsageModelBreakdowns(rows []insight.TokenUsageRow) []insight.ModelUsag
 
 	breakdowns := make([]insight.ModelUsage, 0, len(buckets))
 	for key, bucket := range buckets {
+		// token_usage rows double as context-size markers (compaction
+		// checkpoints, turns whose provider reported no usage): their token
+		// sums are all zero. A bucket made only of such rows carries no
+		// spend signal and would render as a meaningless 0/0 card.
+		if bucket.TotalContextTokens() == 0 {
+			continue
+		}
 		bucket.Sessions = len(sessionsByBucket[key])
 		breakdowns = append(breakdowns, *bucket)
 	}


### PR DESCRIPTION
## Problem

The settings usage panel showed per-model cards with 0 input / 0 output and no hit rate (e.g. `test`, `codex-chat-compatible`, `minimax-openai`).

## Root cause

`token_usage` rows double as context-size markers and are persisted whenever the context size is nonzero, even when all usage fields are zero:

- compaction checkpoints deliberately write all-zero usage with the compacted context size (turn_handlers.go);
- turns whose provider never reports usage (test/chat-compatible providers, failed turns) still carry the assembled context estimate.

The insight scanner drops the context-size field and keeps only input/output/cache, so `buildUsageModelBreakdowns` produced buckets whose token sums are all zero — rendered as meaningless 0/0 cards.

Verified against a real session store: `test|gpt-test` had 99 all-zero rows, and several chat-compatible providers had 1–3 each, all with `context_tokens > 0`.

## Fix

Skip buckets whose total token count (input + output + cache creation + cache read) is zero when building the settings usage model breakdowns. The write path is untouched: the context size on those rows is load-bearing for session resume.

## Test

- New: `TestSettingsUsageModelBreakdownsSkipZeroUsageBuckets`
- `go test ./internal/appserver/` passes (full package)