### PR TITLE
perf(desktop): reduce idle renderer activity

### DIFF
--- a/desktop/src/renderer/AssistantTurnShell.test.tsx
+++ b/desktop/src/renderer/AssistantTurnShell.test.tsx
@@ -1345,6 +1345,16 @@ describe("AssistantTurnShell — turn divider styles", () => {
     );
   });
 
+  it("pauses infinite turn animations while the renderer is hidden", () => {
+    expect(turnsCSS).toContain(
+      ":root[data-renderer-hidden] .turn-progress.in_progress .turn-progress-title",
+    );
+    expect(turnsCSS).toContain(
+      ":root[data-renderer-hidden] .process-surface-row.is-live-gray::after",
+    );
+    expect(turnsCSS).toContain("animation-play-state: paused;");
+  });
+
   it("keeps live bottom content on real layout instead of placeholder layout", () => {
     const liveTurnRule = cssRule('.turn[data-turn-status="in_progress"]');
     expect(liveTurnRule).toContain("content-visibility: visible;");

--- a/desktop/src/renderer/BrowserVisibility.test.ts
+++ b/desktop/src/renderer/BrowserVisibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ActivitySession } from "../shared/protocol";
 import {
   boundsChanged,
@@ -6,10 +6,16 @@ import {
   computeForegroundPromotion,
   isForegroundControlled,
   isMeasurableRect,
+  observeBrowserPanelBounds,
   pickBoundsRect,
   roundRect,
   type ForegroundSnapshot,
 } from "./BrowserVisibility";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
 
 function activity(overrides: Partial<ActivitySession> = {}): ActivitySession {
   return {
@@ -95,6 +101,96 @@ describe("pickBoundsRect", () => {
     const zeroHost = { x: 0, y: 0, width: 0, height: 0 };
     expect(pickBoundsRect(zeroHost, undefined)).toBe(zeroHost);
     expect(pickBoundsRect(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("observeBrowserPanelBounds", () => {
+  it("stops requesting frames after a stable measurement", () => {
+    const frame = document.createElement("div");
+    frame.className = "workspace-browser-frame";
+    const host = document.createElement("div");
+    host.className = "workspace-browser-host";
+    frame.append(host);
+    document.body.append(frame);
+    vi.spyOn(host, "getBoundingClientRect").mockReturnValue({
+      x: 10,
+      y: 20,
+      left: 10,
+      top: 20,
+      right: 310,
+      bottom: 220,
+      width: 300,
+      height: 200,
+      toJSON: () => ({}),
+    });
+
+    const frames: FrameRequestCallback[] = [];
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frames.push(callback);
+        return frames.length;
+      });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const report = vi.fn();
+
+    const cleanup = observeBrowserPanelBounds(report);
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    frames.shift()?.(0);
+
+    expect(report).toHaveBeenCalledWith({
+      x: 10,
+      y: 20,
+      width: 300,
+      height: 200,
+    });
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it("tracks frames only while a panel geometry transition is active", () => {
+    const panel = document.createElement("aside");
+    panel.className = "workspace-right-panel";
+    const frame = document.createElement("div");
+    frame.className = "workspace-browser-frame";
+    panel.append(frame);
+    document.body.append(panel);
+    vi.spyOn(frame, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 300,
+      bottom: 200,
+      width: 300,
+      height: 200,
+      toJSON: () => ({}),
+    });
+
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    const cleanup = observeBrowserPanelBounds(vi.fn());
+    frames.shift()?.(0);
+
+    const run = new Event("transitionrun", { bubbles: true });
+    Object.defineProperty(run, "propertyName", { value: "transform" });
+    panel.dispatchEvent(run);
+    expect(frames).toHaveLength(1);
+    frames.shift()?.(16);
+    expect(frames).toHaveLength(1);
+
+    const end = new Event("transitionend", { bubbles: true });
+    Object.defineProperty(end, "propertyName", { value: "transform" });
+    panel.dispatchEvent(end);
+    frames.shift()?.(32);
+    expect(frames).toHaveLength(0);
+    cleanup();
   });
 });
 

--- a/desktop/src/renderer/BrowserVisibility.ts
+++ b/desktop/src/renderer/BrowserVisibility.ts
@@ -132,13 +132,164 @@ function measureRect(element: Element | null): BrowserBoundsRect | undefined {
   });
 }
 
-function measureBrowserPanelRect(): BrowserBoundsRect | undefined {
-  // A single browser panel is mounted at a time, so querying by class avoids
-  // threading a ref through WorkspaceRightPanel → WorkspacePanels →
-  // WorkspaceBrowserPanel (App.tsx is a high-conflict 4500-line file).
-  const host = document.querySelector(".workspace-browser-host");
-  const frame = document.querySelector(".workspace-browser-frame");
+function measureBrowserPanelRect(
+  host: Element | null,
+  frame: Element | null,
+): BrowserBoundsRect | undefined {
   return pickBoundsRect(measureRect(host), measureRect(frame));
+}
+
+const BOUNDS_TRANSITION_PROPERTIES = new Set([
+  "grid-template-columns",
+  "transform",
+  "width",
+]);
+const BOUNDS_TRANSITION_MAX_MS = 1000;
+
+function transitionAffectsBrowserPanel(
+  event: TransitionEvent,
+  host: Element | null,
+  frame: Element | null,
+): boolean {
+  if (!BOUNDS_TRANSITION_PROPERTIES.has(event.propertyName)) {
+    return false;
+  }
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return [host, frame].some(
+    (element) =>
+      element !== null &&
+      (target === element || target.contains(element) || element.contains(target)),
+  );
+}
+
+// Keep the native WebContentsView aligned without a permanent frame loop.
+// Resize/scroll changes schedule one measurement; the short rAF loop only
+// runs while a geometry-changing CSS transition is active.
+export function observeBrowserPanelBounds(
+  report: (rect: BrowserBoundsRect) => void,
+): () => void {
+  let host: Element | null = null;
+  let frame: Element | null = null;
+  let rafHandle: number | undefined;
+  let activeTransitions = 0;
+  let transitionSafetyTimer: number | undefined;
+  let lastRect: BrowserBoundsRect | undefined;
+  let mountObserver: MutationObserver | undefined;
+  const resizeObserver =
+    typeof ResizeObserver === "undefined"
+      ? undefined
+      : new ResizeObserver(() => scheduleMeasure());
+
+  const syncElements = (): void => {
+    const nextHost = host?.isConnected
+      ? host
+      : document.querySelector(".workspace-browser-host");
+    const nextFrame = frame?.isConnected
+      ? frame
+      : document.querySelector(".workspace-browser-frame");
+    if (nextHost === host && nextFrame === frame) {
+      return;
+    }
+    host = nextHost;
+    frame = nextFrame;
+    resizeObserver?.disconnect();
+    if (host) {
+      resizeObserver?.observe(host);
+    }
+    if (frame && frame !== host) {
+      resizeObserver?.observe(frame);
+    }
+    if (host || frame) {
+      mountObserver?.disconnect();
+      mountObserver = undefined;
+    }
+  };
+
+  const measureAndReport = (): void => {
+    syncElements();
+    const rect = measureBrowserPanelRect(host, frame);
+    if (rect && boundsChanged(lastRect, rect)) {
+      lastRect = rect;
+      report(rect);
+    }
+  };
+
+  function flushMeasure(): void {
+    rafHandle = undefined;
+    measureAndReport();
+    if (activeTransitions > 0) {
+      rafHandle = window.requestAnimationFrame(flushMeasure);
+    }
+  }
+
+  function scheduleMeasure(): void {
+    if (rafHandle === undefined) {
+      rafHandle = window.requestAnimationFrame(flushMeasure);
+    }
+  }
+
+  const handleTransitionRun = (rawEvent: Event): void => {
+    const event = rawEvent as TransitionEvent;
+    syncElements();
+    if (!transitionAffectsBrowserPanel(event, host, frame)) {
+      return;
+    }
+    activeTransitions += 1;
+    if (transitionSafetyTimer !== undefined) {
+      window.clearTimeout(transitionSafetyTimer);
+    }
+    transitionSafetyTimer = window.setTimeout(() => {
+      activeTransitions = 0;
+      transitionSafetyTimer = undefined;
+    }, BOUNDS_TRANSITION_MAX_MS);
+    scheduleMeasure();
+  };
+  const handleTransitionStop = (rawEvent: Event): void => {
+    const event = rawEvent as TransitionEvent;
+    if (!transitionAffectsBrowserPanel(event, host, frame)) {
+      return;
+    }
+    activeTransitions = Math.max(0, activeTransitions - 1);
+    if (activeTransitions === 0 && transitionSafetyTimer !== undefined) {
+      window.clearTimeout(transitionSafetyTimer);
+      transitionSafetyTimer = undefined;
+    }
+    scheduleMeasure();
+  };
+
+  syncElements();
+  if (!host && !frame && typeof MutationObserver !== "undefined") {
+    mountObserver = new MutationObserver(() => {
+      syncElements();
+      scheduleMeasure();
+    });
+    mountObserver.observe(document.body, { childList: true, subtree: true });
+  }
+  window.addEventListener("resize", scheduleMeasure);
+  window.addEventListener("scroll", scheduleMeasure, true);
+  document.addEventListener("transitionrun", handleTransitionRun);
+  document.addEventListener("transitionend", handleTransitionStop);
+  document.addEventListener("transitioncancel", handleTransitionStop);
+  scheduleMeasure();
+
+  return () => {
+    if (rafHandle !== undefined) {
+      window.cancelAnimationFrame(rafHandle);
+    }
+    if (transitionSafetyTimer !== undefined) {
+      window.clearTimeout(transitionSafetyTimer);
+    }
+    resizeObserver?.disconnect();
+    mountObserver?.disconnect();
+    window.removeEventListener("resize", scheduleMeasure);
+    window.removeEventListener("scroll", scheduleMeasure, true);
+    document.removeEventListener("transitionrun", handleTransitionRun);
+    document.removeEventListener("transitionend", handleTransitionStop);
+    document.removeEventListener("transitioncancel", handleTransitionStop);
+  };
 }
 
 // ── Hook ─────────────────────────────────────────────────────────────────
@@ -200,39 +351,15 @@ export function useBrowserVisibility({
     activeBrowserActivity?.id,
   ]);
 
-  // Bounds reporter: while the agent view is visible, stream the panel's
-  // on-screen rect so main can keep the WebContentsView aligned. rAF polling
-  // (not just ResizeObserver, which does not observe pure translation) so a
-  // window move / scroll / panel drag is tracked too.
+  // Bounds reporter: event-driven while the panel is still, with short rAF
+  // tracking only for geometry-changing CSS transitions.
   useEffect(() => {
     const report = window.wuu.reportBrowserBounds;
     if (!foregroundTarget || typeof report !== "function") {
       return undefined;
     }
     const { workdir, tabID } = foregroundTarget;
-    let rafHandle = 0;
-    let lastRect: BrowserBoundsRect | undefined;
-    const tick = (): void => {
-      const rect = measureBrowserPanelRect();
-      if (rect && boundsChanged(lastRect, rect)) {
-        lastRect = rect;
-        report(workdir, tabID, rect);
-      }
-      rafHandle = window.requestAnimationFrame(tick);
-    };
-    rafHandle = window.requestAnimationFrame(tick);
-    // resize/scroll only force the next frame to re-measure; the rAF loop does
-    // the actual measuring so no change is ever missed between events.
-    const invalidate = (): void => {
-      lastRect = undefined;
-    };
-    window.addEventListener("resize", invalidate);
-    window.addEventListener("scroll", invalidate, true);
-    return () => {
-      window.cancelAnimationFrame(rafHandle);
-      window.removeEventListener("resize", invalidate);
-      window.removeEventListener("scroll", invalidate, true);
-    };
+    return observeBrowserPanelBounds((rect) => report(workdir, tabID, rect));
   }, [foregroundTarget]);
 
   // Overlay suppression: hide the agent view while a full-window overlay is

--- a/desktop/src/renderer/ComposerTokenGauge.tsx
+++ b/desktop/src/renderer/ComposerTokenGauge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useI18n } from "./i18n";
 
 // Toolbar gauge. The numeric readout is rendered inline next to the dial
@@ -7,9 +7,9 @@ import { useI18n } from "./i18n";
 // applies to both.
 const MAX_TOKENS_PER_SEC = 100;
 const HIGH_SPEED_THRESHOLD = 70;
-const DISPLAY_LERP = 0.055;
 const STALE_HOLD_MS = 1200;
 const STALE_DECAY_MS = 5200;
+const STALE_DECAY_STEP_MS = 100;
 
 const GAUGE_ARC_PATH = "M 2.5 17 A 9.5 9.5 0 0 1 21.5 17";
 const GAUGE_ARC_PATH_LENGTH = 100;
@@ -40,68 +40,50 @@ export function ComposerTokenGauge({
   source?: "real" | "estimated" | "none";
 }): JSX.Element {
   const { t, formatNumber } = useI18n();
-  // Displayed value tracks the target with a per-frame lerp so the needle
-  // settles instead of jittering on every sliding-window update. The initial
-  // value is the target itself so the gauge paints the real number on first
-  // mount and tests that render synchronously can see the right value.
+  // CSS transitions smooth the needle and arc between samples. React only
+  // updates when the target changes or a stale sample is winding down, so a
+  // stable running turn does not keep the renderer on a permanent rAF loop.
   const [displayed, setDisplayed] = useState(() =>
     running ? Math.max(0, tokensPerSecond) : 0,
   );
-  const runningRef = useRef(running);
-  const displayedRef = useRef(displayed);
-  const targetRef = useRef(0);
-  const sampledAtRef = useRef<number | undefined>(sampledAt);
-  runningRef.current = running;
-  targetRef.current = running ? Math.max(0, tokensPerSecond) : 0;
-  sampledAtRef.current = sampledAt;
 
   useEffect(() => {
-    let raf = 0;
-    const shouldAnimate = (): boolean =>
-      runningRef.current ||
-      targetRef.current > 0.05 ||
-      displayedRef.current > 0.05;
-
-    if (!shouldAnimate()) {
-      displayedRef.current = 0;
-      setDisplayed(0);
-      return;
+    const target = running ? Math.max(0, tokensPerSecond) : 0;
+    setDisplayed(target);
+    if (!running || target <= 0.05 || sampledAt === undefined) {
+      return undefined;
     }
 
-    const tick = (): void => {
-      const now = Date.now();
-      // Apply the same stale decay to the display so the gauge visibly
-      // winds down toward 0 once the model stops streaming, instead of
-      // freezing on the last known rate.
-      let resolvedTarget = runningRef.current ? targetRef.current : 0;
-      const sampleAge = sampledAtRef.current
-        ? now - sampledAtRef.current
-        : 0;
-      if (resolvedTarget > 0 && sampleAge > STALE_HOLD_MS) {
-        const decay = Math.max(
-          0,
-          1 - (sampleAge - STALE_HOLD_MS) / STALE_DECAY_MS,
-        );
-        resolvedTarget *= decay;
+    let decayTimer: number | undefined;
+    let decayInterval: number | undefined;
+    const updateDecay = (): boolean => {
+      const decayElapsed = Date.now() - sampledAt - STALE_HOLD_MS;
+      const decay = Math.max(0, 1 - decayElapsed / STALE_DECAY_MS);
+      setDisplayed(target * decay);
+      if (decay === 0 && decayInterval !== undefined) {
+        window.clearInterval(decayInterval);
+        decayInterval = undefined;
       }
-      setDisplayed((current) => {
-        const diff = resolvedTarget - current;
-        let next = resolvedTarget;
-        if (Math.abs(diff) < 0.05) {
-          displayedRef.current = next;
-          return next;
-        }
-        next = current + diff * DISPLAY_LERP;
-        displayedRef.current = next;
-        return next;
-      });
-      if (shouldAnimate()) {
-        raf = window.requestAnimationFrame(tick);
+      return decay > 0;
+    };
+    const startDecay = (): void => {
+      if (updateDecay()) {
+        decayInterval = window.setInterval(updateDecay, STALE_DECAY_STEP_MS);
       }
     };
-    raf = window.requestAnimationFrame(tick);
+    const holdRemaining = Math.max(
+      0,
+      sampledAt + STALE_HOLD_MS - Date.now(),
+    );
+    decayTimer = window.setTimeout(startDecay, holdRemaining);
+
     return () => {
-      window.cancelAnimationFrame(raf);
+      if (decayTimer !== undefined) {
+        window.clearTimeout(decayTimer);
+      }
+      if (decayInterval !== undefined) {
+        window.clearInterval(decayInterval);
+      }
     };
   }, [running, sampledAt, tokensPerSecond]);
 

--- a/desktop/src/renderer/ComposerView.test.tsx
+++ b/desktop/src/renderer/ComposerView.test.tsx
@@ -2069,13 +2069,10 @@ describe("ComposerTokenGauge", () => {
     expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
   });
 
-  it("renders a live gauge with the speed label inline, no hover required", () => {
+  it("renders a live gauge without scheduling animation frames", () => {
     const requestAnimationFrame = vi
       .spyOn(window, "requestAnimationFrame")
       .mockImplementation(() => 1);
-    const cancelAnimationFrame = vi
-      .spyOn(window, "cancelAnimationFrame")
-      .mockImplementation(() => {});
 
     try {
       renderComposer({ running: true, tokensPerSecond: 18.4 });
@@ -2084,7 +2081,7 @@ describe("ComposerTokenGauge", () => {
       expect(gauge).not.toBeNull();
       expect(gauge?.getAttribute("data-state")).toBe("running");
       expect(gauge?.getAttribute("title")).toBeNull();
-      expect(requestAnimationFrame).toHaveBeenCalled();
+      expect(requestAnimationFrame).not.toHaveBeenCalled();
 
       // Label is inline; no portal, no hover gate. Hovering must not
       // resurrect a tooltip either.
@@ -2108,7 +2105,42 @@ describe("ComposerTokenGauge", () => {
       expect(container.querySelectorAll(".composer-token-gauge-speed-dot")).toHaveLength(0);
     } finally {
       requestAnimationFrame.mockRestore();
-      cancelAnimationFrame.mockRestore();
+    }
+  });
+
+  it("decays a stale token speed without animation frames", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const requestAnimationFrame = vi.spyOn(window, "requestAnimationFrame");
+
+    try {
+      renderComposer({
+        running: true,
+        tokensPerSecond: 20,
+        tokenSpeedSampledAt: Date.now(),
+      });
+
+      expect(container.querySelector(".composer-token-gauge-label")?.textContent).toContain(
+        "20 tok/s",
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(3_800);
+      });
+      expect(container.querySelector(".composer-token-gauge-label")?.textContent).toContain(
+        "10 tok/s",
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(3_000);
+      });
+      expect(container.querySelector(".composer-token-gauge-label")?.textContent).toContain(
+        "0 tok/s",
+      );
+      expect(requestAnimationFrame).not.toHaveBeenCalled();
+    } finally {
+      requestAnimationFrame.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/desktop/src/renderer/RendererVisibility.test.ts
+++ b/desktop/src/renderer/RendererVisibility.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  startRendererVisibilitySync,
+  syncRendererVisibility,
+} from "./RendererVisibility";
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-renderer-hidden");
+  vi.restoreAllMocks();
+});
+
+describe("renderer visibility", () => {
+  it("stamps hidden state without changing visible documents", () => {
+    syncRendererVisibility(document.documentElement, "hidden");
+    expect(document.documentElement.hasAttribute("data-renderer-hidden")).toBe(true);
+
+    syncRendererVisibility(document.documentElement, "visible");
+    expect(document.documentElement.hasAttribute("data-renderer-hidden")).toBe(false);
+  });
+
+  it("tracks document visibility changes for the renderer lifetime", () => {
+    const visibilityState = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("hidden");
+    const stop = startRendererVisibilitySync();
+    expect(document.documentElement.hasAttribute("data-renderer-hidden")).toBe(true);
+
+    visibilityState.mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(document.documentElement.hasAttribute("data-renderer-hidden")).toBe(false);
+
+    stop();
+  });
+});

--- a/desktop/src/renderer/RendererVisibility.ts
+++ b/desktop/src/renderer/RendererVisibility.ts
@@ -1,0 +1,17 @@
+const RENDERER_HIDDEN_ATTRIBUTE = "data-renderer-hidden";
+
+export function syncRendererVisibility(
+  root: HTMLElement,
+  visibilityState: DocumentVisibilityState,
+): void {
+  root.toggleAttribute(RENDERER_HIDDEN_ATTRIBUTE, visibilityState === "hidden");
+}
+
+export function startRendererVisibilitySync(): () => void {
+  const sync = (): void => {
+    syncRendererVisibility(document.documentElement, document.visibilityState);
+  };
+  sync();
+  document.addEventListener("visibilitychange", sync);
+  return () => document.removeEventListener("visibilitychange", sync);
+}

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -3,6 +3,7 @@ import { MESSAGE_FLOW_FONT_SIZE_RANGE } from "../shared/protocol";
 import { App } from "./App";
 import { applyMessageFlowFontSize } from "./MessageFlowFontSizeSection";
 import { applyPlatformStamp } from "./platform";
+import { startRendererVisibilitySync } from "./RendererVisibility";
 import { applyThemePreference, startThemePreferenceSync } from "./Theme";
 import "./styles.css";
 import { I18nProvider } from "./i18n";
@@ -20,6 +21,11 @@ startThemePreferenceSync();
 // Same story for data-platform: the preload stamps it pre-paint; this
 // covers boots whose preload was replaced (e2e mocks).
 applyPlatformStamp();
+
+// Pause ambient infinite animations while the native window is hidden or
+// minimized. Finite UI transitions remain untouched so their lifecycle events
+// can still complete normally.
+startRendererVisibilitySync();
 
 // Re-apply the message-stream font size in case the preload stamp was
 // dropped (e.g. user unset window.wuu during boot, or the file was

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -2454,6 +2454,19 @@
   z-index: 1;
 }
 
+:root[data-renderer-hidden] .turn-progress.in_progress .turn-progress-title,
+:root[data-renderer-hidden] .turn-process-live-dot,
+:root[data-renderer-hidden] .process-surface-row.is-live-gray::after,
+:root[data-renderer-hidden] .turn-reasoning-summary-text.is-live-gray::after,
+:root[data-renderer-hidden] .turn-process-preview.is-live::after,
+:root[data-renderer-hidden] .live-progress-chip::after,
+:root[data-renderer-hidden] .wuu-launch-glass::after,
+:root[data-renderer-hidden] .wuu-launch-mark::after,
+:root[data-renderer-hidden] .wuu-launch-mark span,
+:root[data-renderer-hidden] .wuu-launch-rail::after {
+  animation-play-state: paused;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .process-surface-count.is-changing {
     animation: none;


### PR DESCRIPTION
## Summary

- replace the token-rate gauge’s permanent animation-frame React loop with CSS transitions and bounded stale decay
- replace permanent browser-panel bounds polling with resize/scroll observers and transition-scoped frame tracking
- pause known infinite ambient animations while the renderer is hidden or minimized

## Testing

- `npm test`
- `npm run build`
- `git diff --check origin/main...HEAD`