### PR TITLE
feat(context): compact dynamic request context

### DIFF
--- a/cmd/wuu/main_test.go
+++ b/cmd/wuu/main_test.go
@@ -1207,7 +1207,7 @@ func TestEvalContextBlockObservationsSummarizeRuntimeBlocks(t *testing.T) {
 		t.Fatalf("stable environment should not be reported as runtime context block: %+v", got)
 	}
 	active := byKind["ACTIVE_FILES"]
-	if active.Source != "read_file" || active.TokenBudget == 0 || !strings.Contains(active.ContentPreview, "main.go") {
+	if active.Source != "read_file" || active.TokenBudget == 0 || !strings.Contains(active.ContentPreview, "files: current=1") {
 		t.Fatalf("active files block missing read metadata: %+v", active)
 	}
 }

--- a/internal/agent/request_assembler.go
+++ b/internal/agent/request_assembler.go
@@ -173,7 +173,11 @@ func projectRequestOnlyBlocks(blocks []wuucontext.Block) []requestOnlyBlockProje
 	counts := make(map[string]int, len(blocks))
 	projections := make([]requestOnlyBlockProjection, 0, len(blocks))
 	for _, block := range blocks {
-		rendered := wuucontext.CompileBlocks([]wuucontext.Block{block})
+		compile := wuucontext.CompileBlocks
+		if wuucontext.DynamicContextProjectionEnabled() {
+			compile = wuucontext.CompileRequestBlocks
+		}
+		rendered := compile([]wuucontext.Block{block})
 		if strings.TrimSpace(rendered) == "" {
 			continue
 		}
@@ -197,14 +201,22 @@ func projectRequestOnlyBlocks(blocks []wuucontext.Block) []requestOnlyBlockProje
 }
 
 func activeRequestContextContent(name, rendered string) string {
+	rule := "Only the latest context update with this key applies; it replaces earlier active or inactive updates."
+	if wuucontext.DynamicContextProjectionEnabled() {
+		rule = "Latest update for this key wins."
+	}
 	return "<system-reminder>\n" + requestContextUpdateMarker +
 		"\nkey: " + name +
 		"\nstatus: active" +
-		"\nrule: Only the latest context update with this key applies; it replaces earlier active or inactive updates.\n\n" +
+		"\nrule: " + rule + "\n\n" +
 		rendered + "\n</system-reminder>"
 }
 
 func inactiveRequestContextMessage(name string) providers.ChatMessage {
+	rule := "This context is no longer active. Ignore earlier active updates with this key."
+	if wuucontext.DynamicContextProjectionEnabled() {
+		rule = "Inactive; ignore earlier active updates for this key."
+	}
 	return providers.ChatMessage{
 		Role:   "user",
 		Name:   name,
@@ -212,7 +224,7 @@ func inactiveRequestContextMessage(name string) providers.ChatMessage {
 		Content: "<system-reminder>\n" + requestContextUpdateMarker +
 			"\nkey: " + name +
 			"\nstatus: inactive" +
-			"\nrule: This context is no longer active. Ignore earlier active updates with this key.\n" +
+			"\nrule: " + rule + "\n" +
 			"</system-reminder>",
 	}
 }

--- a/internal/agent/request_assembler.go
+++ b/internal/agent/request_assembler.go
@@ -173,11 +173,7 @@ func projectRequestOnlyBlocks(blocks []wuucontext.Block) []requestOnlyBlockProje
 	counts := make(map[string]int, len(blocks))
 	projections := make([]requestOnlyBlockProjection, 0, len(blocks))
 	for _, block := range blocks {
-		compile := wuucontext.CompileBlocks
-		if wuucontext.DynamicContextProjectionEnabled() {
-			compile = wuucontext.CompileRequestBlocks
-		}
-		rendered := compile([]wuucontext.Block{block})
+		rendered := compileRequestOnlyBlocks([]wuucontext.Block{block})
 		if strings.TrimSpace(rendered) == "" {
 			continue
 		}
@@ -198,6 +194,13 @@ func projectRequestOnlyBlocks(blocks []wuucontext.Block) []requestOnlyBlockProje
 		})
 	}
 	return projections
