### PR TITLE
perf(desktop): memoize conversation turns on server-event re-renders

### DIFF
--- a/desktop/src/renderer/CachedConversationPanes.tsx
+++ b/desktop/src/renderer/CachedConversationPanes.tsx
@@ -7,6 +7,7 @@ import type {
   MessageMarkWire,
   Thread,
   ThreadItem,
+  Turn,
 } from "../shared/protocol";
 import {
   chatReaderCountForThread,
@@ -29,13 +30,13 @@ import {
   pendingComposerMessagesForThread as pendingComposerMessagesForThreadSnapshot,
   type PendingComposerMessagesByThread,
 } from "./ComposerPendingMessages";
-import {
-  TurnView,
-  latestAgentMessageItemID,
-} from "./TurnView";
+import { TurnView } from "./TurnView";
 import { turnEventForTurn } from "./TurnEvents";
 import type { TurnFileDiffSelection } from "./TurnFileDiffTypes";
-import { turnHasAssistantOutput } from "./TurnViewHelpers";
+import {
+  latestAgentMessageLocation,
+  turnHasAssistantOutput,
+} from "./TurnViewHelpers";
 import type { HistoryMessageEditState } from "./ConversationHistoryActions";
 
 const CONVERSATION_GRID_COLUMNS = 12;
@@ -231,9 +232,64 @@ const CachedConversationPane = memo(function CachedConversationPane({
     (path: string) => onOpenFile?.(threadRef.current, path),
     [onOpenFile],
   );
+  // Memo-safe callbacks: PaneTurnView is React.memo'd, so every function prop
+  // must keep a stable identity across re-renders or the bailout never fires.
+  // They read the live thread through threadRef (same pattern as
+  // handleOpenFile) instead of closing over the render-scope thread.
+  const handleOpenAgentByID = useCallback(
+    (agentID: string) => {
+      const agent = threadRef.current.child_agents?.find(
+        (candidate) => candidate.id === agentID,
+      );
+      if (agent) {
+        void onOpenAgent(agent);
+      }
+    },
+    [onOpenAgent],
+  );
+  const handleForkMessage = useCallback(
+    (turnID: string, itemID: string) =>
+      onForkMessage(threadRef.current, turnID, itemID),
+    [onForkMessage],
+  );
+  const handleEditMessage = useCallback(
+    (turnID: string, item: ThreadItem) =>
+      onEditMessage(threadRef.current, turnID, item),
+    [onEditMessage],
+  );
+  const handleSubmitEditMessage = useCallback(
+    (
+      turnID: string,
+      item: ThreadItem,
+      text: string,
+      images: InputImage[],
+      files: InputFile[],
+    ) =>
+      onSubmitEditMessage(
+        threadRef.current,
+        turnID,
+        item,
+        text,
+        images,
+        files,
+      ),
+    [onSubmitEditMessage],
+  );
+  const handleOpenFileDiffSelection = useCallback(
+    (selection: TurnFileDiffSelection) =>
+      onOpenFileDiff(threadRef.current, selection),
+    [onOpenFileDiff],
+  );
+  const handleOpenTurnRunsForThread = useCallback(
+    (turnID: string) => onOpenTurnRuns?.(threadRef.current, turnID),
+    [onOpenTurnRuns],
+  );
   const threadTurns = thread.turns ?? [];
   const pendingChatMessages = pendingChatMessagesByThread[thread.id]?.queued;
-  const threadLatestAgentMessageID = latestAgentMessageItemID(threadTurns);
+  // Location (owner turn + item) lets renderTurn scope latestAgentMessageID to
+  // the one turn that can match it, so a new agent message re-renders only
+  // the previous and next owner turns instead of every PaneTurnView.
+  const latestAgentLocation = latestAgentMessageLocation(threadTurns);
   const threadContextEntries = contextCompositionEntries.filter(
     (entry) => entry.threadID === thread.id,
   );
@@ -464,47 +520,28 @@ const CachedConversationPane = memo(function CachedConversationPane({
               historyMessageEdit ? [historyMessageEdit.turnID] : undefined
             }
             renderTurn={(turn) => (
-              <TurnView
+              <PaneTurnView
                 turn={turn}
                 cwd={thread.cwd ?? activeContextCwd}
                 onOpenFile={onOpenFile ? handleOpenFile : undefined}
-                onOpenAgent={(agentID) => {
-                  const agent = thread.child_agents?.find(
-                    (candidate) => candidate.id === agentID,
-                  );
-                  if (agent) {
-                    void onOpenAgent(agent);
-                  }
-                }}
-                latestAgentMessageID={threadLatestAgentMessageID}
-                isLatestTurn={
-                  thread.turns[thread.turns.length - 1]?.id === turn.id
-                }
-                onStreamFrame={onStreamFrame}
-                onCollapseComplete={onCollapseComplete}
-                onForkMessage={(turnID, itemID) =>
-                  onForkMessage(thread, turnID, itemID)
-                }
-                onEditMessage={
-                  canEditThreadMessage(thread)
-                    ? (turnID, item) => onEditMessage(thread, turnID, item)
+                onOpenAgent={handleOpenAgentByID}
+                latestAgentMessageID={
+                  latestAgentLocation?.turnID === turn.id
+                    ? latestAgentLocation.itemID
                     : undefined
                 }
+                isLatestTurn={latestTurn?.id === turn.id}
+                onStreamFrame={onStreamFrame}
+                onCollapseComplete={onCollapseComplete}
+                onForkMessage={handleForkMessage}
+                canEdit={canEditThreadMessage(thread)}
+                onEditMessage={handleEditMessage}
                 editingMessage={historyMessageEdit}
                 onCancelEditMessage={onCancelEditMessage}
-                onSubmitEditMessage={(turnID, item, text, images, files) =>
-                  onSubmitEditMessage(
-                    thread,
-                    turnID,
-                    item,
-                    text,
-                    images,
-                    files,
-                  )
-                }
-                onOpenFileDiff={(selection) => onOpenFileDiff(thread, selection)}
-                onOpenRuns={
-                  onOpenTurnRuns ? () => onOpenTurnRuns(thread, turn.id) : undefined
+                onSubmitEditMessage={handleSubmitEditMessage}
+                onOpenFileDiff={handleOpenFileDiffSelection}
+                onOpenTurnRuns={
+                  onOpenTurnRuns ? handleOpenTurnRunsForThread : undefined
                 }
                 streamStatus={
                   latestTurn?.id === turn.id ? latestTurnStreamStatus : undefined
@@ -515,6 +552,87 @@ const CachedConversationPane = memo(function CachedConversationPane({
         )}
       </div>
     </div>
+  );
+});
+
+type PaneTurnViewProps = {
+  turn: Turn;
+  cwd?: string;
+  latestAgentMessageID?: string;
+  isLatestTurn: boolean;
+  canEdit: boolean;
+  editingMessage?: HistoryMessageEditState;
+  streamStatus?: TurnStreamStatus;
+  onOpenFile?: (path: string) => void;
+  onOpenAgent: (agentID: string) => void;
+  onStreamFrame: () => void;
+  onCollapseComplete: () => void;
+  onForkMessage: (turnID: string, itemID: string) => void;
+  onEditMessage: (turnID: string, item: ThreadItem) => void;
+  onCancelEditMessage: () => void;
+  onSubmitEditMessage: (
+    turnID: string,
+    item: ThreadItem,
+    text: string,
+    images: InputImage[],
+    files: InputFile[],
+  ) => void;
+  onOpenFileDiff: (selection: TurnFileDiffSelection) => void;
+  onOpenTurnRuns?: (turnID: string) => void;
+};
+
+// Memo boundary for the turn tree. Server events (item/started, item/
+// completed, turn/completed) rebuild the thread object but preserve the
+// identity of every turn they did not touch, so a memoized per-turn wrapper
+// lets hundreds of untouched TurnView subtrees bail out of the re-render
+// instead of reconciling the whole conversation on every event. All props
+// must be value-compared or identity-stable — every callback the pane passes
+// is a useCallback reading through threadRef for exactly that reason.
+const PaneTurnView = memo(function PaneTurnView({
+  turn,
+  cwd,
+  latestAgentMessageID,
+  isLatestTurn,
+  canEdit,
+  editingMessage,
+  streamStatus,
+  onOpenFile,
+  onOpenAgent,
+  onStreamFrame,
+  onCollapseComplete,
+  onForkMessage,
+  onEditMessage,
+  onCancelEditMessage,
+  onSubmitEditMessage,
+  onOpenFileDiff,
+  onOpenTurnRuns,
+}: PaneTurnViewProps): JSX.Element {
+  // TurnView's onOpenRuns takes no argument; bind the turn id here so the
+  // pane-level callback can stay identity-stable (per-turn inline closures
+  // would defeat the memo).
+  const handleOpenRuns = useCallback(
+    () => onOpenTurnRuns?.(turn.id),
+    [onOpenTurnRuns, turn.id],
+  );
+  return (
+    <TurnView
+      turn={turn}
+      cwd={cwd}
+      onOpenFile={onOpenFile}
+      onOpenAgent={onOpenAgent}
+      latestAgentMessageID={latestAgentMessageID}
+      isLatestTurn={isLatestTurn}
+      onStreamFrame={onStreamFrame}
+      onCollapseComplete={onCollapseComplete}
+      onForkMessage={onForkMessage}
+      onEditMessage={canEdit ? onEditMessage : undefined}
+      editingMessage={editingMessage}
+      onCancelEditMessage={onCancelEditMessage}
+      onSubmitEditMessage={onSubmitEditMessage}
+      onOpenFileDiff={onOpenFileDiff}
+      onOpenRuns={onOpenTurnRuns ? handleOpenRuns : undefined}
+      streamStatus={streamStatus}
+    />
   );
 });
 

--- a/desktop/src/renderer/ConversationTurnList.tsx
+++ b/desktop/src/renderer/ConversationTurnList.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import type { Turn } from "../shared/protocol";
 import { queryTextForUserItem } from "./AppState";
 import {
@@ -67,6 +74,19 @@ export function ConversationTurnList({
     turns.length - TURN_LIST_RECENT_FULL_TURNS,
   );
 
+  // Identity-stable expander: TurnListEntry memoizes its children on turn
+  // identity, which only works if this callback never changes between renders.
+  const expandTurn = useCallback((turnID: string) => {
+    setExpandedTurnIDs((current) => {
+      if (current.has(turnID)) {
+        return current;
+      }
+      const next = new Set(current);
+      next.add(turnID);
+      return next;
+    });
+  }, []);
+
   return (
     <>
       {renderBeforeTurns}
@@ -82,16 +102,7 @@ export function ConversationTurnList({
             key={turn.id}
             turn={turn}
             full={full}
-            onExpand={() =>
-              setExpandedTurnIDs((current) => {
-                if (current.has(turn.id)) {
-                  return current;
-                }
-                const next = new Set(current);
-                next.add(turn.id);
-                return next;
-              })
-            }
+            onExpand={expandTurn}
             renderTurn={renderTurn}
             renderAfterTurn={renderAfterTurn}
           />
@@ -111,23 +122,30 @@ function TurnListEntry({
 }: {
   turn: Turn;
   full: boolean;
-  onExpand: () => void;
+  onExpand: (turnID: string) => void;
   renderTurn: (turn: Turn) => ReactNode;
   renderAfterTurn?: (turn: Turn) => ReactNode;
 }): JSX.Element {
+  // CollapsedTurnView is memoized on turn identity (untouched turns keep
+  // their object across server events); the expand callback must be equally
+  // stable or it defeats that memo on every list render.
+  const handleExpand = useCallback(() => onExpand(turn.id), [onExpand, turn.id]);
   return (
     <>
       {full ? (
         renderTurn(turn)
       ) : (
-        <CollapsedTurnView turn={turn} onExpand={onExpand} />
+        <CollapsedTurnView turn={turn} onExpand={handleExpand} />
       )}
       {renderAfterTurn?.(turn)}
     </>
   );
 }
 
-function CollapsedTurnView({
+// Memoized on turn identity: server events rebuild the thread object but
+// keep untouched turns referentially equal, so hundreds of collapsed rows
+// skip re-rendering (and skip re-running their snippet scans) on each event.
+const CollapsedTurnView = memo(function CollapsedTurnView({
   turn,
   onExpand,
 }: {
@@ -179,7 +197,7 @@ function CollapsedTurnView({
       </button>
     </section>
   );
-}
+});
 
 function compactPreview(text: string, maxLength = 180): string {
   const compact = text.replace(/\s+/g, " ").trim();

--- a/desktop/src/renderer/TurnMemoization.test.tsx
+++ b/desktop/src/renderer/TurnMemoization.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Render-bailout guarantees for the conversation turn tree.
+ *
+ * Server events (item/started, item/completed, turn/completed) rebuild the
+ * thread object but preserve the identity of every turn they did not touch.
+ * PaneTurnView (in CachedConversationPanes) and CollapsedTurnView (in
+ * ConversationTurnList) are memoized on that identity, so an event targeting
+ * one turn must not re-render the subtrees of the others. These tests pin
+ * that contract: without it, every tool-call completion in a long session
+ * reconciles the entire conversation (measured ~110ms at 2000 turns).
+ */
+import { act, createElement, type ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Thread, Turn } from "../shared/protocol";
+import { CachedConversationPanes } from "./CachedConversationPanes";
+import { ImagePreviewProvider } from "./ImagePreview";
+
+const turnViewRenders = vi.hoisted(() => new Map<string, number>());
+const replySnippetCalls = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("./TurnView", () => ({
+  TurnView: ({ turn }: { turn: Turn }): JSX.Element => {
+    turnViewRenders.set(turn.id, (turnViewRenders.get(turn.id) ?? 0) + 1);
+    return <section data-turn-id={turn.id} data-testid={`full-${turn.id}`} />;
+  },
+  latestAgentMessageItemID: (): undefined => undefined,
+  scrollToUserMessage: (): void => {},
+}));
+
+vi.mock("./TurnViewHelpers", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./TurnViewHelpers")>();
+  return {
+    ...original,
+    turnReplySnippet: (turn: Turn) => {
+      replySnippetCalls.count += 1;
+      return original.turnReplySnippet(turn);
+    },
+  };
+});
+
+let roots: Root[] = [];
+
+afterEach(() => {
+  for (const root of roots) {
+    act(() => root.unmount());
+  }
+  roots = [];
+  turnViewRenders.clear();
+  replySnippetCalls.count = 0;
+  document.body.innerHTML = "";
+});
+
+function makeTurn(index: number, status: Turn["status"] = "completed"): Turn {
+  return {
+    id: `turn-${index}`,
+    status,
+    items_view: "full",
+    items: [
+      {
+        id: `turn-${index}-user`,
+        type: "user_message",
+        text: `question ${index}`,
+      },
+      {
+        id: `turn-${index}-agent`,
+        type: "agent_message",
+        text: `answer ${index}`,
+        status: "completed",
+      },
+    ],
+  } as Turn;
+}
+
+function threadWithTurns(id: string, turns: Turn[]): Thread {
+  return {
+    id,
+    preview: id,
+    title: id,
+    model_provider: "test",
+    model: "test",
+    cwd: "/tmp/wuu",
+    status: "idle",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    turns,
+  } as Thread;
+}
+
+// Stable callback identities, mirroring the App's useStableCallback wiring:
+// PaneTurnView's memo only bails out when every callback prop keeps its
+// identity across App re-renders, which the real App guarantees. Recreating
+// them per render in this harness would measure the test, not the component.
+const stableCallbacks = {
+  onStreamFrame: () => {},
+  onCollapseComplete: () => {},
+  onDismissContextComposition: () => {},
+  onDismissInstructions: () => {},
+  canEditThreadMessage: () => false,
+  onForkMessage: () => {},
+  onOpenAgent: () => {},
+  onOpenSubthread: () => {},
+  onReact: () => {},
+  onEditMessage: () => {},
+  onCancelEditMessage: () => {},
+  onSubmitEditMessage: () => {},
+  onOpenFileDiff: () => {},
+  resolveParticipantName: (id: string) => id,
+};
+
+const stableCollections = {
+  contextCompositionEntries: [],
+  instructionFilesEntries: [],
+  turnStreamStatus: {},
+  busyParticipantIDs: new Set<string>(),
+  activeThreadMarks: [],
+  pendingChatMessagesByThread: {},
+};
+
+function paneProps(thread: Thread): ComponentProps<typeof CachedConversationPanes> {
+  return {
+    threadIDs: [thread.id],
+    threadsByID: new Map([[thread.id, thread]]),
+    activeThreadID: thread.id,
+    conversationGridVisible: false,
+    chatReaderCount: 0,
+    ...stableCallbacks,
+    ...stableCollections,
+  };
+}
+
+function mountPanes(thread: Thread): {
+  container: HTMLElement;
+  rerender: (next: Thread) => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const renderWith = (current: Thread): JSX.Element => (
+    <ImagePreviewProvider>
+      <CachedConversationPanes {...paneProps(current)} />
+    </ImagePreviewProvider>
+  );
+  act(() => {
+    root.render(renderWith(thread));
+  });
+  return {
+    container,
+    rerender: (next: Thread) => {
+      act(() => {
+        root.render(renderWith(next));
+      });
+    },
+  };
+}
+
+describe("conversation turn memoization", () => {
+  it("re-renders only the turn a server event touched", () => {
+    const turns = [makeTurn(1), makeTurn(2), makeTurn(3)];
+    const thread = threadWithTurns("thread-memo", turns);
+    const { rerender } = mountPanes(thread);
+
+    expect(turnViewRenders.get("turn-1")).toBe(1);
+    expect(turnViewRenders.get("turn-2")).toBe(1);
+    expect(turnViewRenders.get("turn-3")).toBe(1);
+
+    // Simulate item/completed landing on turn-3: new thread + new turn-3
+    // object, turn-1/turn-2 referentially untouched (upsertTurnItem shape).
+    const updated = threadWithTurns("thread-memo", [
+      turns[0],
+      turns[1],
+      {
+        ...turns[2],
+        items: [
+          ...turns[2].items,
+          {
+            id: "turn-3-tool",
+            type: "tool_call",
+            name: "bash",
+            status: "completed",
+          },
+        ],
+      } as Turn,
+    ]);
+    rerender(updated);
+
+    expect(turnViewRenders.get("turn-1")).toBe(1);
+    expect(turnViewRenders.get("turn-2")).toBe(1);
+    expect(turnViewRenders.get("turn-3")).toBe(2);
+  });
+
+  it("collapsed turns skip re-render and snippet recompute on events", () => {
+    // 90 turns: beyond TURN_LIST_COLLAPSE_THRESHOLD (80), so the oldest 50
+    // render collapsed and the newest 40 render full.
+    const turns = Array.from({ length: 90 }, (_, index) => makeTurn(index + 1));
+    const thread = threadWithTurns("thread-collapsed", turns);
+    const { container, rerender } = mountPanes(thread);
+
+    const collapsedCount = () =>
+      container.querySelectorAll(".turn-collapsed").length;
+    expect(collapsedCount()).toBe(50);
+    const snippetsAfterMount = replySnippetCalls.count;
+    expect(snippetsAfterMount).toBe(50);
+    expect(turnViewRenders.get("turn-90")).toBe(1);
+
+    const updated = threadWithTurns("thread-collapsed", [
+      ...turns.slice(0, 89),
+      {
+        ...turns[89],
+        items: [
+          ...turns[89].items,
+          {
+            id: "turn-90-tool",
+            type: "tool_call",
+            name: "read_file",
+            status: "completed",
+          },
+        ],
+      } as Turn,
+    ]);
+    rerender(updated);
+
+    // Only the touched full turn re-renders; no collapsed row recomputed.
+    expect(turnViewRenders.get("turn-90")).toBe(2);
+    expect(turnViewRenders.get("turn-89")).toBe(1);
+    expect(replySnippetCalls.count).toBe(snippetsAfterMount);
+    expect(collapsedCount()).toBe(50);
+  });
+
+  it("still expands a collapsed turn on click after memoization", () => {
+    const turns = Array.from({ length: 90 }, (_, index) => makeTurn(index + 1));
+    const thread = threadWithTurns("thread-expand", turns);
+    const { container } = mountPanes(thread);
+
+    expect(turnViewRenders.get("turn-1")).toBeUndefined();
+    const expandButton = container.querySelector<HTMLButtonElement>(
+      '[data-turn-id="turn-1"] .turn-collapsed-button',
+    );
+    expect(expandButton).not.toBeNull();
+    act(() => {
+      expandButton!.click();
+    });
+    expect(turnViewRenders.get("turn-1")).toBe(1);
+  });
+});

--- a/desktop/src/renderer/TurnViewHelpers.ts
+++ b/desktop/src/renderer/TurnViewHelpers.ts
@@ -506,6 +506,22 @@ export function latestAgentMessageItemID(turns: Turn[]): string | undefined {
   return undefined;
 }
 
+// Same scan as latestAgentMessageItemID, but also reports which turn owns the
+// item. Callers rendering per-turn subtrees can then scope the "latest"
+// affordance to the owner turn instead of handing every turn an id it can
+// never match (item ids are unique per thread).
+export function latestAgentMessageLocation(
+  turns: Turn[],
+): { turnID: string; itemID: string } | undefined {
+  for (let turnIndex = turns.length - 1; turnIndex >= 0; turnIndex--) {
+    const itemID = latestAgentMessageItemIDForTurn(turns[turnIndex]);
+    if (itemID) {
+      return { turnID: turns[turnIndex].id, itemID };
+    }
+  }
+  return undefined;
+}
+
 function latestAgentMessageItemIDForTurn(turn: Turn): string | undefined {
   for (let itemIndex = turn.items.length - 1; itemIndex >= 0; itemIndex--) {
     const item = turn.items[itemIndex];


### PR DESCRIPTION
## Problem

Every server event that upserts a turn item (`item/started`, `item/completed`, `turn/completed`) rebuilds the thread object in the renderer but preserves the identity of every turn it did not touch. The conversation pane ignored that property: each event reconciled the entire `TurnView` tree. Measured with the real component tree in jsdom (2000 turns, realistic markdown + tool-call content): **~110ms of synchronous main-thread work per event** — a visible stall on every tool-call completion in long sessions, scaling linearly (~245ms at 5000 turns).

## Change

Add a memo boundary at the turn level:

- **`PaneTurnView`** (new, in `CachedConversationPanes.tsx`) wraps `TurnView` in `React.memo`. Every callback the pane passes down is now identity-stable — `useCallback` reading the live thread through `threadRef`, the same pattern the pane already used for `handleOpenFile`. `onOpenRuns` moves its per-turn closure into the wrapper so the pane-level handler stays stable. `TurnView`'s public API is unchanged (four other call sites untouched).
- **`latestAgentMessageID` is scoped to the owning turn** via a new `latestAgentMessageLocation` helper. Item ids are unique per thread, so non-owner turns previously behaved exactly as if it were `undefined` — this is behavior-identical, and means a new agent message re-renders only the previous/next owner turns instead of every turn.
- **`CollapsedTurnView`** gets the same memo, with the expand callback stabilized through a shared `useCallback`, so hundreds of collapsed rows skip re-rendering (and skip their snippet scans) on each event.

## Measured impact

jsdom probe with the real pane tree, 2000 turns:

| update shape | before | after |
|---|---|---|
| item event on one turn (the frequent streaming case) | ~110ms | ~16–31ms |
| resume snapshot refresh (all identities fresh) | ~130ms | ~130ms (unchanged by design) |

The residual item-event cost is pane-level O(items) bookkeeping scans plus the one touched `TurnView`. The resume-snapshot path cannot bail out (every turn arrives with a fresh identity); fixing that needs server-side pagination/incremental snapshots and is deliberately out of scope.

## Non-goals / verified unaffected

- **Turn rail**: reads `turns` at the App level and anchors to turn DOM ids, both untouched.
- **Chat-style threads (DM/group)**: use their own windowed `ChatThreadView`, not this path.
- **Streaming text**: flows through `streamTextStore` external-store subscriptions, independent of ancestor re-renders — memo cannot freeze live tokens.
- **Context-composition cards**: rendered via `renderAfterTurn` outside the memo boundary, still update on every pane render.

## Tests

- New `TurnMemoization.test.tsx` pins the bailout contract: an item event re-renders only the touched turn, collapsed rows do not recompute snippets, and expanding a collapsed turn still works after memoization.
- Full renderer suite: 186 files / 2148 tests pass; `tsc --noEmit` clean.