### PR TITLE
fix(desktop): allow environment panel with docked right panel

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2432,11 +2432,15 @@ export function App(): JSX.Element {
     state.lastViewedMessageSeqByThreadID,
   ]);
   const sideThreadPanelVisible = Boolean(activeThreadID && sideThread.entry?.open);
+  // The environment panel floats inside the conversation pane, so it can
+  // coexist with the docked workspace right panel. Only the globalized
+  // (full-window sheet) right panel blocks it, because that mode makes the
+  // entire conversation pane inert.
   const environmentPanelCanShow = Boolean(
     state.initialized &&
     !poppedOutMode &&
     !previewingLaunch &&
-    !rightPanelOpen &&
+    !rightPanelGlobalized &&
     !openSubthreadPanel &&
     !participantPanel &&
     !sideThreadPanelVisible,


### PR DESCRIPTION
## Problem

When the workspace right panel (the docked right sidebar) is open, the environment/info panel cannot be opened. This is unnecessarily restrictive because the environment panel floats inside the conversation pane and does not overlap with the docked right panel.

## Change

Change the visibility gate from `!rightPanelOpen` to `!rightPanelGlobalized` so the environment panel is only blocked when the right panel is in the full-window "globalized" sheet mode. In that mode the conversation pane is `inert`, so the environment panel cannot be interacted with anyway.

## Verification

- `npm run typecheck` passes
- Relevant unit tests pass: `EnvironmentActions`, `EnvironmentSideStack`, `AppLayoutState`, `App`