### PR TITLE
chore(appserver): drop unused settings/usage entries field

### DIFF
--- a/desktop/src/renderer/SettingsRuntimeState.test.tsx
+++ b/desktop/src/renderer/SettingsRuntimeState.test.tsx
@@ -64,7 +64,6 @@ function usage(range: SettingsUsageRange): SettingsUsageResponse {
     },
     model_breakdowns: [],
     days: [],
-    entries: [],
   };
 }
 

--- a/desktop/src/renderer/SettingsView.test.tsx
+++ b/desktop/src/renderer/SettingsView.test.tsx
@@ -1063,20 +1063,6 @@ describe("SettingsView About section", () => {
         turns: 1,
         agents: 0,
       })),
-      entries: [
-        {
-          id: "turn:turn-1",
-          source: "turn",
-          title: "测试会话",
-          provider: "OpenAI API",
-          model: "fake-model",
-          at: "2026-06-18T12:00:00Z",
-          input_tokens: 1000,
-          output_tokens: 200,
-          cache_creation_tokens: 20,
-          cache_read_tokens: 50,
-        },
-      ],
     };
     const { rootText } = renderSettings({
       initialized: baseInitialized(),

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -2313,29 +2313,12 @@ type SettingsUsageDay struct {
 	Agents              int     `json:"agents"`
 }
 
-// SettingsUsageEntry is one recent token-spending record surfaced in the
-// "最近记录" list. Source identifies whether the row came from a primary
-// session turn or a subagent run; Title is rendered as the entry headline.
-type SettingsUsageEntry struct {
-	ID                  string `json:"id"`
-	Source              string `json:"source"` // "turn" | "agent"
-	Title               string `json:"title"`
-	Provider            string `json:"provider"`
-	Model               string `json:"model"`
-	At                  string `json:"at"`
-	InputTokens         int    `json:"input_tokens"`
-	OutputTokens        int    `json:"output_tokens"`
-	CacheCreationTokens int    `json:"cache_creation_tokens"`
-	CacheReadTokens     int    `json:"cache_read_tokens"`
-}
-
 // SettingsUsageResponse is the single source of truth for the desktop
 // usage page. Range mirrors the requested window. Metrics is the headline
 // number block, ModelBreakdowns is the per-model table sorted by total
 // context tokens descending (legacy rows with empty provider+model are
-// surfaced as "(unknown)"), Days is the calendar-day series for the
-// heatmap (gaps filled by the desktop), and Entries is the most recent
-// N token_usage rows within the range for the "最近记录" list.
+// surfaced as "(unknown)"), and Days is the calendar-day series for the
+// heatmap (gaps filled by the desktop).
 type SettingsUsageResponse struct {
 	Range           SettingsUsageRange   `json:"range"`
 	TotalSessions   int                  `json:"total_sessions"`
@@ -2343,5 +2326,4 @@ type SettingsUsageResponse struct {
 	Metrics         SettingsUsageMetrics `json:"metrics"`
 	ModelBreakdowns []insight.ModelUsage `json:"model_breakdowns"`
 	Days            []SettingsUsageDay   `json:"days"`
-	Entries         []SettingsUsageEntry `json:"entries"`
 }

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -4146,23 +4146,13 @@ func (s *Server) handleSettingsUsage(req Request) error {
 	now := time.Now().UTC()
 	cutoff := settingsUsageRangeCutoff(rangeFilter, now)
 
-	metas, err := insight.ScanSessions(sessDir, 0)
-	if err != nil {
-		return s.writeResponse(req.ID, nil, fmt.Errorf("scan sessions: %w", err))
-	}
 	rows, err := insight.CollectTokenUsageRows(sessDir)
 	if err != nil {
 		return s.writeResponse(req.ID, nil, fmt.Errorf("collect usage rows: %w", err))
 	}
 	filteredRows := filterUsageRowsByCutoff(rows, cutoff)
 
-	titleByID := make(map[string]string, len(metas))
-	for _, m := range metas {
-		if title := strings.TrimSpace(m.FirstUserMsg); title != "" {
-			titleByID[m.ID] = truncateUsageTitle(title)
-		}
-	}
-	metrics, days, entries := aggregateUsageRows(filteredRows, titleByID)
+	metrics, days := aggregateUsageRows(filteredRows)
 	totalSessions := countSessionsInRange(rows, cutoff)
 
 	return s.writeResponse(req.ID, SettingsUsageResponse{
@@ -4172,7 +4162,6 @@ func (s *Server) handleSettingsUsage(req Request) error {
 		Metrics:         metrics,
 		ModelBreakdowns: buildUsageModelBreakdowns(filteredRows),
 		Days:            days,
-		Entries:         entries,
 	}, nil)
 }
 
@@ -4258,11 +4247,10 @@ func buildUsageModelBreakdowns(rows []insight.TokenUsageRow) []insight.ModelUsag
 }
 
 // aggregateUsageRows is the single source of truth for the desktop
-// usage page's metrics, daily series, and recent-entries list. It
-// never reads from session metadata — only the per-row token_usage
-// trail — so the headline numbers, the heatmap, and the "最近记录"
-// list all stay numerically consistent.
-func aggregateUsageRows(rows []insight.TokenUsageRow, titleByID map[string]string) (SettingsUsageMetrics, []SettingsUsageDay, []SettingsUsageEntry) {
+// usage page's metrics and daily series. It never reads from session
+// metadata — only the per-row token_usage trail — so the headline
+// numbers and the heatmap stay numerically consistent.
+func aggregateUsageRows(rows []insight.TokenUsageRow) (SettingsUsageMetrics, []SettingsUsageDay) {
 	metrics := SettingsUsageMetrics{}
 	type dayBucket struct {
 		input, output, cacheRead, cacheCreation int
@@ -4327,57 +4315,7 @@ func aggregateUsageRows(rows []insight.TokenUsageRow, titleByID map[string]strin
 	}
 	sort.Slice(days, func(i, j int) bool { return days[i].Date < days[j].Date })
 
-	entries := buildUsageEntries(rows, titleByID, 8)
-	return metrics, days, entries
-}
-
-// buildUsageEntries picks the most recent N token_usage rows (by At)
-// and renders them as SettingsUsageEntry rows. Rows with a zero At are
-// sorted last so legacy imports never steal the top slots in the
-// "最近记录" list.
-func buildUsageEntries(rows []insight.TokenUsageRow, titleByID map[string]string, limit int) []SettingsUsageEntry {
-	type sortable struct {
-		row insight.TokenUsageRow
-		ts  time.Time
-	}
-	items := make([]sortable, 0, len(rows))
-	for _, r := range rows {
-		items = append(items, sortable{row: r, ts: r.At})
-	}
-	sort.Slice(items, func(i, j int) bool {
-		iZero, jZero := items[i].ts.IsZero(), items[j].ts.IsZero()
-		if iZero != jZero {
-			return !iZero
-		}
-		if items[i].ts.Equal(items[j].ts) {
-			return items[i].row.SessionID < items[j].row.SessionID
-		}
-		return items[i].ts.After(items[j].ts)
-	})
-	if limit > 0 && len(items) > limit {
-		items = items[:limit]
-	}
-	entries := make([]SettingsUsageEntry, 0, len(items))
-	for _, it := range items {
-		r := it.row
-		title := titleByID[r.SessionID]
-		if title == "" {
-			title = r.SessionID
-		}
-		entries = append(entries, SettingsUsageEntry{
-			ID:                  "turn:" + r.SessionID + "@" + r.At.Format(time.RFC3339Nano),
-			Source:              "turn",
-			Title:               title,
-			Provider:            r.Provider,
-			Model:               r.Model,
-			At:                  r.At.UTC().Format(time.RFC3339Nano),
-			InputTokens:         r.InputTokens,
-			OutputTokens:        r.OutputTokens,
-			CacheCreationTokens: r.CacheCreationTokens,
-			CacheReadTokens:     r.CacheReadTokens,
-		})
-	}
-	return entries
+	return metrics, days
 }
 
 // truncateUsageTitle shortens a session's first user message down to a

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1941,29 +1941,12 @@ export type SettingsUsageDay = {
   agents: number;
 };
 
-// SettingsUsageEntry is one recent token-spending record surfaced in
-// the "最近记录" list. Source distinguishes primary-session turns from
-// subagent runs so the UI can label them differently.
-export type SettingsUsageEntry = {
-  id: string;
-  source: "turn" | "agent";
-  title: string;
-  provider: string;
-  model: string;
-  at: string;
-  input_tokens: number;
-  output_tokens: number;
-  cache_creation_tokens: number;
-  cache_read_tokens: number;
-};
-
 // SettingsUsageResponse is the single source of truth for the desktop
 // usage page. ModelBreakdowns is sorted by total context tokens
 // descending; empty Provider+Model entries are bucketed as "(unknown)"
-// in the UI. Days carries the calendar-day series for the heatmap and
-// Entries carries the most recent N rows for the "最近记录" list —
+// in the UI. Days carries the calendar-day series for the heatmap —
 // both are derived from the same per-row token_usage trail so the
-// three views always sum to the same totals.
+// views always sum to the same totals.
 export type SettingsUsageResponse = {
   range: SettingsUsageRange;
   total_sessions: number;
@@ -1971,7 +1954,6 @@ export type SettingsUsageResponse = {
   metrics: SettingsUsageMetrics;
   model_breakdowns: ModelUsage[];
   days: SettingsUsageDay[];
-  entries: SettingsUsageEntry[];
 };
 
 // ComposerGoalSummary is the composer-banner view of the current thread goal.


### PR DESCRIPTION
Closes #115.

## What

Removes the `entries` ("最近记录") payload from the `settings/usage` RPC end to end:

- `internal/appserver/turn_handlers.go`: delete `buildUsageEntries`; `aggregateUsageRows` now returns only metrics + days; `handleSettingsUsage` drops the `titleByID` construction and the `insight.ScanSessions` walk that existed solely to title entries
- `internal/appserver/protocol.go`: delete `SettingsUsageEntry` and `SettingsUsageResponse.Entries`
- `packages/protocol/src/index.ts`: same removal on the TS protocol layer
- Desktop test mocks updated (they carried the field but the UI has not rendered it since `399515b5`)

`truncateUsageTitle` intentionally stays — `subthread_handlers.go` still uses it.

## Why

No client has read `entries` since the desktop section was removed in `399515b5`; the server still paid a full sort of all token_usage rows plus a ScanSessions pass over every session on each `settings/usage` call.

## Test

- `go test ./internal/appserver/ -run TestSettingsUsage` passes; `go build` + `go vet` clean
- `tsc --noEmit` clean
- `vitest run SettingsView.test.tsx SettingsRuntimeState.test.tsx`: 31/31 pass