### PR TITLE
fix(desktop): keep process summaries neutral

### DIFF
--- a/desktop/src/renderer/ProcessSurface.test.tsx
+++ b/desktop/src/renderer/ProcessSurface.test.tsx
@@ -209,6 +209,41 @@ describe("ProcessSurface", () => {
     expect(label?.textContent).toBe("思考过程");
   });
 
+  it("keeps process summaries neutral when a tool fails", () => {
+    const failedTool = {
+      ...makeReadFile("tool-1", "a.ts", "failed"),
+      error: "command failed",
+    };
+    const { container } = render({
+      processItems: [
+        failedTool,
+        makeReasoning("reason-1", "recovering", "in_progress"),
+      ],
+      streaming: true,
+      active: false,
+    });
+    const row = container.querySelector(".process-surface-row");
+    expect(row?.classList.contains("is-streaming")).toBe(true);
+    expect(row?.classList.contains("is-live-gray")).toBe(false);
+    expect(row?.classList.contains("failed")).toBe(false);
+
+    rerender({
+      processItems: [
+        failedTool,
+        makeReasoning("reason-1", "recovered", "completed"),
+      ],
+      streaming: false,
+    });
+    expect(
+      container
+        .querySelector(".process-surface-row")
+        ?.classList.contains("failed"),
+    ).toBe(false);
+    expect(
+      container.querySelector(".activity-detail-error")?.textContent,
+    ).toContain("命令执行失败");
+  });
+
   it("keeps the fold collapsed when streaming starts", () => {
     const { container } = render({
       processItems: [

--- a/desktop/src/renderer/ProcessSurface.tsx
+++ b/desktop/src/renderer/ProcessSurface.tsx
@@ -146,7 +146,6 @@ export function ProcessSurface({
   const hasMultipleTools = toolItems.length > 1;
   const hasDetails = hasReasoning || hasMultipleTools;
   const hasErrors = toolSegments.some((segment) => Boolean(segment.error));
-  const failed = toolSegments.some((segment) => segment.status === "failed");
   const reasoningStreaming =
     streaming &&
     reasoningItems.some((item) => item.status === "in_progress");
@@ -185,7 +184,7 @@ export function ProcessSurface({
 
   const className = `process-surface${
     hasDetails ? " has-details" : " no-details"
-  }${streaming ? " is-streaming" : ""}${failed ? " failed" : ""}`;
+  }${streaming ? " is-streaming" : ""}`;
 
   const summaryLine = (
     <span className="process-surface-summary-line">
@@ -243,8 +242,6 @@ export function ProcessSurface({
       <details
         className={`process-surface-fold${hasDetails ? " has-details" : " no-details"}${
           expanded ? " expanded" : " collapsed"
-        }${
-          failed ? " failed" : ""
         }`}
         open={hasDetails && expanded}
         onToggle={handleToggle}
@@ -252,7 +249,7 @@ export function ProcessSurface({
         <summary
           className={`process-surface-row${
             activeGrayText ? " is-live-gray" : ""
-          }${streaming ? " is-streaming" : ""}${failed ? " failed" : ""}`}
+          }${streaming ? " is-streaming" : ""}`}
           onClick={handleSummaryClick}
         >
           {summaryLine}

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -2480,10 +2480,6 @@
   }
 }
 
-.process-surface-row.failed {
-  color: var(--danger);
-}
-
 .process-surface-fold.no-details > .process-surface-row {
   cursor: default;
 }


### PR DESCRIPTION
## Summary
- keep process summary rows visually neutral when tool calls fail
- retain detailed error messages inside the expandable process body
- add regression coverage for streaming and settled failed-tool states

## Verification
- 68 targeted renderer tests passed
- desktop TypeScript typecheck passed
- git diff --check passed