### PR TITLE
feat(composer): surface token speed via hover tooltip on narrow composer bars

### DIFF
--- a/desktop/src/renderer/ComposerTokenGauge.tsx
+++ b/desktop/src/renderer/ComposerTokenGauge.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useI18n } from "./i18n";
+import { FloatingMenuPortal } from "./ComposerFloatingMenu";
 
 // Toolbar gauge. The numeric readout is rendered inline next to the dial
-// so the user can see the current rate without hovering. The needle and
-// the text share the same currentColor so the idle/mid/high color tier
-// applies to both.
+// so the user can see the current rate without hovering when the toolbar is
+// wide enough. When the composer is narrow and the inline label is hidden
+// by the container query, the same value is surfaced through a hover tooltip
+// so the speed remains accessible.
 const MAX_TOKENS_PER_SEC = 100;
 const HIGH_SPEED_THRESHOLD = 70;
 const STALE_HOLD_MS = 1200;
 const STALE_DECAY_MS = 5200;
 const STALE_DECAY_STEP_MS = 100;
+const TOOLTIP_WIDTH = 160;
 
 const GAUGE_ARC_PATH = "M 2.5 17 A 9.5 9.5 0 0 1 21.5 17";
 const GAUGE_ARC_PATH_LENGTH = 100;