+}
+
+func compileRequestOnlyBlocks(blocks []wuucontext.Block) string {
+	if wuucontext.DynamicContextProjectionEnabled() {
+		return wuucontext.CompileRequestBlocks(blocks)
+	}
+	return wuucontext.CompileBlocks(blocks)
 }
 
 func activeRequestContextContent(name, rendered string) string {

--- a/internal/agent/request_assembler_test.go
+++ b/internal/agent/request_assembler_test.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
+	wuucontext "github.com/blueberrycongee/wuu/internal/context"
 	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
@@ -24,5 +26,28 @@ func TestAssembleModelRequestRequiresExplicitRequestOnlyPolicy(t *testing.T) {
 	}
 	if !assembly.Messages[1].Hidden || assembly.Messages[1].Content != "explicit context" {
 		t.Fatalf("explicit request-only projection not normalized: %+v", assembly.Messages[1])
+	}
+}
+
+func TestRequestOnlyContextProjectionSwitch(t *testing.T) {
+	block := wuucontext.Block{
+		Kind: wuucontext.BlockTaskState, Title: "Task", Source: "runtime", Content: "state: active", TokenBudget: 200,
+	}
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "")
+	compact := requestOnlyMessagesFromBlocks([]wuucontext.Block{block})
+	if len(compact) != 1 || !strings.Contains(compact[0].Content, "rule: Latest update for this key wins.") {
+		t.Fatalf("expected compact default projection: %+v", compact)
+	}
+	for _, omitted := range []string{"title: Task", "source: runtime", "token_budget: 200"} {
+		if strings.Contains(compact[0].Content, omitted) {
+			t.Fatalf("compact projection should omit %q:\n%s", omitted, compact[0].Content)
+		}
+	}
+
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
+	legacy := requestOnlyMessagesFromBlocks([]wuucontext.Block{block})
+	if len(legacy) != 1 || !strings.Contains(legacy[0].Content, "title: Task") ||
+		!strings.Contains(legacy[0].Content, "Only the latest context update with this key applies") {
+		t.Fatalf("off should restore legacy projection: %+v", legacy)
 	}
 }

--- a/internal/agent/request_assembler_test.go
+++ b/internal/agent/request_assembler_test.go
@@ -51,3 +51,36 @@ func TestRequestOnlyContextProjectionSwitch(t *testing.T) {
 		t.Fatalf("off should restore legacy projection: %+v", legacy)
 	}
 }
+
+func TestRequestBlockMetricsMatchProjectionSwitch(t *testing.T) {
+	block := wuucontext.Block{
+		Kind: wuucontext.BlockTaskState, Title: "Task", Source: "runtime", Content: "state: active", TokenBudget: 200,
+	}
+	measure := func() int {
+		t.Helper()
+		assembly := assembleModelRequest(nil, RequestOnlyContextBlocks([]wuucontext.Block{block}))
+		_, counts, bytesByKind := requestBlockMetrics(assembly)
+		kind := string(wuucontext.BlockTaskState)
+		if counts[kind] != 1 {
+			t.Fatalf("request block count = %d, want 1: %+v", counts[kind], counts)
+		}
+		return bytesByKind[kind]
+	}
+
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "")
+	compactBytes := measure()
+	wantCompact := len([]byte(strings.TrimSpace(wuucontext.CompileRequestBlocks([]wuucontext.Block{block}))))
+	if compactBytes != wantCompact {
+		t.Fatalf("compact block bytes = %d, want projected bytes %d", compactBytes, wantCompact)
+	}
+
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
+	legacyBytes := measure()
+	wantLegacy := len([]byte(strings.TrimSpace(wuucontext.CompileBlocks([]wuucontext.Block{block}))))
+	if legacyBytes != wantLegacy {
+		t.Fatalf("legacy block bytes = %d, want projected bytes %d", legacyBytes, wantLegacy)
+	}
+	if compactBytes >= legacyBytes {
+		t.Fatalf("compact block bytes should be smaller: compact=%d legacy=%d", compactBytes, legacyBytes)
+	}
+}

