### PR TITLE
feat(context): drop derived context ledgers from default model projection

### DIFF
--- a/cmd/wuu/main_test.go
+++ b/cmd/wuu/main_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/appserver"
 	"github.com/blueberrycongee/wuu/internal/config"
+	wuucontext "github.com/blueberrycongee/wuu/internal/context"
 	"github.com/blueberrycongee/wuu/internal/evalharness"
 	wuuexec "github.com/blueberrycongee/wuu/internal/exec"
 	"github.com/blueberrycongee/wuu/internal/modelprofile"
@@ -1163,6 +1164,7 @@ func TestEvalModelProfileObservation(t *testing.T) {
 }
 
 func TestEvalContextBlockObservationsSummarizeRuntimeBlocks(t *testing.T) {
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/eval\n"), 0o644); err != nil {
 		t.Fatalf("write go.mod: %v", err)

--- a/internal/agent/request_assembler.go
+++ b/internal/agent/request_assembler.go
@@ -345,6 +345,12 @@ func reconciledRetainedContext(retained []RetainedContextMessage, currentSegment
 	current := requestContextContentByKey(currentSegments)
 	out := make([]RetainedContextMessage, 0, len(retained))
 	for _, entry := range retained {
+		// Derived ledgers removed from the default projection must not ride
+		// the retained stream across turns: drop stale copies instead of
+		// re-splicing (and later tombstoning) them on every request.
+		if !wuucontext.DerivedContextLedgersEnabled() && wuucontext.IsDerivedLedgerBlockName(entry.Message.Name) {
+			continue
+		}
 		// Typed runtime blocks form an ordered update stream. Keeping every
 		// prior update preserves the previous request byte-for-byte; the latest
 		// active/inactive update determines current semantics. Generic request

--- a/internal/agent/request_assembler_test.go
+++ b/internal/agent/request_assembler_test.go
@@ -84,3 +84,31 @@ func TestRequestBlockMetricsMatchProjectionSwitch(t *testing.T) {
 		t.Fatalf("compact block bytes should be smaller: compact=%d legacy=%d", compactBytes, legacyBytes)
 	}
 }
+
+// TestReconciledRetainedContextDropsDerivedLedgers locks the issue-128
+// migration behavior: derived-ledger updates retained by an earlier turn must
+// not re-enter the request stream once they leave the default projection.
+// The A/B baseline ("on") keeps the legacy stream intact.
+func TestReconciledRetainedContextDropsDerivedLedgers(t *testing.T) {
+	ledger := wuucontext.Block{Kind: wuucontext.BlockActiveFiles, Title: "Active files", Source: "read_file", Content: "files:\n- go.mod"}
+	kept := wuucontext.Block{Kind: wuucontext.BlockTestFailures, Title: "Test failures", Source: "bash", Content: "go test failed"}
+	ledgerMsg := requestOnlyMessagesFromBlocks([]wuucontext.Block{ledger})[0]
+	keptMsg := requestOnlyMessagesFromBlocks([]wuucontext.Block{kept})[0]
+	retained := []RetainedContextMessage{
+		{AfterDurable: 0, Message: ledgerMsg},
+		{AfterDurable: 1, Message: keptMsg},
+	}
+	current := RequestOnlyContextBlocks([]wuucontext.Block{kept})
+
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "")
+	got := reconciledRetainedContext(retained, current)
+	if len(got) != 1 || got[0].Message.Name != keptMsg.Name {
+		t.Fatalf("derived ledger must be dropped from retained context: %+v", got)
+	}
+
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
+	got = reconciledRetainedContext(retained, current)
+	if len(got) != 2 {
+		t.Fatalf("A/B baseline keeps the retained ledger stream: %+v", got)
+	}
+}

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -2316,6 +2316,47 @@ func TestStreamRunner_CrossTurnContinuitySurvivesUsageSynchronization(t *testing
 	}
 }
 