@@ -40,6 +43,9 @@ export function ComposerTokenGauge({
   source?: "real" | "estimated" | "none";
 }): JSX.Element {
   const { t, formatNumber } = useI18n();
+  const tooltipID = useId();
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   // CSS transitions smooth the needle and arc between samples. React only
   // updates when the target changes or a stale sample is winding down, so a
   // stable running turn does not keep the renderer on a permanent rAF loop.
@@ -94,15 +100,23 @@ export function ComposerTokenGauge({
   const rounded = Math.round(displayed);
   const isEstimated = source === "estimated";
   const speedLabel = t(isEstimated ? "composer.speed.estimatedShort" : "composer.speed.short", { speed: formatNumber(rounded) });
+  const tooltipLabel = t(isEstimated ? "composer.speed.estimatedLabel" : "composer.speed.label", { speed: formatNumber(rounded) });
 
   return (
     <div
+      ref={anchorRef}
       className="composer-token-gauge"
       data-state={running ? "running" : "idle"}
       role="status"
       aria-live="polite"
-      aria-label={t(isEstimated ? "composer.speed.estimatedLabel" : "composer.speed.label", { speed: formatNumber(rounded) })}
+      aria-label={tooltipLabel}
+      aria-describedby={tooltipOpen ? tooltipID : undefined}
+      tabIndex={0}
       style={{ color }}
+      onBlur={() => setTooltipOpen(false)}
+      onFocus={() => setTooltipOpen(true)}
+      onMouseEnter={() => setTooltipOpen(true)}
+      onMouseLeave={() => setTooltipOpen(false)}
     >
       <svg
         viewBox="0 0 24 24"
@@ -145,6 +159,24 @@ export function ComposerTokenGauge({
         />
       </svg>
       <span className="composer-token-gauge-label">{speedLabel}</span>
+      {tooltipOpen ? (
+        <FloatingMenuPortal
+          anchorRef={anchorRef}
+          owner="composer-token-gauge"
+          placement="above"
+          align="right"
+          offset={8}
+          width={TOOLTIP_WIDTH}
+        >
+          <div
+            id={tooltipID}
+            className="composer-token-gauge-tooltip"
+            role="tooltip"
+          >
+            {tooltipLabel}
+          </div>
+        </FloatingMenuPortal>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/ComposerTypes.ts
+++ b/desktop/src/renderer/ComposerTypes.ts
@@ -14,6 +14,7 @@ export type FloatingMenuOwner =
   | "composer-runtime"
   | "composer-access"
   | "composer-context-meter"
+  | "composer-token-gauge"
   | "composer-focus"
   | "composer-goal"
   | "composer-plus"

--- a/desktop/src/renderer/ComposerView.test.tsx
+++ b/desktop/src/renderer/ComposerView.test.tsx
@@ -57,7 +57,7 @@ afterEach(() => {
   container.remove();
   document.body
     .querySelectorAll(
-      "[data-floating-menu-owner=\"composer-access\"], [data-floating-menu-owner=\"composer-focus\"], [data-floating-menu-owner=\"composer-plus\"]",
+      "[data-floating-menu-owner=\"composer-access\"], [data-floating-menu-owner=\"composer-focus\"], [data-floating-menu-owner=\"composer-plus\"], [data-floating-menu-owner=\"composer-token-gauge\"]",
     )
     .forEach((element) => element.remove());
 });
@@ -2053,15 +2053,16 @@ describe("ComposerTokenGauge", () => {
     }
   });
 
-  it("keeps the gauge visible with the speed label always shown when idle", () => {
+  it("keeps the gauge visible with the speed label inline and a hidden hover tooltip", () => {
     renderComposer({ running: false, tokensPerSecond: 0 });
     const gauge = container.querySelector(".composer-token-gauge");
     expect(gauge).not.toBeNull();
     expect(gauge?.getAttribute("data-state")).toBe("idle");
     expect(gauge?.getAttribute("aria-label")).toContain("0 token 每秒");
 
-    // The label is now inline next to the dial — no hover portal. It must
-    // be in the DOM from the first render so the user always sees the rate.
+    // The label is still inline next to the dial when the toolbar is wide
+    // enough, but the same value is also available through a hover tooltip
+    // for narrow widths where the inline label is hidden by the container query.
     const label = container.querySelector(".composer-token-gauge-label");
     expect(label).not.toBeNull();
     expect(label?.textContent).toContain("0 tok/s");
@@ -2069,7 +2070,7 @@ describe("ComposerTokenGauge", () => {
     expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
   });
 
-  it("renders a live gauge without scheduling animation frames", () => {
+  it("renders a live gauge without scheduling animation frames and shows the speed on hover", () => {
     const requestAnimationFrame = vi
       .spyOn(window, "requestAnimationFrame")
       .mockImplementation(() => 1);
@@ -2083,17 +2084,20 @@ describe("ComposerTokenGauge", () => {
       expect(gauge?.getAttribute("title")).toBeNull();
       expect(requestAnimationFrame).not.toHaveBeenCalled();
 
-      // Label is inline; no portal, no hover gate. Hovering must not
-      // resurrect a tooltip either.
+      // Label is inline by default; hovering opens the tooltip portal.
       const label = container.querySelector(".composer-token-gauge-label");
       expect(label).not.toBeNull();
       expect(label?.textContent).toContain("18 tok/s");
       expect(label?.textContent).toContain("tok/s");
+      expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
 
       act(() => {
         gauge?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       });
-      expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
+      const tooltip = document.body.querySelector(".composer-token-gauge-tooltip");
+      expect(tooltip).not.toBeNull();
+      expect(tooltip?.textContent).toContain("18");
+      expect(tooltip?.textContent).toContain("token 每秒");
 
       // Dial components are still rendered.
       const svg = container.querySelector(".composer-token-gauge-svg");

--- a/desktop/src/renderer/styles/composer-token-gauge.css
+++ b/desktop/src/renderer/styles/composer-token-gauge.css
@@ -5,9 +5,14 @@
   --token-gauge-mid: #d48345;
   --token-gauge-high: var(--accent-warm);
   --token-gauge-track: rgba(138, 142, 145, 0.24);
+  --token-gauge-tooltip-bg: var(--paper);
+  --token-gauge-tooltip-border: rgba(15, 17, 21, 0.08);
+  --token-gauge-tooltip-shadow: 0 6px 22px rgba(15, 17, 21, 0.12);
+  --composer-token-gauge-focus-outline: rgba(95, 99, 104, 0.55);
 }
 
 .composer-token-gauge {
+  position: relative;
   display: inline-flex;
   min-width: 0;
   align-items: center;
@@ -17,9 +22,16 @@
   user-select: none;
   line-height: 1;
   cursor: default;
+  outline: none;
   transition:
     color 420ms var(--ease-out),
     opacity var(--motion-slow) var(--ease-out);
+}
+
+.composer-token-gauge:focus-visible {
+  outline: 2px solid var(--composer-token-gauge-focus-outline);
+  outline-offset: 2px;
+  border-radius: 999px;
 }
 
 .composer-token-gauge .composer-token-gauge-svg {
@@ -83,6 +95,24 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: currentColor;
+}
+
+/* Hover/focus tooltip. Mounted in the shared floating-menu layer so the
+   composer toolbar's overflow clipping cannot hide the value when the
+   inline label is collapsed at narrow widths. */
+.composer-token-gauge-tooltip {
+  width: 160px;
+  padding: 6px 10px;
+  background: var(--token-gauge-tooltip-bg);
+  border: 1px solid var(--token-gauge-tooltip-border);
+  border-radius: 8px;
+  box-shadow: var(--token-gauge-tooltip-shadow);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--ink);
+  text-align: center;
+  pointer-events: none;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
When the composer toolbar is narrowed by the container query, the inline token speed label is hidden and the rate becomes inaccessible. This PR mirrors the context meter pattern: keep the inline label visible when space permits, and show the same value in a hover/focus tooltip so users can still see the speed on narrow bars.

Changes:
- Add a `FloatingMenuPortal` tooltip to `ComposerTokenGauge` that appears on hover/focus.
- Add `composer-token-gauge` to `FloatingMenuOwner`.
- Style the tooltip to match the context meter hover card.
- Update `ComposerView.test.tsx` to assert the tooltip appears on hover.

Tested:
- `npx vitest run src/renderer/ComposerView.test.tsx -t "ComposerTokenGauge"` passes.
- `npm run typecheck` passes.