--- a/internal/agent/request_shape.go
+++ b/internal/agent/request_shape.go
@@ -132,7 +132,7 @@ func requestBlockMetrics(assembly RequestAssembly) ([]string, map[string]int, ma
 	for _, segment := range assembly.Segments {
 		if len(segment.Blocks) > 0 {
 			for _, block := range segment.Blocks {
-				rendered := strings.TrimSpace(wuucontext.CompileBlocks([]wuucontext.Block{block}))
+				rendered := strings.TrimSpace(compileRequestOnlyBlocks([]wuucontext.Block{block}))
 				if rendered == "" {
 					continue
 				}

--- a/internal/appserver/ultra_turn_test.go
+++ b/internal/appserver/ultra_turn_test.go
@@ -171,7 +171,7 @@ func TestNextUserTurnFoldsFrozenWorkerTree(t *testing.T) {
 	}
 	found := false
 	for _, msg := range requests[0].Messages {
-		if msg.Role == "user" && strings.Contains(msg.Content, "Frozen worker tree") {
+		if msg.Role == "user" && strings.Contains(msg.Content, "whole anonymous-worker tree was frozen") {
 			if !msg.Hidden || !wuucontext.IsSystemReminder(msg.Name, msg.Content) {
 				t.Fatalf("freeze snapshot should be request-only hidden context: %+v", msg)
 			}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -26,6 +27,10 @@ import (
 const SystemReminderMessageName = "wuu_system_reminder"
 
 const systemReminderBlockMessageNamePrefix = "wuu_ctx_"
+
+// DynamicContextProjectionEnvVar controls compact request-only context
+// projection. It defaults to active; set it to "off" for the legacy baseline.
+const DynamicContextProjectionEnvVar = "WUU_DYNAMIC_CONTEXT_PROJECTION"
 
 // TaskContractMessageName marks legacy hidden task-contract context derived
 // from recent user directives. New requests no longer synthesize this
@@ -96,9 +101,19 @@ func Snapshot(cwd string) EnvInfo {
 }
 
 func CompileBlocks(blocks []Block) string {
+	return compileBlocks(blocks, false)
+}
+
+// CompileRequestBlocks renders request-only blocks without model-visible
+// metadata that is already carried by the block and request telemetry.
+func CompileRequestBlocks(blocks []Block) string {
+	return compileBlocks(blocks, true)
+}
+
+func compileBlocks(blocks []Block, compact bool) string {
 	var b strings.Builder
 	for _, block := range blocks {
-		rendered := renderBlock(block)
+		rendered := renderBlock(block, compact)
 		if rendered == "" {
 			continue
 		}
@@ -108,6 +123,13 @@ func CompileBlocks(blocks []Block) string {
 		b.WriteString(rendered)
 	}
 	return b.String()
+}
+
+// DynamicContextProjectionEnabled returns whether request-only context uses
+// compact projection. Empty and unknown values intentionally resolve active so
+// the feature remains on by default; "off" is the A/B baseline.
+func DynamicContextProjectionEnabled() bool {
+	return !strings.EqualFold(strings.TrimSpace(os.Getenv(DynamicContextProjectionEnvVar)), "off")
 }
 
 func FormatSystemReminderBlocks(blocks ...Block) string {
@@ -170,7 +192,7 @@ func sanitizeMessageNameSlug(value string) string {
 	return strings.Trim(b.String(), "_")
 }
 
-func renderBlock(block Block) string {
+func renderBlock(block Block, compact bool) string {
 	content := strings.TrimSpace(block.Content)
 	if content == "" {
 		return ""
@@ -182,6 +204,10 @@ func renderBlock(block Block) string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "[%s]\n", kind)
+	if compact {
+		b.WriteString(content)
+		return strings.TrimRight(b.String(), "\n")
+	}
 	if title := strings.TrimSpace(block.Title); title != "" {
 		fmt.Fprintf(&b, "title: %s\n", title)
 	}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -44,6 +44,31 @@ func TestCompileBlocksRendersTypedContext(t *testing.T) {
 	}
 }
 
+func TestCompileRequestBlocksOmitsRuntimeMetadata(t *testing.T) {
+	got := CompileRequestBlocks([]Block{{
+		Kind: BlockTaskState, Title: "Task", Source: "runtime", Content: "state: active", TokenBudget: 200,
+	}})
+	if !strings.Contains(got, "[TASK_STATE]\nstate: active") {
+		t.Fatalf("compact request block missing kind or content:\n%s", got)
+	}
+	for _, omitted := range []string{"title:", "source:", "token_budget:"} {
+		if strings.Contains(got, omitted) {
+			t.Fatalf("compact request block should omit %q:\n%s", omitted, got)
+		}
+	}
+}
+
+func TestDynamicContextProjectionDefaultsActiveAndSupportsOff(t *testing.T) {
+	t.Setenv(DynamicContextProjectionEnvVar, "")
+	if !DynamicContextProjectionEnabled() {
+		t.Fatal("dynamic context projection should default active")
+	}
+	t.Setenv(DynamicContextProjectionEnvVar, "off")
+	if DynamicContextProjectionEnabled() {
+		t.Fatal("off should disable dynamic context projection")
+	}
+}
+
 func TestCompileBlocksEnforcesTokenBudget(t *testing.T) {
 	longContent := strings.Repeat("src/internal/really/long/path/to/file.go\n", 200)
 	got := CompileBlocks([]Block{

--- a/internal/runtime/session_test.go
+++ b/internal/runtime/session_test.go
@@ -555,7 +555,7 @@ func TestRuntimeContextInjectorIncludesOnlyDynamicTypedBlocks(t *testing.T) {
 		combined.WriteString("\n")
 	}
 	content := combined.String()
-	for _, want := range []string{"<system-reminder>", "[TASK_STATE]", "source: update_plan", "[in_progress] edit"} {
+	for _, want := range []string{"<system-reminder>", "[TASK_STATE]", "rule: Latest update for this key wins.", "[in_progress] edit"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("injected context missing %q:\n%s", want, content)
 		}

--- a/internal/tools/tool_context.go
+++ b/internal/tools/tool_context.go
@@ -220,6 +220,15 @@ func (t *Toolkit) ActiveFilesContextBlock() (wuucontext.Block, bool) {
 	sort.Slice(paths, func(i, j int) bool {
 		return t.env.NormalizeDisplayPath(paths[i]) < t.env.NormalizeDisplayPath(paths[j])
 	})
+	if wuucontext.DynamicContextProjectionEnabled() {
+		return wuucontext.Block{
+			Kind:        wuucontext.BlockActiveFiles,
+			Title:       "Files read in this session",
+			Source:      "read_file",
+			TokenBudget: 700,
+			Content:     t.compactActiveFilesContext(paths, entries),
+		}, true
+	}
 	const maxFiles = 12
 	listed := paths
 	if len(listed) > maxFiles {
@@ -230,12 +239,7 @@ func (t *Toolkit) ActiveFilesContextBlock() (wuucontext.Block, bool) {
 	b.WriteString("read_files:\n")
 	for _, absPath := range listed {
 		entry := entries[absPath]
-		status := "current"
-		if info, err := os.Stat(absPath); err != nil || info.IsDir() || !readEntryMatchesInfo(entry, info) {
-			status = "possibly_stale"
-		} else if entry.BaselineOnly {
-			status = "current_baseline"
-		}
+		status := activeFileContextStatus(absPath, entry)
 		fmt.Fprintf(&b, "- path=%s status=%s file_sha=%s size_bytes=%d read_range=%s\n",
 			compactContextLine(redactToolOutput(t.env.NormalizeDisplayPath(absPath))),
 			status,
@@ -256,6 +260,44 @@ func (t *Toolkit) ActiveFilesContextBlock() (wuucontext.Block, bool) {
 		TokenBudget: 700,
 		Content:     strings.TrimRight(b.String(), "\n"),
 	}, true
+}
+
+func (t *Toolkit) compactActiveFilesContext(paths []string, entries map[string]ReadFileEntry) string {
+	var current, baseline, stale int
+	var flagged strings.Builder
+	for _, absPath := range paths {
+		entry := entries[absPath]
+		status := activeFileContextStatus(absPath, entry)
+		switch status {
+		case "current":
+			current++
+			continue
+		case "current_baseline":
+			baseline++
+		case "possibly_stale":
+			stale++
+		}
+		fmt.Fprintf(&flagged, "- path=%s status=%s read_range=%s\n",
+			compactContextLine(redactToolOutput(t.env.NormalizeDisplayPath(absPath))), status, activeFileReadRange(entry))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "files: current=%d baseline=%d stale=%d\n", current, baseline, stale)
+	b.WriteString(flagged.String())
+	if baseline+stale > 0 {
+		b.WriteString("action: read flagged files again before editing.\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func activeFileContextStatus(absPath string, entry ReadFileEntry) string {
+	if info, err := os.Stat(absPath); err != nil || info.IsDir() || !readEntryMatchesInfo(entry, info) {
+		return "possibly_stale"
+	}
+	if entry.BaselineOnly {
+		return "current_baseline"
+	}
+	return "current"
 }
 
 func (t *Toolkit) TestFailureContextBlock() (wuucontext.Block, bool) {
@@ -407,10 +449,19 @@ func (t *Toolkit) ToolResultSummaryContextBlock() (wuucontext.Block, bool) {
 	if len(records) > maxRenderedRecords {
 		start = len(records) - maxRenderedRecords
 	}
+	currentRevision := workspaceRevision(context.Background(), t.env.RootDir)
+	if wuucontext.DynamicContextProjectionEnabled() {
+		return wuucontext.Block{
+			Kind:        wuucontext.BlockToolResultSummary,
+			Title:       "Recent tool result summary",
+			Source:      "tool_telemetry",
+			TokenBudget: 400,
+			Content:     t.compactToolResultSummary(records, start, currentRevision),
+		}, true
+	}
 
 	var b strings.Builder
 	b.WriteString("recent_tool_calls:\n")
-	currentRevision := workspaceRevision(context.Background(), t.env.RootDir)
 	for i, record := range records[start:] {
 		status := "ok"
 		if !record.Success {
@@ -473,6 +524,73 @@ func (t *Toolkit) ToolResultSummaryContextBlock() (wuucontext.Block, bool) {
 		TokenBudget: 400,
 		Content:     strings.TrimRight(b.String(), "\n"),
 	}, true
+}
+
+func (t *Toolkit) compactToolResultSummary(records []ToolExecutionRecord, start int, currentRevision string) string {
+	recent := records[start:]
+	var b strings.Builder
+	b.WriteString("tools: ")
+	for i, record := range recent {
+		if i > 0 {
+			b.WriteString(" > ")
+		}
+		name := compactContextLine(redactToolOutput(strings.TrimSpace(record.Name)))
+		status := "ok"
+		if !record.Success {
+			status = "error"
+		}
+		fmt.Fprintf(&b, "%s:%s", name, status)
+	}
+	if start > 0 {
+		fmt.Fprintf(&b, " older=%d", start)
+	}
+	b.WriteString("\n")
+
+	for _, record := range recent {
+		stale := toolEvidenceStatus(record, currentRevision) == "possibly_stale"
+		nonAllow := record.PolicyAction != "" && record.PolicyAction != ToolPolicyAllow
+		patchRisk := record.PatchRiskSummary != nil && record.PatchRiskSummary.RiskLevel != "low"
+		if record.Success && !record.ResultBudgeted && record.ResultRef == "" && !stale && !nonAllow && !patchRisk {
+			continue
+		}
+		fmt.Fprintf(&b, "- tool=%s", compactContextLine(redactToolOutput(strings.TrimSpace(record.Name))))
+		if !record.Success {
+			b.WriteString(" status=error")
+			if record.ErrorKind != "" {
+				fmt.Fprintf(&b, " error_kind=%s", compactContextLine(redactToolOutput(record.ErrorKind)))
+			}
+			if strings.TrimSpace(record.Error) != "" {
+				fmt.Fprintf(&b, " error=%s", compactContextLine(redactToolOutput(record.Error)))
+			}
+		}
+		if nonAllow {
+			fmt.Fprintf(&b, " policy=%s", record.PolicyAction)
+		}
+		if stale {
+			b.WriteString(" evidence=stale")
+		}
+		if record.ResultBudgeted {
+			b.WriteString(" result=projected")
+		}
+		if record.ResultRef != "" {
+			fmt.Fprintf(&b, " ref=%s", compactContextLine(redactToolOutput(contextArtifactRef(t.env, record.ResultRef))))
+		} else if record.ResultBudgeted && len(record.ArtifactRefs) > 0 {
+			fmt.Fprintf(&b, " ref=%s", redactedContextArtifactRefs(t.env, record.ArtifactRefs, 1)[0])
+		}
+		if patchRisk {
+			fmt.Fprintf(&b, " patch_risk=%s", compactToolPatchRisk(*record.PatchRiskSummary))
+		}
+		b.WriteString("\n")
+	}
+
+	loopStart := 0
+	if len(records) > 8 {
+		loopStart = len(records) - 8
+	}
+	for _, item := range repeatedToolArguments(records[loopStart:]) {
+		fmt.Fprintf(&b, "loop_warning: tool=%s repeated=%d; inspect prior evidence before retrying.\n", item.ToolName, item.Count)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 func toolEvidenceStatus(record ToolExecutionRecord, currentRevision string) string {

--- a/internal/tools/toolkit_test.go
+++ b/internal/tools/toolkit_test.go
@@ -3463,7 +3463,7 @@ func TestToolkit_RepeatedToolInputGuardBlocksThirdIdenticalCall(t *testing.T) {
 	}
 	block, ok := kit.ToolResultSummaryContextBlock()
 	if !ok ||
-		!strings.Contains(block.Content, "repeated_arguments:") ||
+		!strings.Contains(block.Content, "loop_warning:") ||
 		!strings.Contains(block.Content, "error_kind=repeated_tool_input") {
 		t.Fatalf("tool summary missing repeated input guard evidence:\n%s", block.Content)
 	}
@@ -3687,6 +3687,7 @@ func TestToolkit_ToolTelemetry_RecordsToolError(t *testing.T) {
 }
 
 func TestToolkit_ToolResultSummaryContextBlockOmitsToolBodies(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "a.txt"), "API_KEY=secret-value-1234567890\n")
 	kit, err := New(root)
@@ -3811,7 +3812,54 @@ func TestToolkit_ToolResultSummaryContextBlockOmitsToolBodies(t *testing.T) {
 	}
 }
 
+func TestToolkit_ToolResultSummaryContextBlockDefaultsCompact(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "")
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	sessionDir := filepath.Join(root, ".wuu-state", "sessions", "session-1")
+	kit.SetSessionDir(sessionDir)
+	repeatedArgs := strings.Repeat("a", 64)
+	for _, record := range []ToolExecutionRecord{
+		{Name: "read_file", Success: true, PolicyAction: ToolPolicyAllow, ResultAction: "read"},
+		{Name: "bash", Success: false, PolicyAction: ToolPolicyAllow, ErrorKind: "exit_status", Error: "API_KEY=secret-value"},
+		{Name: "run_test", Success: true, PolicyAction: ToolPolicyAllow, ArgumentsSHA256: repeatedArgs, ResultBudgeted: true, ResultRef: filepath.Join(sessionDir, "tool-results", "large.txt")},
+		{Name: "run_test", Success: true, PolicyAction: ToolPolicyAllow, ArgumentsSHA256: repeatedArgs},
+	} {
+		kit.env.toolTelemetry.record(record)
+	}
+
+	compact, ok := kit.ToolResultSummaryContextBlock()
+	if !ok {
+		t.Fatal("expected compact tool result summary")
+	}
+	for _, want := range []string{
+		"tools: read_file:ok > bash:error > run_test:ok > run_test:ok",
+		"error_kind=exit_status",
+		"result=projected ref=$SESSION_DIR/tool-results/large.txt",
+		"loop_warning: tool=run_test repeated=2",
+	} {
+		if !strings.Contains(compact.Content, want) {
+			t.Fatalf("compact tool summary missing %q:\n%s", want, compact.Content)
+		}
+	}
+	for _, omitted := range []string{"recent_tool_calls:", "result_action=", "evidence_status=current", "secret-value"} {
+		if strings.Contains(compact.Content, omitted) {
+			t.Fatalf("compact tool summary should omit %q:\n%s", omitted, compact.Content)
+		}
+	}
+
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
+	legacy, ok := kit.ToolResultSummaryContextBlock()
+	if !ok || len(compact.Content) >= len(legacy.Content) {
+		t.Fatalf("compact summary should be smaller than legacy: compact=%d legacy=%d", len(compact.Content), len(legacy.Content))
+	}
+}
+
 func TestToolkit_ToolResultSummaryContextBlockShortensArtifactRefs(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	root := t.TempDir()
 	kit, err := New(root)
 	if err != nil {
@@ -3860,6 +3908,7 @@ func TestToolkit_ToolResultSummaryContextBlockShortensArtifactRefs(t *testing.T)
 }
 
 func TestToolkit_ToolResultSummaryContextBlockLimitsRenderedCalls(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	kit, err := New(t.TempDir())
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -3894,6 +3943,7 @@ func TestToolkit_ToolResultSummaryContextBlockLimitsRenderedCalls(t *testing.T) 
 }
 
 func TestToolkit_ActiveFilesContextBlockTracksReadFiles(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "dir", "a.txt"), "line one\nAPI_KEY=secret-value-1234567890\nline three\nline four\n")
 	kit, err := New(root)
@@ -3957,6 +4007,55 @@ func TestToolkit_ActiveFilesContextBlockTracksReadFiles(t *testing.T) {
 	}
 	if !strings.Contains(block.Content, "status=possibly_stale") {
 		t.Fatalf("active files context should mark changed file stale:\n%s", block.Content)
+	}
+}
+
+func TestToolkit_ActiveFilesContextBlockDefaultsCompact(t *testing.T) {
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "")
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for i := 1; i <= 5; i++ {
+		path := filepath.Join(root, "dir", fmt.Sprintf("%d.txt", i))
+		mustWriteFile(t, path, "one\ntwo\nthree\n")
+		if _, err := kit.Execute(context.Background(), providers.ToolCall{
+			Name: "read_file", Arguments: fmt.Sprintf(`{"path":"dir/%d.txt","offset":1,"limit":2}`, i),
+		}); err != nil {
+			t.Fatalf("read_file %d: %v", i, err)
+		}
+	}
+
+	current, ok := kit.ActiveFilesContextBlock()
+	if !ok || current.Content != "files: current=5 baseline=0 stale=0" {
+		t.Fatalf("unexpected compact current files block: %+v", current)
+	}
+	for i := 1; i <= 5; i++ {
+		mustWriteFile(t, filepath.Join(root, "dir", fmt.Sprintf("%d.txt", i)), "changed\n")
+	}
+	stale, ok := kit.ActiveFilesContextBlock()
+	if !ok {
+		t.Fatal("expected compact stale files block")
+	}
+	for _, want := range []string{
+		"files: current=0 baseline=0 stale=5",
+		"path=dir/1.txt status=possibly_stale",
+		"path=dir/5.txt status=possibly_stale",
+		"action: read flagged files again before editing",
+	} {
+		if !strings.Contains(stale.Content, want) {
+			t.Fatalf("compact active files missing %q:\n%s", want, stale.Content)
+		}
+	}
+	if strings.Contains(stale.Content, "file_sha=") {
+		t.Fatalf("compact active files should omit hashes:\n%s", stale.Content)
+	}
+
+	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
+	legacy, ok := kit.ActiveFilesContextBlock()
+	if !ok || !strings.Contains(legacy.Content, "file_sha=") || len(stale.Content) >= len(legacy.Content) {
+		t.Fatalf("off should restore larger legacy active files block: compact=%d legacy=%d", len(stale.Content), len(legacy.Content))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a simple, default-on compact projection for dynamic request context so later A/B testing can compare prompt size and behavior against the exact legacy baseline. Addresses the context growth observed in #119.

## Changes

- Compact normal `ACTIVE_FILES` state to counts while retaining every stale/baseline path and reread action
- Compact `TOOL_RESULT_SUMMARY` to an action trail, expanding failures, policy exceptions, projected refs, stale evidence, and loop warnings
- Remove repeated block title/source/budget wrapper metadata in active mode
- Add `WUU_DYNAMIC_CONTEXT_PROJECTION=off` to restore the legacy blocks and wrapper; unset or `active` uses the compact projection
- Leave task state, test failures, web evidence, primary tool-result projection, and preserved Kimi thinking unchanged

## Test plan

- [x] Added or updated unit tests for the change
- [x] `go test ./...` passes
- [ ] `cd desktop && npm test` passes — not applicable; no desktop code changed
- [ ] Manually verified the behavior in the desktop shell — not applicable; request assembly is covered by Go tests

## Risk and rollback

- Risk level: medium; this changes model-visible request-only context by default
- Set `WUU_DYNAMIC_CONTEXT_PROJECTION=off` for the legacy baseline, or revert this PR

## Linked issues / docs

Related to #119