+// TestStreamRunner_DerivedLedgersDoNotReappearAcrossTurns locks the issue-128
+// acceptance behavior: a derived ledger sent by an earlier turn must not ride
+// the retained stream into later turns once the producer stops emitting it,
+// and the dropped key must not earn an inactive tombstone on every turn.
+func TestStreamRunner_DerivedLedgersDoNotReappearAcrossTurns(t *testing.T) {
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "")
+	ledger := wuucontext.Block{
+		Kind: wuucontext.BlockActiveFiles, Title: "Active files", Source: "read_file", Content: "files:\n- go.mod",
+	}
+	client := &mockStreamClient{attempts: []mockStreamAttempt{
+		{events: []providers.StreamEvent{{Type: providers.EventContentDelta, Content: "turn one"}, {Type: providers.EventDone}}},
+		{events: []providers.StreamEvent{{Type: providers.EventContentDelta, Content: "turn two"}, {Type: providers.EventDone}}},
+	}}
+	runner := &StreamRunner{
+		Client: client, Model: "m",
+		BeforeRequestContext: func() []ContextSegment { return RequestOnlyContextBlocks([]wuucontext.Block{ledger}) },
+	}
+	history1 := []providers.ChatMessage{userMsg("first ask")}
+	res1, err := runner.RunWithCallback(context.Background(), history1, nil)
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if got := countMessagesContaining(client.requests[0].Messages, "[ACTIVE_FILES]"); got != 1 {
+		t.Fatalf("turn 1 should carry the ledger, got %d", got)
+	}
+
+	// Post-upgrade turn: the producer no longer emits the ledger.
+	runner.BeforeRequestContext = func() []ContextSegment { return nil }
+	history2 := append(append(providers.CloneChatMessages(history1), res1.NewMessages...), userMsg("second ask"))
+	if _, err := runner.RunWithCallback(context.Background(), history2, nil); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	turn2 := client.requests[1].Messages
+	if got := countMessagesContaining(turn2, "[ACTIVE_FILES]"); got != 0 {
+		t.Fatalf("derived ledger must not reappear from retained state, got %d in %+v", got, turn2)
+	}
+	if got := countMessagesContaining(turn2, "status: inactive"); got != 0 {
+		t.Fatalf("dropped ledgers must not earn tombstones, got %d in %+v", got, turn2)
+	}
+}
+
 func TestStreamRunner_CanceledTurnRetainsPrefixForRetry(t *testing.T) {
 	block := wuucontext.Block{
 		Kind: wuucontext.BlockActiveFiles, Title: "Active files", Source: "read_file", Content: "files:\n- go.mod",

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -32,6 +32,12 @@ const systemReminderBlockMessageNamePrefix = "wuu_ctx_"
 // projection. It defaults to active; set it to "off" for the legacy baseline.
 const DynamicContextProjectionEnvVar = "WUU_DYNAMIC_CONTEXT_PROJECTION"
 
+// DerivedContextLedgersEnvVar gates the legacy derived context ledgers
+// (plan TASK_STATE, ACTIVE_FILES, TOOL_RESULT_SUMMARY, WEB_EVIDENCE). They
+// are excluded from the default model projection; set it to "on" for the
+// A/B baseline.
+const DerivedContextLedgersEnvVar = "WUU_DERIVED_CONTEXT_LEDGERS"
+
 // TaskContractMessageName marks legacy hidden task-contract context derived
 // from recent user directives. New requests no longer synthesize this
 // context; older persisted histories can still carry this message name and
@@ -130,6 +136,49 @@ func compileBlocks(blocks []Block, compact bool) string {
 // the feature remains on by default; "off" is the A/B baseline.
 func DynamicContextProjectionEnabled() bool {
 	return !strings.EqualFold(strings.TrimSpace(os.Getenv(DynamicContextProjectionEnvVar)), "off")
+}
+
+// DerivedContextLedgersEnabled returns whether the legacy derived context
+// ledgers ride in request-only context. They default to off: ordinary
+// requests read the same facts from their causal source (update_plan calls,
+// read_file results, web tool results, and the tool transcript itself).
+// "on" restores the ledger projection as the A/B baseline.
+func DerivedContextLedgersEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(DerivedContextLedgersEnvVar)), "on")
+}
+
+// derivedLedgerBlockIdentities are the (kind, source) pairs removed from the
+// default model projection. Other blocks sharing a kind — session-memory
+// recovery, subagent status, frozen worker trees — are not ledgers and stay.
+var derivedLedgerBlockIdentities = []struct {
+	kind   BlockKind
+	source string
+}{
+	{BlockTaskState, "update_plan"},
+	{BlockActiveFiles, "read_file"},
+	{BlockToolResultSummary, "tool_telemetry"},
+	{BlockWebEvidence, "web_tools"},
+}
+
+// IsDerivedLedgerBlockName reports whether a system-reminder block message
+// name belongs to a derived ledger excluded from the default projection, so
+// retained request state can drop stale copies instead of re-splicing them
+// into every later request.
+func IsDerivedLedgerBlockName(name string) bool {
+	name = strings.TrimSpace(name)
+	if !strings.HasPrefix(name, systemReminderBlockMessageNamePrefix) {
+		return false
+	}
+	for _, identity := range derivedLedgerBlockIdentities {
+		slug := sanitizeMessageNameSlug(string(identity.kind) + "_" + identity.source)
+		if slug == "" {
+			continue
+		}
+		if strings.HasPrefix(name, systemReminderBlockMessageNamePrefix+slug+"_") {
+			return true
+		}
+	}
+	return false
 }
 
 func FormatSystemReminderBlocks(blocks ...Block) string {

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -69,6 +69,52 @@ func TestDynamicContextProjectionDefaultsActiveAndSupportsOff(t *testing.T) {
 	}
 }
 
