### PR TITLE
style(desktop): simplify sidebar wordmark color

### DIFF
--- a/desktop/src/renderer/styles/sidebar.css
+++ b/desktop/src/renderer/styles/sidebar.css
@@ -17,6 +17,7 @@
   --sidebar-glass-overlay-accent: rgba(209, 220, 211, 0.12);
   --sidebar-glass-overlay-highlight-strong: rgba(255, 255, 255, 0.44);
   --sidebar-drawer-bg: #ffffff;
+  --sidebar-brand-wordmark-color: #b64a32;
   --sidebar-resizer-hover-bg: var(--ink-overlay-18);
   --sidebar-resizer-hover-ring: rgba(255, 255, 255, 0.4);
   /* Dev fixtures: text + nav-border come from the shared ink ladder so they
@@ -606,15 +607,7 @@
   font-weight: 600;
   letter-spacing: 0.6px;
   line-height: 1;
-  background: linear-gradient(
-    95deg,
-    var(--wuu-accent) 0%,
-    color-mix(in srgb, var(--ink-strong) 78%, var(--wuu-accent)) 60%,
-    var(--ink-strong) 100%
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+  color: var(--sidebar-brand-wordmark-color);
 }
 
 .sidebar-main {

--- a/desktop/src/renderer/styles/theme.css
+++ b/desktop/src/renderer/styles/theme.css
@@ -284,6 +284,7 @@
   --sidebar-glass-overlay-accent: rgba(209, 220, 211, 0.03);
   --sidebar-glass-overlay-highlight-strong: rgba(255, 255, 255, 0.05);
   --sidebar-drawer-bg: #1a1d20;
+  --sidebar-brand-wordmark-color: #e06b4f;
   --sidebar-resizer-hover-bg: var(--ink-overlay-18);
   --sidebar-resizer-hover-ring: rgba(0, 0, 0, 0.4);
   --sidebar-dev-fixture-nav-border: var(--ink-overlay-12);


### PR DESCRIPTION
## Summary
- replace the sidebar wuu wordmark gradient with a solid terracotta color
- use theme-specific solid colors for balanced contrast in light and dark mode

## Validation
- `git diff --check`
- verified the wordmark rule no longer uses gradients or background clipping
- verified contrast ratios of 4.88:1 or higher

## Test note
- targeted Vitest could not start from the isolated worktree because its temporary config could not resolve the desktop-local `vitest` package