### PR TITLE
fix(agent): prevent repeated proactive compaction

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -173,6 +173,7 @@ func RunToolLoop(
 		// Without caller-owned cross-turn state, seed this run from a
 		// local estimate so resumed long sessions can compact before
 		// the first provider request.
+		usage.SetAdjustment(UsageAdjustmentInitialHistoryEstimate)
 		usage.RecordPendingMessages(messages)
 	}
 	// Cross-run continuity: splice the previous run's retained request-only
@@ -205,6 +206,7 @@ func RunToolLoop(
 		pendingRetainedContext = nil
 		historyRewritten = true
 		usage.Reset()
+		usage.SetAdjustment(UsageAdjustmentCompactionRewriteEstimate)
 		usage.RecordPendingMessages(messages)
 	}
 	// runCompactPass executes one compact attempt. Non-forced passes are
@@ -218,7 +220,8 @@ func RunToolLoop(
 		if !force && (proactiveSuppressed || threshold <= 0 || usage.EstimateCurrent() < threshold || !canProactivelyCompact(messages, cfg)) {
 			return
 		}
-		before := usage.EstimateCurrent()
+		usageBefore := usage.Breakdown()
+		before := usageBefore.Total()
 		msgsBefore := len(messages)
 		if cfg.OnCompactStart != nil {
 			cfg.OnCompactStart(reason)
@@ -230,25 +233,25 @@ func RunToolLoop(
 			if !force {
 				proactiveSuppressed = true
 			}
-			emitCompactAttempt(cfg, CompactAttemptInfo{
+			emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 				Reason:         reason,
 				Status:         CompactAttemptFailed,
 				TokensBefore:   before,
 				MessagesBefore: msgsBefore,
 				Error:          cerr.Error(),
-			})
+			}, usageBefore))
 		case compactChanged(messages, compacted):
 			if compactOperationID := lineage.LastOperationID(); compactOperationID != "" && compactOperationID != lastAgentOperationID {
 				nextOperationParentID = compactOperationID
 			}
 			resetTranscript(compacted)
-			emitCompactAttempt(cfg, CompactAttemptInfo{
+			emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 				Reason:         reason,
 				Status:         CompactAttemptSucceeded,
 				TokensBefore:   before,
 				MessagesBefore: msgsBefore,
 				MessagesAfter:  len(messages),
-			})
+			}, usageBefore))
 			if cfg.OnCompact != nil {
 				cfg.OnCompact(CompactInfo{
 					Reason:         reason,
@@ -261,13 +264,13 @@ func RunToolLoop(
 			if !force {
 				proactiveSuppressed = true
 			}
-			emitCompactAttempt(cfg, CompactAttemptInfo{
+			emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 				Reason:         reason,
 				Status:         CompactAttemptUnchanged,
 				TokensBefore:   before,
 				MessagesBefore: msgsBefore,
 				MessagesAfter:  len(compacted),
-			})
+			}, usageBefore))
 		}
 	}
 	tryProactiveCompact := func() { runCompactPass(CompactReasonProactive, false) }
@@ -432,7 +435,8 @@ func RunToolLoop(
 			// where our proactive estimate undercounted.
 			if cfg.Compact != nil && providers.IsContextOverflow(err) && !overflowCompacted {
 				overflowCompacted = true // gate first; never retry twice
-				before := usage.EstimateCurrent()
+				usageBefore := usage.Breakdown()
+				before := usageBefore.Total()
 				msgsBefore := len(messages)
 				if cfg.OnCompactStart != nil {
 					cfg.OnCompactStart(CompactReasonOverflow)
@@ -448,13 +452,13 @@ func RunToolLoop(
 						// context; re-queue it so the retried request still
 						// carries tool-produced notices.
 						postToolContextSegments = consumedPostToolSegments
-						emitCompactAttempt(cfg, CompactAttemptInfo{
+						emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 							Reason:         CompactReasonOverflow,
 							Status:         CompactAttemptSucceeded,
 							TokensBefore:   before,
 							MessagesBefore: msgsBefore,
 							MessagesAfter:  len(messages),
-						})
+						}, usageBefore))
 						if cfg.OnCompact != nil {
 							cfg.OnCompact(CompactInfo{
 								Reason:         CompactReasonOverflow,
@@ -465,21 +469,21 @@ func RunToolLoop(
 						}
 						continue
 					}
-					emitCompactAttempt(cfg, CompactAttemptInfo{
+					emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 						Reason:         CompactReasonOverflow,
 						Status:         CompactAttemptUnchanged,
 						TokensBefore:   before,
 						MessagesBefore: msgsBefore,
 						MessagesAfter:  len(compacted),
-					})
+					}, usageBefore))
 				} else {
-					emitCompactAttempt(cfg, CompactAttemptInfo{
+					emitCompactAttempt(cfg, compactAttemptWithUsage(CompactAttemptInfo{
 						Reason:         CompactReasonOverflow,
 						Status:         CompactAttemptFailed,
 						TokensBefore:   before,
 						MessagesBefore: msgsBefore,
 						Error:          cerr.Error(),
-					})
+					}, usageBefore))
 				}
 			}
 			// A streaming step can fail after content deltas were already shown to