+func TestDerivedContextLedgersDefaultOffAndSupportOn(t *testing.T) {
+	t.Setenv(DerivedContextLedgersEnvVar, "")
+	if DerivedContextLedgersEnabled() {
+		t.Fatal("derived context ledgers should default off")
+	}
+	t.Setenv(DerivedContextLedgersEnvVar, "on")
+	if !DerivedContextLedgersEnabled() {
+		t.Fatal("on should restore derived context ledgers as the A/B baseline")
+	}
+}
+
+func TestIsDerivedLedgerBlockName(t *testing.T) {
+	nameFor := func(kind BlockKind, source string) string {
+		return SystemReminderBlockMessageName(Block{Kind: kind, Title: "T", Source: source, Content: "x"}, 0)
+	}
+	for _, ledger := range derivedLedgerBlockIdentities {
+		if !IsDerivedLedgerBlockName(nameFor(ledger.kind, ledger.source)) {
+			t.Fatalf("expected derived ledger match for %s/%s", ledger.kind, ledger.source)
+		}
+	}
+	kept := []struct {
+		kind   BlockKind
+		source string
+	}{
+		{BlockTaskState, "session.summary"},
+		{BlockTaskState, "session.checkpoint"},
+		{BlockTaskState, "session.notes"},
+		{BlockTaskState, "runtime.subagent_status"},
+		{BlockTaskState, "runtime"},
+		{BlockActiveFiles, "runtime.active_files"},
+		{BlockTestFailures, "bash"},
+		{BlockToolPolicy, "ultra"},
+		{BlockMemory, "session.notes"},
+	}
+	for _, block := range kept {
+		if IsDerivedLedgerBlockName(nameFor(block.kind, block.source)) {
+			t.Fatalf("kept block %s/%s must not match derived ledgers", block.kind, block.source)
+		}
+	}
+	for _, nonBlock := range []string{"", "wuu_system_reminder", "wuu_agent_notification"} {
+		if IsDerivedLedgerBlockName(nonBlock) {
+			t.Fatalf("non-block name %q must not match derived ledgers", nonBlock)
+		}
+	}
+}
+
 func TestCompileBlocksEnforcesTokenBudget(t *testing.T) {
 	longContent := strings.Repeat("src/internal/really/long/path/to/file.go\n", 200)
 	got := CompileBlocks([]Block{

--- a/internal/tools/tool_context.go
+++ b/internal/tools/tool_context.go
@@ -30,17 +30,23 @@ func (t *Toolkit) ContextBlocks() []wuucontext.Block {
 	}
 	var blocks []wuucontext.Block
 	blocks = append(blocks, t.SessionMemoryContextBlocks()...)
-	blocks = append(blocks, t.PlanContextBlocks()...)
-	if block, ok := t.ActiveFilesContextBlock(); ok {
-		blocks = append(blocks, block)
+	if wuucontext.DerivedContextLedgersEnabled() {
+		// Legacy derived ledgers, kept only as the A/B baseline arm. Ordinary
+		// requests read these facts from their causal source (update_plan
+		// calls, read_file results, web tool results, and the tool
+		// transcript itself) instead of re-stating them every request.
+		blocks = append(blocks, t.PlanContextBlocks()...)
+		if block, ok := t.ActiveFilesContextBlock(); ok {
+			blocks = append(blocks, block)
+		}
+		if block, ok := t.WebEvidenceContextBlock(); ok {
+			blocks = append(blocks, block)
+		}
+		if block, ok := t.ToolResultSummaryContextBlock(); ok {
+			blocks = append(blocks, block)
+		}
 	}
 	if block, ok := t.TestFailureContextBlock(); ok {
-		blocks = append(blocks, block)
-	}
-	if block, ok := t.WebEvidenceContextBlock(); ok {
-		blocks = append(blocks, block)
-	}
-	if block, ok := t.ToolResultSummaryContextBlock(); ok {
 		blocks = append(blocks, block)
 	}
 	return blocks

--- a/internal/tools/toolkit_test.go
+++ b/internal/tools/toolkit_test.go
@@ -3687,6 +3687,7 @@ func TestToolkit_ToolTelemetry_RecordsToolError(t *testing.T) {
 }
 
 func TestToolkit_ToolResultSummaryContextBlockOmitsToolBodies(t *testing.T) {
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
 	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "a.txt"), "API_KEY=secret-value-1234567890\n")
@@ -3942,7 +3943,72 @@ func TestToolkit_ToolResultSummaryContextBlockLimitsRenderedCalls(t *testing.T) 
 	}
 }
 
+// TestToolkit_ContextBlocksOmitsDerivedLedgersByDefault locks the issue-128
+// behavior: the four derived ledgers (plan TASK_STATE, ACTIVE_FILES,
+// TOOL_RESULT_SUMMARY, WEB_EVIDENCE) stay out of the default model projection
+// even when their underlying state exists, and WUU_DERIVED_CONTEXT_LEDGERS=on
+// restores them as the A/B baseline.
+func TestToolkit_ContextBlocksOmitsDerivedLedgersByDefault(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "a.txt"), "one\ntwo\n")
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for _, call := range []providers.ToolCall{
+		{Name: "update_plan", Arguments: `{"plan":[{"step":"ship it","status":"in_progress"}]}`},
+		{Name: "read_file", Arguments: `{"path":"a.txt"}`},
+		{Name: "web_fetch", Arguments: `{"url":"http://127.0.0.1/"}`},
+	} {
+		if _, err := kit.Execute(context.Background(), call); err != nil {
+			t.Fatalf("%s: %v", call.Name, err)
+		}
+	}
+	// Sanity: every ledger producer holds state, so gating is what excludes
+	// the blocks, not empty inputs.
+	if len(kit.PlanContextBlocks()) == 0 {
+		t.Fatal("expected plan state for update_plan")
+	}
+	if _, ok := kit.ActiveFilesContextBlock(); !ok {
+		t.Fatal("expected active files state for read_file")
+	}
+	if _, ok := kit.ToolResultSummaryContextBlock(); !ok {
+		t.Fatal("expected tool telemetry state")
+	}
+	if _, ok := kit.WebEvidenceContextBlock(); !ok {
+		t.Fatal("expected web evidence state for web_fetch")
+	}
+
+	ledgerKinds := []wuucontext.BlockKind{
+		wuucontext.BlockTaskState,
+		wuucontext.BlockActiveFiles,
+		wuucontext.BlockToolResultSummary,
+		wuucontext.BlockWebEvidence,
+	}
+	present := func() map[wuucontext.BlockKind]bool {
+		got := map[wuucontext.BlockKind]bool{}
+		for _, block := range kit.ContextBlocks() {
+			got[block.Kind] = true
+		}
+		return got
+	}
+
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "")
+	if got := present(); len(got) != 0 {
+		t.Fatalf("default projection must omit derived ledgers and carry no other toolkit blocks: %+v", got)
+	}
+
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
+	got := present()
+	for _, kind := range ledgerKinds {
+		if !got[kind] {
+			t.Fatalf("A/B baseline should restore %s: %+v", kind, got)
+		}
+	}
+}
+
 func TestToolkit_ActiveFilesContextBlockTracksReadFiles(t *testing.T) {
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
 	t.Setenv(wuucontext.DynamicContextProjectionEnvVar, "off")
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "dir", "a.txt"), "line one\nAPI_KEY=secret-value-1234567890\nline three\nline four\n")

