### PR TITLE
fix(appserver): hide zero-usage model buckets from settings usage panel

### DIFF
--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -9744,6 +9744,70 @@ func TestSettingsUsageAggregatesAcrossSessions(t *testing.T) {
 	}
 }
 
+func TestSettingsUsageModelBreakdownsSkipZeroUsageBuckets(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	now := time.Now().UTC()
+
+	sess1, err := session.CreateWithMetadata(rt.SessionDir, "usage-real", rt.RootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "real session"},
+		{
+			Role: "meta", Content: "token_usage", Provider: "openai", Model: "gpt-4o",
+			At: now.Add(-time.Hour), InputTokens: 200, OutputTokens: 100, CacheReadTokens: 50,
+		},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess1.ID, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Providers that never report usage (and compaction markers) persist
+	// token_usage rows with all-zero usage but a nonzero context size. A
+	// bucket made only of such rows must not surface as a 0/0 card.
+	sess2, err := session.CreateWithMetadata(rt.SessionDir, "usage-zero", rt.RootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "zero session"},
+		{
+			Role: "meta", Content: "token_usage", Provider: "test", Model: "gpt-test",
+			At: now.Add(-time.Hour), ContextTokens: 4096,
+		},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess2.ID, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	raw, err := json.Marshal(map[string]any{
+		"id":     "1",
+		"method": MethodSettingsUsage,
+		"params": map[string]any{"range": string(SettingsUsageRangeAll)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.handleLine(context.Background(), raw); err != nil {
+		t.Fatalf("handleLine: %v", err)
+	}
+
+	msgs := parseOutput(t, out.String())
+	result := remarshal[SettingsUsageResponse](t, responseByID(t, msgs, "1")["result"])
+
+	if len(result.ModelBreakdowns) != 1 {
+		t.Fatalf("expected 1 breakdown, got %d (%+v)", len(result.ModelBreakdowns), result.ModelBreakdowns)
+	}
+	if result.ModelBreakdowns[0].Provider != "openai" || result.ModelBreakdowns[0].InputTokens != 200 {
+		t.Fatalf("expected only the openai breakdown, got %+v", result.ModelBreakdowns[0])
+	}
+}
+
 func TestSettingsUsageModelBreakdownsRespectRange(t *testing.T) {
 	rt := newTestRuntime(t, &fakeClient{})
 	now := time.Now().UTC()

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -4241,6 +4241,13 @@ func buildUsageModelBreakdowns(rows []insight.TokenUsageRow) []insight.ModelUsag
 
 	breakdowns := make([]insight.ModelUsage, 0, len(buckets))
 	for key, bucket := range buckets {
+		// token_usage rows double as context-size markers (compaction
+		// checkpoints, turns whose provider reported no usage): their token
+		// sums are all zero. A bucket made only of such rows carries no
+		// spend signal and would render as a meaningless 0/0 card.
+		if bucket.TotalContextTokens() == 0 {
+			continue
+		}
 		bucket.Sessions = len(sessionsByBucket[key])
 		breakdowns = append(breakdowns, *bucket)
 	}


### PR DESCRIPTION
## Problem

The settings usage panel showed per-model cards with 0 input / 0 output and no hit rate (e.g. `test`, `codex-chat-compatible`, `minimax-openai`).

## Root cause

`token_usage` rows double as context-size markers and are persisted whenever the context size is nonzero, even when all usage fields are zero:

- compaction checkpoints deliberately write all-zero usage with the compacted context size (turn_handlers.go);
- turns whose provider never reports usage (test/chat-compatible providers, failed turns) still carry the assembled context estimate.

The insight scanner drops the context-size field and keeps only input/output/cache, so `buildUsageModelBreakdowns` produced buckets whose token sums are all zero — rendered as meaningless 0/0 cards.

Verified against a real session store: `test|gpt-test` had 99 all-zero rows, and several chat-compatible providers had 1–3 each, all with `context_tokens > 0`.

## Fix

Skip buckets whose total token count (input + output + cache creation + cache read) is zero when building the settings usage model breakdowns. The write path is untouched: the context size on those rows is load-bearing for session resume.

Supersedes #112 (that branch picked up an unrelated commit from a shared worktree; this one is a single clean commit off latest main).

## Test

- New: `TestSettingsUsageModelBreakdownsSkipZeroUsageBuckets`
- `go test ./internal/appserver/` passes (full package, run on the identical diff in #112; targeted suite re-run on this branch)