@@ -646,7 +650,8 @@ func RunToolLoop(
 		}
 		usage.RecordPendingMessages(orderedToolMessages)
 		if cfg.PostToolRewrite != nil {
-			before := usage.EstimateCurrent()
+			usageBefore := usage.Breakdown()
+			before := usageBefore.Total()
 			msgsBefore := len(messages)
 			rewritten, changed, rerr := cfg.PostToolRewrite(ctx, providers.CloneChatMessages(messages), providers.CloneChatMessages(orderedToolMessages))
 			if rerr != nil {
@@ -668,7 +673,7 @@ func RunToolLoop(
 					MessagesAfter:  len(rewritten),
 				}
 				resetTranscript(rewritten)
-				emitCompactAttempt(cfg, attempt)
+				emitCompactAttempt(cfg, compactAttemptWithUsage(attempt, usageBefore))
 				if cfg.OnCompact != nil {
 					cfg.OnCompact(CompactInfo{
 						Reason:         CompactReasonHelpMe,
@@ -744,6 +749,13 @@ func emitCompactAttempt(cfg LoopConfig, info CompactAttemptInfo) {
 	if cfg.OnCompactAttempt != nil {
 		cfg.OnCompactAttempt(info)
 	}
+}
+
+func compactAttemptWithUsage(info CompactAttemptInfo, usage UsageBreakdown) CompactAttemptInfo {
+	info.LastResponseTotal = usage.LastResponseTotal
+	info.PendingDelta = usage.PendingDelta
+	info.UsageAdjustment = usage.Adjustment
+	return info
 }
 
 // proactiveCompactThreshold returns the absolute token count at which

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1812,6 +1812,9 @@ func TestRunToolLoop_ProactiveCompactFailureEmitsAttempt(t *testing.T) {
 	if len(attempts) != 1 ||
 		attempts[0].Reason != CompactReasonProactive ||
 		attempts[0].Status != CompactAttemptFailed ||
+		attempts[0].LastResponseTotal != 1300 ||
+		attempts[0].PendingDelta != 0 ||
+		attempts[0].UsageAdjustment != UsageAdjustmentProviderResponse ||
 		!strings.Contains(attempts[0].Error, compactErr.Error()) {
 		t.Fatalf("expected proactive failed attempt, got %+v", attempts)
 	}

--- a/internal/agent/step.go
+++ b/internal/agent/step.go
@@ -120,12 +120,15 @@ type CompactInfo struct {
 // CompactAttemptInfo describes every compact attempt, including failures and
 // no-op results. It is metadata-only and must not include raw prompt text.
 type CompactAttemptInfo struct {
-	Reason         CompactReason
-	Status         CompactAttemptStatus
-	TokensBefore   int
-	MessagesBefore int
-	MessagesAfter  int
-	Error          string
+	Reason            CompactReason
+	Status            CompactAttemptStatus
+	TokensBefore      int
+	LastResponseTotal int
+	PendingDelta      int
+	UsageAdjustment   UsageAdjustment
+	MessagesBefore    int
+	MessagesAfter     int
+	Error             string
 }
 
 // ToolBatchRejectionInfo describes a whole assistant tool-call batch that was

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -532,7 +532,8 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 		// provider usage measured. Preserve that trustworthy baseline and count
 		// only messages appended after the boundary instead of pessimistically
 		// re-estimating the entire durable transcript.
-		if anchor := findHistoryTailAnchor(history, trackedTailHash); tracker.HasGroundTruth() && anchor >= 0 {
+		breakdown := tracker.Breakdown()
+		if anchor := findHistoryTailAnchor(history, trackedTailHash); canRebaseUsageAfterTail(history, anchor, breakdown) {
 			tracker.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			tracker.RecordPendingMessages(history[anchor+1:])
 			return tracker, len(history)
@@ -607,6 +608,18 @@ func findHistoryTailAnchor(history []providers.ChatMessage, anchor string) int {
 	return -1
 }
 
+func canRebaseUsageAfterTail(history []providers.ChatMessage, anchor int, usage UsageBreakdown) bool {
+	if usage.LastResponseTotal <= 0 || usage.PendingDelta != 0 || anchor < 0 || anchor >= len(history) {
+		return false
+	}
+	for _, msg := range history[anchor+1:] {
+		if !strings.EqualFold(strings.TrimSpace(msg.Role), "user") {
+			return false
+		}
+	}
+	return true
+}
+
 // ResetConversationUsage discards the persistent cross-turn usage baseline and
 // re-seeds it from the supplied post-compaction history. It mirrors the
 // explicit usage.Reset()+RecordPendingMessages the loop performs after an
@@ -660,8 +673,9 @@ func (r *StreamRunner) SynchronizeConversationUsage(history []providers.ChatMess
 		r.trackedHistoryTailHash = historyTailAnchor(history)
 		return
 	}
-	if len(history) >= r.trackedHistoryLen && r.conversationUsage.HasGroundTruth() {
-		if anchor := findHistoryTailAnchor(history, r.trackedHistoryTailHash); anchor >= 0 {
+	if len(history) >= r.trackedHistoryLen {
+		usage := r.conversationUsage.Breakdown()
+		if anchor := findHistoryTailAnchor(history, r.trackedHistoryTailHash); anchor == len(history)-1 && usage.LastResponseTotal > 0 && usage.PendingDelta == 0 {
 			r.conversationUsage.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			r.conversationUsage.RecordPendingMessages(history[anchor+1:])
 			r.trackedHistoryLen = len(history)

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -146,10 +146,11 @@ type StreamRunner struct {
 	// round and nested compaction owned by this runner.
 	InferenceJournal providers.InferenceJournal
 
-	usageMu            sync.Mutex
-	conversationUsage  *UsageTracker
-	trackedHistoryLen  int
-	trackedHistoryHash string
+	usageMu                sync.Mutex
+	conversationUsage      *UsageTracker
+	trackedHistoryLen      int
+	trackedHistoryHash     string
+	trackedHistoryTailHash string
 
 	// retainedContextMu guards the cross-turn request-context state used for
 	// prompt-cache prefix continuity. The state is fingerprinted against the
@@ -510,6 +511,7 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 	tracker := r.conversationUsage.Clone()
 	trackedLen := r.trackedHistoryLen
 	trackedHash := r.trackedHistoryHash
+	trackedTailHash := r.trackedHistoryTailHash
 	if trackedLen < 0 {
 		trackedLen = 0
 	}
@@ -521,13 +523,28 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 	// necessarily message-count-smaller.
 	if trackedLen > len(history) {
 		tracker.Reset()
+		tracker.SetAdjustment(UsageAdjustmentLengthReset)
 		trackedLen = 0
 	}
 	if trackedLen > 0 && trackedHash != "" && hashMessagesForRequestShape(history[:trackedLen]) != trackedHash {
+		// Provider checkpoints and durable reloads can expand or normalize the
+		// old prefix while retaining the exact response boundary that the live
+		// provider usage measured. Preserve that trustworthy baseline and count
+		// only messages appended after the boundary instead of pessimistically
+		// re-estimating the entire durable transcript.
+		if anchor := findHistoryTailAnchor(history, trackedTailHash); tracker.HasGroundTruth() && anchor >= 0 {
+			tracker.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
+			tracker.RecordPendingMessages(history[anchor+1:])
+			return tracker, len(history)
+		}
 		tracker.Reset()
+		tracker.SetAdjustment(UsageAdjustmentRequestShapeReset)
 		trackedLen = 0
 	}
 	if trackedLen == 0 {
+		if tracker.Breakdown().Adjustment == "" {
+			tracker.SetAdjustment(UsageAdjustmentInitialHistoryEstimate)
+		}
 		tracker.RecordPendingMessages(history)
 		return tracker, len(history)
 	}
@@ -568,6 +585,26 @@ func (r *StreamRunner) commitUsageTracker(tracker *UsageTracker, history []provi
 	r.conversationUsage = tracker.Clone()
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = hashMessagesForRequestShape(history)
+	r.trackedHistoryTailHash = historyTailAnchor(history)
+}
+
+func historyTailAnchor(history []providers.ChatMessage) string {
+	if len(history) == 0 {
+		return ""
+	}
+	return hashMessagesForRequestShape(history[len(history)-1:])
+}
+
+func findHistoryTailAnchor(history []providers.ChatMessage, anchor string) int {
+	if anchor == "" {
+		return -1
+	}
+	for i := len(history) - 1; i >= 0; i-- {
+		if hashMessagesForRequestShape(history[i:i+1]) == anchor {
+			return i
+		}
+	}
+	return -1
 }
 
 // ResetConversationUsage discards the persistent cross-turn usage baseline and
@@ -595,9 +632,11 @@ func (r *StreamRunner) ResetConversationUsage(history []providers.ChatMessage) {
 		r.conversationUsage = NewUsageTracker()
 	}
 	r.conversationUsage.Reset()
+	r.conversationUsage.SetAdjustment(UsageAdjustmentCompactionRewriteEstimate)
 	r.conversationUsage.RecordPendingMessages(history)
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = hashMessagesForRequestShape(history)
+	r.trackedHistoryTailHash = historyTailAnchor(history)
 }
 
 // SynchronizeConversationUsage reconciles a long-lived runner with the
@@ -618,16 +657,30 @@ func (r *StreamRunner) SynchronizeConversationUsage(history []providers.ChatMess
 	if r.trackedHistoryLen == len(history) &&
 		(r.trackedHistoryHash == "" || r.trackedHistoryHash == historyHash) {
 		r.trackedHistoryHash = historyHash
+		r.trackedHistoryTailHash = historyTailAnchor(history)
 		return
+	}
+	if len(history) >= r.trackedHistoryLen && r.conversationUsage.HasGroundTruth() {
+		if anchor := findHistoryTailAnchor(history, r.trackedHistoryTailHash); anchor >= 0 {
+			r.conversationUsage.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
+			r.conversationUsage.RecordPendingMessages(history[anchor+1:])
+			r.trackedHistoryLen = len(history)
+			r.trackedHistoryHash = historyHash
+			r.trackedHistoryTailHash = historyTailAnchor(history)
+			return
+		}
 	}
 	r.conversationUsage.Reset()
 	if persistedTotal > 0 {
 		r.conversationUsage.SeedGroundTruth(persistedTotal)
+		r.conversationUsage.SetAdjustment(UsageAdjustmentExternalRewriteSeed)
 	} else {
+		r.conversationUsage.SetAdjustment(UsageAdjustmentExternalRewriteEstimate)
 		r.conversationUsage.RecordPendingMessages(history)
 	}
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = historyHash
+	r.trackedHistoryTailHash = historyTailAnchor(history)
 }
 
 // SeedConversationUsageBaseline primes the cross-turn usage baseline from a
@@ -649,8 +702,10 @@ func (r *StreamRunner) SeedConversationUsageBaseline(total, historyLen int) {
 		r.conversationUsage = NewUsageTracker()
 	}
 	if r.conversationUsage.SeedGroundTruth(total) {
+		r.conversationUsage.SetAdjustment(UsageAdjustmentRuntimeRebuildSeed)
 		r.trackedHistoryLen = historyLen
 		r.trackedHistoryHash = ""
+		r.trackedHistoryTailHash = ""
 	}
 }
 

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -533,7 +533,7 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 		// only messages appended after the boundary instead of pessimistically
 		// re-estimating the entire durable transcript.
 		breakdown := tracker.Breakdown()
-		if anchor := findHistoryTailAnchor(history, trackedTailHash); canRebaseUsageAfterTail(history, anchor, breakdown) {
+		if anchor, _ := findHistoryTailAnchor(history, trackedTailHash); canRebaseUsageAfterTail(history, anchor, breakdown) {
 			tracker.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			tracker.RecordPendingMessages(history[anchor+1:])
 			return tracker, len(history)
@@ -596,20 +596,25 @@ func historyTailAnchor(history []providers.ChatMessage) string {
 	return hashMessagesForRequestShape(history[len(history)-1:])
 }
 
-func findHistoryTailAnchor(history []providers.ChatMessage, anchor string) int {
+func findHistoryTailAnchor(history []providers.ChatMessage, anchor string) (int, int) {
 	if anchor == "" {
-		return -1
+		return -1, 0
 	}
+	lastMatch := -1
+	matches := 0
 	for i := len(history) - 1; i >= 0; i-- {
 		if hashMessagesForRequestShape(history[i:i+1]) == anchor {
-			return i
+			if lastMatch < 0 {
+				lastMatch = i
+			}
+			matches++
 		}
 	}
-	return -1
+	return lastMatch, matches
 }
 
 func canRebaseUsageAfterTail(history []providers.ChatMessage, anchor int, usage UsageBreakdown) bool {
-	if usage.LastResponseTotal <= 0 || usage.PendingDelta != 0 || anchor < 0 || anchor >= len(history) {
+	if usage.LastResponseTotal <= 0 || usage.PendingDelta != 0 || anchor < 0 || anchor >= len(history)-1 {
 		return false
 	}
 	for _, msg := range history[anchor+1:] {
@@ -675,7 +680,9 @@ func (r *StreamRunner) SynchronizeConversationUsage(history []providers.ChatMess
 	}
 	if len(history) >= r.trackedHistoryLen {
 		usage := r.conversationUsage.Breakdown()
-		if anchor := findHistoryTailAnchor(history, r.trackedHistoryTailHash); anchor == len(history)-1 && usage.LastResponseTotal > 0 && usage.PendingDelta == 0 {
+		anchor, matches := findHistoryTailAnchor(history, r.trackedHistoryTailHash)
+		persistedMatches := persistedTotal <= 0 || persistedTotal == usage.LastResponseTotal
+		if anchor == len(history)-1 && matches == 1 && persistedMatches && usage.LastResponseTotal > 0 && usage.PendingDelta == 0 {
 			r.conversationUsage.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			r.conversationUsage.RecordPendingMessages(history[anchor+1:])
 			r.trackedHistoryLen = len(history)

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -151,6 +151,7 @@ type StreamRunner struct {
 	trackedHistoryLen      int
 	trackedHistoryHash     string
 	trackedHistoryTailHash string
+	trackedHistoryTailID   string
 
 	// retainedContextMu guards the cross-turn request-context state used for
 	// prompt-cache prefix continuity. The state is fingerprinted against the
@@ -512,6 +513,7 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 	trackedLen := r.trackedHistoryLen
 	trackedHash := r.trackedHistoryHash
 	trackedTailHash := r.trackedHistoryTailHash
+	trackedTailID := r.trackedHistoryTailID
 	if trackedLen < 0 {
 		trackedLen = 0
 	}
@@ -533,7 +535,7 @@ func (r *StreamRunner) prepareUsageTracker(history []providers.ChatMessage) (*Us
 		// only messages appended after the boundary instead of pessimistically
 		// re-estimating the entire durable transcript.
 		breakdown := tracker.Breakdown()
-		if anchor, _ := findHistoryTailAnchor(history, trackedTailHash); canRebaseUsageAfterTail(history, anchor, breakdown) {
+		if anchor := findHistoryTailAnchor(history, trackedTailHash, trackedTailID); canRebaseUsageAfterTail(history, anchor, breakdown) {
 			tracker.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			tracker.RecordPendingMessages(history[anchor+1:])
 			return tracker, len(history)
@@ -587,6 +589,7 @@ func (r *StreamRunner) commitUsageTracker(tracker *UsageTracker, history []provi
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = hashMessagesForRequestShape(history)
 	r.trackedHistoryTailHash = historyTailAnchor(history)
+	r.trackedHistoryTailID = historyTailIdentity(history)
 }
 
 func historyTailAnchor(history []providers.ChatMessage) string {
@@ -596,21 +599,55 @@ func historyTailAnchor(history []providers.ChatMessage) string {
 	return hashMessagesForRequestShape(history[len(history)-1:])
 }
 
-func findHistoryTailAnchor(history []providers.ChatMessage, anchor string) (int, int) {
-	if anchor == "" {
-		return -1, 0
+func historyTailIdentity(history []providers.ChatMessage) string {
+	if len(history) == 0 {
+		return ""
 	}
-	lastMatch := -1
-	matches := 0
+	msg := history[len(history)-1]
+	var b strings.Builder
+	writeIdentity := func(kind, provider, model, id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		b.WriteString(kind)
+		b.WriteByte(':')
+		b.WriteString(strings.TrimSpace(provider))
+		b.WriteByte(':')
+		b.WriteString(strings.TrimSpace(model))
+		b.WriteByte(':')
+		b.WriteString(id)
+		b.WriteByte('\n')
+	}
+	writeIdentity("message", msg.ProviderItemProvider, msg.ProviderItemModel, msg.ProviderItemID)
+	writeIdentity("tool_result", "", "", msg.ToolCallID)
+	writeIdentity("tool_invocation", "", "", msg.ToolInvocationID)
+	for _, call := range msg.ToolCalls {
+		writeIdentity("tool_call", call.ProviderItemProvider, call.ProviderItemModel, call.ProviderItemID)
+		writeIdentity("tool_call_id", "", "", call.ID)
+	}
+	for _, block := range msg.ReasoningBlocks {
+		writeIdentity("reasoning_signature", "", "", block.Signature)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return shortRequestShapeHash(b.String())
+}
+
+func findHistoryTailAnchor(history []providers.ChatMessage, anchor, identity string) int {
+	if anchor == "" {
+		return -1
+	}
 	for i := len(history) - 1; i >= 0; i-- {
-		if hashMessagesForRequestShape(history[i:i+1]) == anchor {
-			if lastMatch < 0 {
-				lastMatch = i
-			}
-			matches++
+		if hashMessagesForRequestShape(history[i:i+1]) != anchor {
+			continue
+		}
+		if identity == "" || historyTailIdentity(history[i:i+1]) == identity {
+			return i
 		}
 	}
-	return lastMatch, matches
+	return -1
 }
 
 func canRebaseUsageAfterTail(history []providers.ChatMessage, anchor int, usage UsageBreakdown) bool {
@@ -655,6 +692,7 @@ func (r *StreamRunner) ResetConversationUsage(history []providers.ChatMessage) {
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = hashMessagesForRequestShape(history)
 	r.trackedHistoryTailHash = historyTailAnchor(history)
+	r.trackedHistoryTailID = historyTailIdentity(history)
 }
 
 // SynchronizeConversationUsage reconciles a long-lived runner with the
@@ -676,18 +714,20 @@ func (r *StreamRunner) SynchronizeConversationUsage(history []providers.ChatMess
 		(r.trackedHistoryHash == "" || r.trackedHistoryHash == historyHash) {
 		r.trackedHistoryHash = historyHash
 		r.trackedHistoryTailHash = historyTailAnchor(history)
+		r.trackedHistoryTailID = historyTailIdentity(history)
 		return
 	}
 	if len(history) >= r.trackedHistoryLen {
 		usage := r.conversationUsage.Breakdown()
-		anchor, matches := findHistoryTailAnchor(history, r.trackedHistoryTailHash)
+		anchor := findHistoryTailAnchor(history, r.trackedHistoryTailHash, r.trackedHistoryTailID)
 		persistedMatches := persistedTotal <= 0 || persistedTotal == usage.LastResponseTotal
-		if anchor == len(history)-1 && matches == 1 && persistedMatches && usage.LastResponseTotal > 0 && usage.PendingDelta == 0 {
+		if anchor == len(history)-1 && persistedMatches && usage.LastResponseTotal > 0 && usage.PendingDelta == 0 {
 			r.conversationUsage.SetAdjustment(UsageAdjustmentRequestShapeTailRebase)
 			r.conversationUsage.RecordPendingMessages(history[anchor+1:])
 			r.trackedHistoryLen = len(history)
 			r.trackedHistoryHash = historyHash
 			r.trackedHistoryTailHash = historyTailAnchor(history)
+			r.trackedHistoryTailID = historyTailIdentity(history)
 			return
 		}
 	}
@@ -702,6 +742,7 @@ func (r *StreamRunner) SynchronizeConversationUsage(history []providers.ChatMess
 	r.trackedHistoryLen = len(history)
 	r.trackedHistoryHash = historyHash
 	r.trackedHistoryTailHash = historyTailAnchor(history)
+	r.trackedHistoryTailID = historyTailIdentity(history)
 }
 
 // SeedConversationUsageBaseline primes the cross-turn usage baseline from a
@@ -727,6 +768,7 @@ func (r *StreamRunner) SeedConversationUsageBaseline(total, historyLen int) {
 		r.trackedHistoryLen = historyLen
 		r.trackedHistoryHash = ""
 		r.trackedHistoryTailHash = ""
+		r.trackedHistoryTailID = ""
 	}
 }
 

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -1098,6 +1098,103 @@ func TestStreamRunner_ReusesUsageAcrossTurnsForPreRequestCompact(t *testing.T) {
 	}
 }
 
+func TestStreamRunner_ExpandedDurableHistoryKeepsLastProviderBaseline(t *testing.T) {
+	client := &mockStreamClient{attempts: []mockStreamAttempt{{events: []providers.StreamEvent{
+		{Type: providers.EventContentDelta, Content: "done"},
+		{Type: providers.EventDone, Usage: &providers.TokenUsage{InputTokens: 190_100}},
+	}}}}
+	runner := StreamRunner{
+		Client:                 client,
+		ProviderName:           "openai-codex",
+		Model:                  "gpt-5.6-sol",
+		ContextWindowOverride:  272_000,
+		MaxInputTokens:         272_000,
+		OutputReserveTokens:    128_000,
+		CompactThresholdTokens: 239_000,
+	}
+
+	lastResponse := providers.ChatMessage{Role: "assistant", Content: "previous answer"}
+	compactedHistory := []providers.ChatMessage{
+		{Role: "system", Content: "[Conversation summary] bounded"},
+		lastResponse,
+	}
+	tracker := NewUsageTracker()
+	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 190_000})
+	runner.commitUsageTracker(tracker, compactedHistory)
+
+	// Simulate a durable reload that expands the old prefix with raw tool
+	// results while retaining the exact response boundary measured above. The
+	// lossless durable content is intentionally much larger than the provider
+	// projection stored on ToolResult.
+	expanded := []providers.ChatMessage{
+		{Role: "system", Content: "[Conversation summary] expanded"},
+		{Role: "user", Content: "old request"},
+	}
+	for i := 0; i < 48; i++ {
+		callID := fmt.Sprintf("call-%d", i)
+		expanded = append(expanded, providers.ChatMessage{
+			Role: "assistant",
+			ToolCalls: []providers.ToolCall{{
+				ID: callID, Name: "read_file", Arguments: fmt.Sprintf(`{"path":"file-%d"}`, i),
+			}},
+		})
+		projected := toolresult.FromText("bounded provider projection")
+		expanded = append(expanded, providers.ChatMessage{
+			Role:       "tool",
+			Name:       "read_file",
+			ToolCallID: callID,
+			Content:    strings.Repeat("raw durable output ", 1_300),
+			ToolResult: &projected,
+		})
+	}
+	expanded = append(expanded, lastResponse, userMsg("short follow-up"))
+
+	if raw := estimateMessages(expanded); raw < runner.CompactThresholdTokens {
+		t.Fatalf("raw durable estimate = %d, want above threshold %d", raw, runner.CompactThresholdTokens)
+	}
+	projected, err := providers.PrepareMessagesForProviderRequest(runner.ProviderName, runner.Model, expanded)
+	if err != nil {
+		t.Fatalf("project provider request: %v", err)
+	}
+	if got := estimateMessages(projected); got >= runner.CompactThresholdTokens {
+		t.Fatalf("provider projection estimate = %d, want below threshold %d", got, runner.CompactThresholdTokens)
+	}
+
+	prepared, tracked := runner.prepareUsageTracker(expanded)
+	breakdown := prepared.Breakdown()
+	if tracked != len(expanded) || breakdown.LastResponseTotal != 190_000 {
+		t.Fatalf("rebased tracker = %+v tracked=%d, want provider baseline and %d messages", breakdown, tracked, len(expanded))
+	}
+	if breakdown.Adjustment != UsageAdjustmentRequestShapeTailRebase {
+		t.Fatalf("usage adjustment = %q, want %q", breakdown.Adjustment, UsageAdjustmentRequestShapeTailRebase)
+	}
+	if breakdown.Total() >= runner.CompactThresholdTokens {
+		t.Fatalf("rebased estimate = %d, want below threshold %d", breakdown.Total(), runner.CompactThresholdTokens)
+	}
+
+	// The app-server synchronizes the durable snapshot before admitting the
+	// next user message. A missing persisted total must still preserve the live
+	// provider baseline when the same response boundary is present.
+	runner.SynchronizeConversationUsage(expanded[:len(expanded)-1], 0)
+	synced, _ := runner.prepareUsageTracker(expanded)
+	if got := synced.Breakdown(); got.LastResponseTotal != 190_000 || got.Adjustment != UsageAdjustmentRequestShapeTailRebase || got.Total() >= runner.CompactThresholdTokens {
+		t.Fatalf("synchronized tracker lost provider baseline: %+v", got)
+	}
+
+	var attempts []CompactAttemptInfo
+	runner.OnCompactAttempt = func(info CompactAttemptInfo) { attempts = append(attempts, info) }
+	res, err := runner.RunWithCallback(context.Background(), expanded, nil)
+	if err != nil {
+		t.Fatalf("RunWithCallback: %v", err)
+	}
+	if res.Content != "done" || len(client.requests) != 1 {
+		t.Fatalf("normal request did not run directly: result=%q requests=%d", res.Content, len(client.requests))
+	}
+	if len(attempts) != 0 {
+		t.Fatalf("short follow-up triggered proactive compact: %+v", attempts)
+	}
+}
+
 func TestStreamRunner_PreRequestCompactUsesColdStartEstimate(t *testing.T) {
 	client := &mockStreamClient{
 		events: []providers.StreamEvent{

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -2343,22 +2343,49 @@ func TestStreamRunner_SynchronizeConversationUsageAdoptsExternalCompletedTurn(t 
 }
 
 func TestStreamRunner_SynchronizeConversationUsageRejectsRepeatedTailAnchor(t *testing.T) {
-	oldHistory := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "Done"}}
+	oldHistory := []providers.ChatMessage{userMsg("old"), {
+		Role: "assistant", Content: "Done", ProviderItemID: "msg-old", ProviderItemProvider: "openai-codex", ProviderItemModel: "gpt-test",
+	}}
 	newHistory := append(providers.CloneChatMessages(oldHistory),
 		userMsg("external ask"),
-		providers.ChatMessage{Role: "assistant", Content: "Done"},
+		providers.ChatMessage{Role: "assistant", Content: "Done", ProviderItemID: "msg-new", ProviderItemProvider: "openai-codex", ProviderItemModel: "gpt-test"},
 	)
 	runner := &StreamRunner{}
 	tracker := NewUsageTracker()
 	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 50_000, OutputTokens: 2_000})
 	runner.commitUsageTracker(tracker, oldHistory)
 
-	runner.SynchronizeConversationUsage(newHistory, 9_000)
+	runner.SynchronizeConversationUsage(newHistory, 52_000)
 
 	got, tracked := runner.prepareUsageTracker(newHistory)
 	breakdown := got.Breakdown()
-	if breakdown.Total() != 9_000 || breakdown.Adjustment != UsageAdjustmentExternalRewriteSeed || tracked != len(newHistory) {
+	if breakdown.Total() != 52_000 || breakdown.Adjustment != UsageAdjustmentExternalRewriteSeed || tracked != len(newHistory) {
 		t.Fatalf("repeated tail anchor retained stale usage: usage=%+v tracked=%d", breakdown, tracked)
+	}
+}
+
+func TestStreamRunner_SynchronizeConversationUsageAllowsEarlierMatchingContent(t *testing.T) {
+	current := providers.ChatMessage{
+		Role: "assistant", Content: "Done", ProviderItemID: "msg-current", ProviderItemProvider: "openai-codex", ProviderItemModel: "gpt-test",
+	}
+	oldHistory := []providers.ChatMessage{userMsg("old"), current}
+	expanded := []providers.ChatMessage{
+		userMsg("expanded old ask"),
+		{Role: "assistant", Content: "Done", ProviderItemID: "msg-earlier", ProviderItemProvider: "openai-codex", ProviderItemModel: "gpt-test"},
+		userMsg("current ask"),
+		current,
+	}
+	runner := &StreamRunner{}
+	tracker := NewUsageTracker()
+	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 50_000, OutputTokens: 2_000})
+	runner.commitUsageTracker(tracker, oldHistory)
+
+	runner.SynchronizeConversationUsage(expanded, 0)
+
+	got, tracked := runner.prepareUsageTracker(expanded)
+	breakdown := got.Breakdown()
+	if breakdown.Total() != 52_000 || breakdown.Adjustment != UsageAdjustmentRequestShapeTailRebase || tracked != len(expanded) {
+		t.Fatalf("earlier matching content discarded live usage: usage=%+v tracked=%d", breakdown, tracked)
 	}
 }
 

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -2322,6 +2322,47 @@ func TestStreamRunner_SynchronizeConversationUsageAdoptsExternalRewrite(t *testi
 	}
 }
 
+func TestStreamRunner_SynchronizeConversationUsageAdoptsExternalCompletedTurn(t *testing.T) {
+	oldHistory := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "old answer"}}
+	newHistory := append(providers.CloneChatMessages(oldHistory),
+		userMsg("external ask"),
+		providers.ChatMessage{Role: "assistant", Content: "external answer"},
+	)
+	runner := &StreamRunner{}
+	tracker := NewUsageTracker()
+	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 50_000, OutputTokens: 2_000})
+	runner.commitUsageTracker(tracker, oldHistory)
+
+	runner.SynchronizeConversationUsage(newHistory, 9_000)
+
+	got, tracked := runner.prepareUsageTracker(newHistory)
+	breakdown := got.Breakdown()
+	if breakdown.Total() != 9_000 || breakdown.Adjustment != UsageAdjustmentExternalRewriteSeed || tracked != len(newHistory) {
+		t.Fatalf("external completed turn did not adopt persisted usage: usage=%+v tracked=%d", breakdown, tracked)
+	}
+}
+
+func TestStreamRunner_SynchronizeConversationUsageDoesNotDoubleCountPendingToolDelta(t *testing.T) {
+	oldHistory := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "old answer"}}
+	toolCall := providers.ChatMessage{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: "call-1", Name: "read_file", Arguments: `{}`}}}
+	toolResult := providers.ChatMessage{Role: "tool", Name: "read_file", ToolCallID: "call-1", Content: "result"}
+	newHistory := append(providers.CloneChatMessages(oldHistory), toolCall, toolResult)
+	runner := &StreamRunner{}
+	tracker := NewUsageTracker()
+	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 50_000})
+	tracker.RecordPendingMessages([]providers.ChatMessage{toolCall, toolResult})
+	runner.commitUsageTracker(tracker, oldHistory)
+
+	runner.SynchronizeConversationUsage(newHistory, 0)
+
+	got, tracked := runner.prepareUsageTracker(newHistory)
+	breakdown := got.Breakdown()
+	want := estimateMessages(newHistory)
+	if breakdown.LastResponseTotal != 0 || breakdown.PendingDelta != want || breakdown.Adjustment != UsageAdjustmentExternalRewriteEstimate || tracked != len(newHistory) {
+		t.Fatalf("pending tool delta was retained across durable replay: usage=%+v want=%d tracked=%d", breakdown, want, tracked)
+	}
+}
+
 func TestStreamRunner_PrepareUsageTrackerResetsSameLengthRewrite(t *testing.T) {
 	original := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "old answer"}}
 	rewritten := []providers.ChatMessage{userMsg("new"), {Role: "assistant", Content: "new answer"}}

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -2342,6 +2342,26 @@ func TestStreamRunner_SynchronizeConversationUsageAdoptsExternalCompletedTurn(t 
 	}
 }
 
+func TestStreamRunner_SynchronizeConversationUsageRejectsRepeatedTailAnchor(t *testing.T) {
+	oldHistory := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "Done"}}
+	newHistory := append(providers.CloneChatMessages(oldHistory),
+		userMsg("external ask"),
+		providers.ChatMessage{Role: "assistant", Content: "Done"},
+	)
+	runner := &StreamRunner{}
+	tracker := NewUsageTracker()
+	tracker.RecordResponse(&providers.TokenUsage{InputTokens: 50_000, OutputTokens: 2_000})
+	runner.commitUsageTracker(tracker, oldHistory)
+
+	runner.SynchronizeConversationUsage(newHistory, 9_000)
+
+	got, tracked := runner.prepareUsageTracker(newHistory)
+	breakdown := got.Breakdown()
+	if breakdown.Total() != 9_000 || breakdown.Adjustment != UsageAdjustmentExternalRewriteSeed || tracked != len(newHistory) {
+		t.Fatalf("repeated tail anchor retained stale usage: usage=%+v tracked=%d", breakdown, tracked)
+	}
+}
+
 func TestStreamRunner_SynchronizeConversationUsageDoesNotDoubleCountPendingToolDelta(t *testing.T) {
 	oldHistory := []providers.ChatMessage{userMsg("old"), {Role: "assistant", Content: "old answer"}}
 	toolCall := providers.ChatMessage{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: "call-1", Name: "read_file", Arguments: `{}`}}}

--- a/internal/agent/usage.go
+++ b/internal/agent/usage.go
@@ -30,6 +30,39 @@ type UsageTracker struct {
 	// the last response was recorded. Reset every time RecordResponse
 	// is called.
 	pendingDelta int
+	// adjustment explains which state transition produced the current
+	// baseline/delta pair. It is metadata-only and surfaces in compact traces.
+	adjustment UsageAdjustment
+}
+
+// UsageAdjustment describes the most recent tracker transition relevant to a
+// compact decision. Values are stable because they are persisted in traces.
+type UsageAdjustment string
+
+const (
+	UsageAdjustmentProviderResponse          UsageAdjustment = "provider_response"
+	UsageAdjustmentSeededGroundTruth         UsageAdjustment = "seeded_ground_truth"
+	UsageAdjustmentInitialHistoryEstimate    UsageAdjustment = "initial_history_estimate"
+	UsageAdjustmentLengthReset               UsageAdjustment = "length_reset"
+	UsageAdjustmentRequestShapeReset         UsageAdjustment = "request_shape_reset"
+	UsageAdjustmentRequestShapeTailRebase    UsageAdjustment = "request_shape_tail_rebase"
+	UsageAdjustmentExternalRewriteSeed       UsageAdjustment = "external_rewrite_seed"
+	UsageAdjustmentExternalRewriteEstimate   UsageAdjustment = "external_rewrite_estimate"
+	UsageAdjustmentCompactionRewriteEstimate UsageAdjustment = "compaction_rewrite_estimate"
+	UsageAdjustmentRuntimeRebuildSeed        UsageAdjustment = "runtime_rebuild_seed"
+)
+
+// UsageBreakdown is an atomic snapshot of the values behind EstimateCurrent.
+// It lets compact diagnostics explain whether a trigger came from provider
+// ground truth or locally estimated pending messages.
+type UsageBreakdown struct {
+	LastResponseTotal int
+	PendingDelta      int
+	Adjustment        UsageAdjustment
+}
+
+func (b UsageBreakdown) Total() int {
+	return b.LastResponseTotal + b.PendingDelta
 }
 
 // NewUsageTracker constructs a fresh tracker with no recorded usage.
@@ -56,6 +89,7 @@ func (t *UsageTracker) RecordResponse(usage *providers.TokenUsage) {
 	// The new ground truth already includes everything we'd been
 	// estimating, so the pending delta resets to zero.
 	t.pendingDelta = 0
+	t.adjustment = UsageAdjustmentProviderResponse
 }
 
 // RecordPendingMessages adds an estimate for messages that have been
@@ -82,6 +116,20 @@ func (t *UsageTracker) EstimateCurrent() int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.lastResponseTotal + t.pendingDelta
+}
+
+// Breakdown returns an atomic diagnostic snapshot of the tracker.
+func (t *UsageTracker) Breakdown() UsageBreakdown {
+	if t == nil {
+		return UsageBreakdown{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return UsageBreakdown{
+		LastResponseTotal: t.lastResponseTotal,
+		PendingDelta:      t.pendingDelta,
+		Adjustment:        t.adjustment,
+	}
 }
 
 // LastResponseTotal returns the most recently recorded ground truth.
@@ -127,7 +175,18 @@ func (t *UsageTracker) SeedGroundTruth(total int) bool {
 		return false
 	}
 	t.lastResponseTotal = total
+	t.adjustment = UsageAdjustmentSeededGroundTruth
 	return true
+}
+
+// SetAdjustment records why the current baseline/delta pair was adopted.
+func (t *UsageTracker) SetAdjustment(adjustment UsageAdjustment) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.adjustment = adjustment
 }
 
 // Reset clears all recorded state. Used after a compact pass replaces
@@ -140,6 +199,7 @@ func (t *UsageTracker) Reset() {
 	defer t.mu.Unlock()
 	t.lastResponseTotal = 0
 	t.pendingDelta = 0
+	t.adjustment = ""
 }
 
 // Clone returns a snapshot copy of the current tracker state. Useful
@@ -154,6 +214,7 @@ func (t *UsageTracker) Clone() *UsageTracker {
 	return &UsageTracker{
 		lastResponseTotal: t.lastResponseTotal,
 		pendingDelta:      t.pendingDelta,
+		adjustment:        t.adjustment,
 	}
 }
 

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -2432,12 +2432,15 @@ func (s *Server) persistTurnTrace(threadRuntime *runtime.ThreadRuntime, runner *
 
 func compactRecord(info agent.CompactAttemptInfo) sessiontrace.CompactRecord {
 	return sessiontrace.CompactRecord{
-		Reason:         string(info.Reason),
-		Status:         string(info.Status),
-		TokensBefore:   info.TokensBefore,
-		MessagesBefore: info.MessagesBefore,
-		MessagesAfter:  info.MessagesAfter,
-		Error:          info.Error,
+		Reason:            string(info.Reason),
+		Status:            string(info.Status),
+		TokensBefore:      info.TokensBefore,
+		LastResponseTotal: info.LastResponseTotal,
+		PendingDelta:      info.PendingDelta,
+		UsageAdjustment:   string(info.UsageAdjustment),
+		MessagesBefore:    info.MessagesBefore,
+		MessagesAfter:     info.MessagesAfter,
+		Error:             info.Error,
 	}
 }
 

--- a/internal/appserver/turn_trace_test.go
+++ b/internal/appserver/turn_trace_test.go
@@ -80,10 +80,13 @@ func TestPersistTurnTraceWritesSessionArtifact(t *testing.T) {
 		FullInputItems:         4,
 		DeltaInputItems:        1,
 	}}, []sessiontrace.CompactRecord{{
-		Reason:         "proactive",
-		Status:         "failed",
-		TokensBefore:   252001,
-		MessagesBefore: 42,
+		Reason:            "proactive",
+		Status:            "failed",
+		TokensBefore:      252001,
+		LastResponseTotal: 240000,
+		PendingDelta:      12001,
+		UsageAdjustment:   "provider_response",
+		MessagesBefore:    42,
 	}}, []sessiontrace.BarrierToolBatchRejectionRecord{{
 		StepIndex:     0,
 		BarrierTool:   "helpme",
@@ -102,7 +105,7 @@ func TestPersistTurnTraceWritesSessionArtifact(t *testing.T) {
 		t.Fatalf("read session trace: %v", err)
 	}
 	trace := string(data)
-	for _, want := range []string{`"type":"turn"`, `"type":"context_requests"`, `"type":"provider_states"`, `"type":"compact_attempts"`, `"type":"barrier_tool_batch_rejected"`, `"type":"tool_inventory"`, `"type":"tool_records"`, `"type":"final"`, `"provider_name":"openai"`, `"model":"gpt-test"`, `"permission_mode":"unconfined"`, `"model_profile"`, `"family":"gpt"`, `"default_write_mode":"patch"`, `"name":"read_file"`, `"ENVIRONMENT"`, `"step_index":1`, `"transport":"websocket"`, `"connection_reused":true`, `"fallback_reason":"websocket_failed_before_first_event"`, `"previous_response_id_used":true`, `"tokens_before":252001`, `"barrier_tool":"helpme"`, `"sibling_tools":["run_shell"]`, `"tool_call_count":2`} {
+	for _, want := range []string{`"type":"turn"`, `"type":"context_requests"`, `"type":"provider_states"`, `"type":"compact_attempts"`, `"type":"barrier_tool_batch_rejected"`, `"type":"tool_inventory"`, `"type":"tool_records"`, `"type":"final"`, `"provider_name":"openai"`, `"model":"gpt-test"`, `"permission_mode":"unconfined"`, `"model_profile"`, `"family":"gpt"`, `"default_write_mode":"patch"`, `"name":"read_file"`, `"ENVIRONMENT"`, `"step_index":1`, `"transport":"websocket"`, `"connection_reused":true`, `"fallback_reason":"websocket_failed_before_first_event"`, `"previous_response_id_used":true`, `"tokens_before":252001`, `"last_response_total":240000`, `"pending_delta":12001`, `"usage_adjustment":"provider_response"`, `"barrier_tool":"helpme"`, `"sibling_tools":["run_shell"]`, `"tool_call_count":2`} {
 		if !strings.Contains(trace, want) {
 			t.Fatalf("session trace missing %s:\n%s", want, trace)
 		}

--- a/internal/sessiontrace/trace.go
+++ b/internal/sessiontrace/trace.go
@@ -230,12 +230,15 @@ type ProviderStateRecord struct {
 }
 
 type CompactRecord struct {
-	Reason         string `json:"reason,omitempty"`
-	Status         string `json:"status,omitempty"`
-	TokensBefore   int    `json:"tokens_before,omitempty"`
-	MessagesBefore int    `json:"messages_before,omitempty"`
-	MessagesAfter  int    `json:"messages_after,omitempty"`
-	Error          string `json:"error,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	Status            string `json:"status,omitempty"`
+	TokensBefore      int    `json:"tokens_before,omitempty"`
+	LastResponseTotal int    `json:"last_response_total"`
+	PendingDelta      int    `json:"pending_delta"`
+	UsageAdjustment   string `json:"usage_adjustment,omitempty"`
+	MessagesBefore    int    `json:"messages_before,omitempty"`
+	MessagesAfter     int    `json:"messages_after,omitempty"`
+	Error             string `json:"error,omitempty"`
 }
 
 type BarrierToolBatchRejectionRecord struct {

--- a/internal/sessiontrace/trace_test.go
+++ b/internal/sessiontrace/trace_test.go
@@ -95,11 +95,14 @@ func TestAppendTurnWritesAgentFriendlyEvents(t *testing.T) {
 			DeltaInputItems:        1,
 		}},
 		[]CompactRecord{{
-			Reason:         "proactive",
-			Status:         "failed",
-			TokensBefore:   1234,
-			MessagesBefore: 10,
-			Error:          "compact failed API_KEY=secret-value-compact",
+			Reason:            "proactive",
+			Status:            "failed",
+			TokensBefore:      1234,
+			LastResponseTotal: 1200,
+			PendingDelta:      34,
+			UsageAdjustment:   "request_shape_tail_rebase",
+			MessagesBefore:    10,
+			Error:             "compact failed API_KEY=secret-value-compact",
 		}},
 		[]BarrierToolBatchRejectionRecord{{
 			StepIndex:     0,
@@ -136,6 +139,11 @@ func TestAppendTurnWritesAgentFriendlyEvents(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"cache_creation_tokens":8`) || !strings.Contains(string(raw), `"cache_read_tokens":5`) {
 		t.Fatalf("trace should include prompt cache usage:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), `"last_response_total":1200`) ||
+		!strings.Contains(string(raw), `"pending_delta":34`) ||
+		!strings.Contains(string(raw), `"usage_adjustment":"request_shape_tail_rebase"`) {
+		t.Fatalf("trace should explain compact usage baseline:\n%s", raw)
 	}
 	for _, want := range []string{
 		`"message_count":4`,


### PR DESCRIPTION
## Summary

- preserve the latest trustworthy provider-usage baseline when a durable-history reload expands or normalizes the old prefix but retains the same response boundary
- estimate only messages appended after that boundary, avoiding repeated proactive compaction from a full durable-history fallback
- include the provider baseline, pending delta, and tracker adjustment in compact-attempt traces
- add regression coverage for raw durable tool results that are larger than their provider request projection

## Tests

- go test ./...
- make check-go test-go build-go

Closes #127
