### PR TITLE
fix(appserver): edit messages after history compaction

### DIFF
--- a/internal/appserver/fork.go
+++ b/internal/appserver/fork.go
@@ -192,6 +192,28 @@ func editHistoryBeforeUserMessage(history []providers.ChatMessage, sourceThreadI
 	if targetItemID == "" {
 		return nil, ThreadEditDraft{}, fmt.Errorf("item_id is required")
 	}
+	targetSeq := 0
+	targetFound := false
+	for _, turn := range turns {
+		if turn.ID != targetTurnID {
+			continue
+		}
+		for _, item := range turn.Items {
+			if item.ID != targetItemID {
+				continue
+			}
+			if item.Type != ThreadItemUserMessage {
+				return nil, ThreadEditDraft{}, fmt.Errorf("only regular user messages can be edited")
+			}
+			targetSeq = item.Seq
+			targetFound = true
+			break
+		}
+		break
+	}
+	if !targetFound {
+		return nil, ThreadEditDraft{}, fmt.Errorf("editable user message not found")
+	}
 
 	var currentTurnID string
 	turnIndex := 0
@@ -223,10 +245,19 @@ func editHistoryBeforeUserMessage(history []providers.ChatMessage, sourceThreadI
 			continue
 		}
 		if msg.Steered {
-			if currentTurnID != "" && itemMatches(nextItemID()) {
+			if (targetSeq > 0 && msg.Seq == targetSeq) || (targetSeq == 0 && currentTurnID != "" && itemMatches(nextItemID())) {
 				return nil, ThreadEditDraft{}, fmt.Errorf("only regular user messages can be edited")
 			}
 			continue
+		}
+		if targetSeq > 0 {
+			if msg.Seq != targetSeq {
+				continue
+			}
+			if compactedAttachmentOmission(msg) {
+				return nil, ThreadEditDraft{}, fmt.Errorf("this message contains compacted attachment placeholders and cannot be restored for editing")
+			}
+			return cloneHistory(history[:i]), editDraftFromChatMessage(msg), nil
 		}
 
 		currentTurnIndex = turnIndex

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -6428,6 +6428,95 @@ func TestServerThreadEditMessageRespectsCompactionBoundary(t *testing.T) {
 	}
 }
 
+func TestServerThreadEditMessageAfterProviderCheckpointWithEarlierVisibleTurns(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	sess, err := session.CreateWithMetadata(rt.SessionDir, "20260619-000002-edit-checkpoint", rt.RootDir)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "older prompt"},
+		{Role: "assistant", Content: "older answer"},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess.ID, rec); err != nil {
+			t.Fatalf("append history: %v", err)
+		}
+	}
+	if _, err := session.StoreHistoryCheckpointAtBaseline(
+		rt.SessionDir,
+		sess.ID,
+		session.HistoryCheckpointKindProviderRewrite,
+		[]session.HistoryRecord{
+			{Role: "system", Content: compact.BuildSummaryContent("older prompts are summarized")},
+		},
+		2,
+	); err != nil {
+		t.Fatalf("store provider checkpoint: %v", err)
+	}
+	for _, rec := range []session.HistoryRecord{
+		{Role: "user", Content: "after compact"},
+		{Role: "assistant", Content: "after compact answer"},
+		{Role: "user", Content: "replace me"},
+		{
+			Role:       "meta",
+			Content:    turnTerminalHistoryRecord,
+			ClientID:   fmt.Sprintf("%s-turn-0003", sess.ID),
+			StopReason: string(TurnStatusInterrupted),
+		},
+	} {
+		if err := session.AppendHistoryRecord(rt.SessionDir, sess.ID, rec); err != nil {
+			t.Fatalf("append retained history: %v", err)
+		}
+	}
+
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	resumeReq := fmt.Sprintf(`{"id":"resume","method":"%s","params":{"session_id":%q}}`, MethodThreadResume, sess.ID)
+	if err := srv.handleLine(context.Background(), []byte(resumeReq)); err != nil {
+		t.Fatalf("thread/resume: %v", err)
+	}
+	resumed := remarshal[ThreadResumeResult](t, responseByID(t, parseOutput(t, out.String()), "resume")["result"])
+	if len(resumed.Thread.Turns) != 3 {
+		t.Fatalf("expected earlier visible turn plus two retained turns, got %+v", resumed.Thread.Turns)
+	}
+	targetTurn := resumed.Thread.Turns[2]
+	target := targetTurn.Items[0]
+	if targetTurn.Status != TurnStatusInterrupted || target.Seq != 6 || target.Text != "replace me" {
+		t.Fatalf("unexpected edit target: %+v", target)
+	}
+	editPayload, err := json.Marshal(map[string]any{
+		"id":     "edit",
+		"method": MethodThreadEditMessage,
+		"params": ThreadEditMessageParams{
+			ThreadID: resumed.Thread.ID,
+			TurnID:   targetTurn.ID,
+			ItemID:   target.ID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal edit request: %v", err)
+	}
+	if err := srv.handleLine(context.Background(), editPayload); err != nil {
+		t.Fatalf("thread/edit-message: %v", err)
+	}
+
+	editResponse := responseByID(t, parseOutput(t, out.String()), "edit")
+	if editResponse["error"] != nil {
+		t.Fatalf("thread/edit-message returned error: %+v", editResponse["error"])
+	}
+	result := remarshal[ThreadEditMessageResult](t, editResponse["result"])
+	if result.Draft.Prompt != "replace me" {
+		t.Fatalf("unexpected restored draft: %+v", result.Draft)
+	}
+	persisted, err := loadChatMessages(rt.SessionDir, sess.ID)
+	if err != nil {
+		t.Fatalf("load persisted history: %v", err)
+	}
+	if len(persisted) != 3 || persisted[1].Content != "after compact" || persisted[2].Content != "after compact answer" {
+		t.Fatalf("expected edit to preserve retained history before target, got %+v", persisted)
+	}
+}
+
 func TestServerTurnStartAcceptsImageOnlyPrompt(t *testing.T) {
 	// tinyImageOnlyB64 is a real 1×1 JPEG base64-encoded. imageproc now
 	// runs on every image that crosses the app-server boundary (see


### PR DESCRIPTION
## Summary

Fix historical message editing after provider history compaction. Visible turns can include pre-checkpoint history while provider history begins at the checkpoint, so edits now locate persisted user messages by stable sequence number instead of positional turn alignment.

## Changes

- Resolve persisted edit targets by `session_messages.seq`, retaining the positional fallback for synthetic or legacy messages without a sequence number
- Preserve validation for non-user, steered, and compacted-attachment messages
- Add a regression test covering a checkpoint followed by an interrupted turn and immediate history edit

## Test plan

- [x] Added or updated unit tests for the change
- [ ] `go test ./...` passes
- [ ] `cd desktop && npm test` passes
- [ ] Manually verified the behavior in the desktop shell (if applicable)
- [x] `go test ./internal/appserver ./internal/session -count=1`
- [x] Independent code review: no issues found

## Risk and rollback

- Risk level: low
- Roll back by reverting this PR

## Linked issues / docs

No linked issue.