--- a/internal/tools/web_ssrf_test.go
+++ b/internal/tools/web_ssrf_test.go
@@ -180,6 +180,7 @@ func TestWebFetchBlockedIncludesEvidence(t *testing.T) {
 }
 
 func TestToolkitWebEvidenceContextBlockTracksMetadataOnly(t *testing.T) {
+	t.Setenv(wuucontext.DerivedContextLedgersEnvVar, "on")
 	kit, err := New(t.TempDir())
 	if err != nil {
 		t.Fatalf("New: %v", err)


### PR DESCRIPTION
## Summary

Implements #128: stop injecting the four derived context ledgers — plan `TASK_STATE`, `ACTIVE_FILES`, `TOOL_RESULT_SUMMARY`, `WEB_EVIDENCE` — into ordinary provider requests.

These `[CONTEXT_UPDATE]` blocks restate facts that already live in the canonical transcript at their causal source (`update_plan` calls, `read_file` results, web tool results, and tool results). Because the retained request stream is append-only, every changed snapshot also kept its older copies in the prefix, adding fresh input on later requests without new information.

## What changes

- **Default projection**: `Toolkit.ContextBlocks()` no longer emits the four ledger blocks. Session-memory recovery blocks (summary/checkpoint/notes), subagent status, and `TEST_FAILURES` are untouched, as are all underlying state stores (read tracking, tool telemetry, web evidence, plan state) that feed UI, edit-time validation, and recovery.
- **A/B baseline**: `WUU_DERIVED_CONTEXT_LEDGERS=on` restores the legacy ledger projection, mirroring the `WUU_DYNAMIC_CONTEXT_PROJECTION` experiment pattern, so the task-quality / fresh-input A/B evaluation can run both arms in one binary.
- **Retained-context migration**: `reconciledRetainedContext` drops retained entries whose block name matches a removed ledger, so stale copies cannot ride the cross-turn stream (and do not earn per-turn inactive tombstones).

## Verification

- `go build ./...` + `go vet` clean
- Full `go test ./...` green, including new coverage:
  - `TestToolkit_ContextBlocksOmitsDerivedLedgersByDefault` — default omits all four ledgers with state present; `on` restores them
  - `TestIsDerivedLedgerBlockName` — matches only the four (kind, source) pairs, not session-memory/subagent/frozen `TASK_STATE`
  - `TestReconciledRetainedContextDropsDerivedLedgers` — retained ledgers dropped by default, kept under baseline
  - `TestStreamRunner_DerivedLedgersDoNotReappearAcrossTurns` — multi-turn retained context carries no ledger copies and no tombstones

Per the issue: this PR removes redundant projections as a cost measure; it does **not** claim a task-quality improvement — that requires the A/B evaluation (both arms available via the env flag). Request-context telemetry (`BlockKindBytes`, retained tokens) already measures the input-byte change without storing prompt content.

Closes #128