### PR TITLE
test(process): extend SIGTERM grace in flaky command test

### DIFF
--- a/internal/process/command_test.go
+++ b/internal/process/command_test.go
@@ -46,7 +46,7 @@ while :; do sleep 1; done
 		t.Fatal(err)
 	}
 
-	if err := handle.Stop(200 * time.Millisecond); err != nil {
+	if err := handle.Stop(2 * time.Second); err != nil {
 		t.Fatal(err)
 	}
 	if err := handle.Wait(); err != nil {


### PR DESCRIPTION
Extend the Stop() grace window in `TestCommandHandleStopAllowsCleanupAndKillsDescendants` from 200ms to 2s.

Under CI load, the parent shell sometimes had not run its TERM trap and written the cleanup marker before the force-kill was sent to the process group. The 2s window matches `Manager.Stop` and gives the cleanup a reliable chance to complete.

Fixes the flaky failure seen in CI on #131, #121, and #133.