### PR TITLE
fix(desktop): stable single-line retry error display

### DIFF
--- a/desktop/src/renderer/AppState.test.ts
+++ b/desktop/src/renderer/AppState.test.ts
@@ -1072,6 +1072,214 @@ describe("AppState token usage", () => {
     });
   });
 
+  it("names the failure cause in the single reconnect chip instead of the transport", () => {
+    const thread: Thread = {
+      ...threadWithUserTexts(["hi"]),
+      turns: [
+        {
+          id: "turn-1",
+          items_view: "full",
+          status: "in_progress",
+          items: [],
+        },
+      ],
+    };
+    const state = {
+      ...initialState,
+      thread,
+      threads: [thread],
+      running: true,
+    };
+    const reconnectEvent = {
+      kind: "notification" as const,
+      workdir: "/repo",
+      message: {
+        method: "turn/event",
+        params: {
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          event: {
+            lifecycle: {
+              phase: "reconnecting",
+              attempt: 2,
+              max_attempts: 6,
+              retry_in_ms: 5000,
+              failure_category: "rate_limit",
+              reason: "Provider is overloaded",
+            },
+          },
+        },
+      },
+    };
+
+    const first = reduceServerEvent(state, reconnectEvent);
+    expect(turnStreamStatusForThread(first, first.thread)).toEqual({
+      text: "429 触发限流，约 5 秒后继续（第 2/6 次尝试）",
+      liveProgress: true,
+    });
+
+    // A later attempt with a shorter wait updates the same chip in place —
+    // the turn keeps exactly one status entry, never one per attempt.
+    const second = reduceServerEvent(first, {
+      ...reconnectEvent,
+      message: {
+        ...reconnectEvent.message,
+        params: {
+          ...reconnectEvent.message.params,
+          event: {
+            lifecycle: {
+              phase: "reconnecting",
+              attempt: 3,
+              max_attempts: 6,
+              retry_in_ms: 2000,
+              failure_category: "rate_limit",
+              reason: "Provider is overloaded",
+            },
+          },
+        },
+      },
+    });
+    expect(Object.keys(second.turnStreamStatus)).toEqual(["turn-1"]);
+    expect(turnStreamStatusForThread(second, second.thread)).toEqual({
+      text: "429 触发限流，约 2 秒后继续（第 3/6 次尝试）",
+      liveProgress: true,
+    });
+  });
+
+  it("names auth recovery in the reconnect chip without a wait hint", () => {
+    const thread: Thread = {
+      ...threadWithUserTexts(["hi"]),
+      turns: [
+        {
+          id: "turn-1",
+          items_view: "full",
+          status: "in_progress",
+          items: [],
+        },
+      ],
+    };
+    const state = {
+      ...initialState,
+      thread,
+      threads: [thread],
+      running: true,
+    };
+
+    const reconnecting = reduceServerEvent(state, {
+      kind: "notification",
+      workdir: "/repo",
+      message: {
+        method: "turn/event",
+        params: {
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          event: {
+            lifecycle: {
+              phase: "reconnecting",
+              attempt: 2,
+              failure_category: "authentication",
+              reason: "Authentication failed",
+            },
+          },
+        },
+      },
+    });
+
+    expect(turnStreamStatusForThread(reconnecting, reconnecting.thread)).toEqual({
+      text: "认证失败，正在重连中（第 2 次尝试）",
+      liveProgress: true,
+    });
+  });
+
+  it("falls back to the redacted reason summary when failure_category is absent", () => {
+    const thread: Thread = {
+      ...threadWithUserTexts(["hi"]),
+      turns: [
+        {
+          id: "turn-1",
+          items_view: "full",
+          status: "in_progress",
+          items: [],
+        },
+      ],
+    };
+    const state = {
+      ...initialState,
+      thread,
+      threads: [thread],
+      running: true,
+    };
+
+    const reconnecting = reduceServerEvent(state, {
+      kind: "notification",
+      workdir: "/repo",
+      message: {
+        method: "turn/event",
+        params: {
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          event: {
+            lifecycle: {
+              phase: "reconnecting",
+              attempt: 1,
+              reason: "Provider is overloaded",
+            },
+          },
+        },
+      },
+    });
+
+    expect(turnStreamStatusForThread(reconnecting, reconnecting.thread)).toEqual({
+      text: "上游过载，正在重连中（第 1 次尝试）",
+      liveProgress: true,
+    });
+  });
+
+  it("keeps the transport wording when the reconnect cause is unknown", () => {
+    const thread: Thread = {
+      ...threadWithUserTexts(["hi"]),
+      turns: [
+        {
+          id: "turn-1",
+          items_view: "full",
+          status: "in_progress",
+          items: [],
+        },
+      ],
+    };
+    const state = {
+      ...initialState,
+      thread,
+      threads: [thread],
+      running: true,
+    };
+
+    const reconnecting = reduceServerEvent(state, {
+      kind: "notification",
+      workdir: "/repo",
+      message: {
+        method: "turn/event",
+        params: {
+          thread_id: "thread-1",
+          turn_id: "turn-1",
+          event: {
+            lifecycle: {
+              phase: "reconnecting",
+              attempt: 1,
+              failure_category: "replay_unsafe",
+              reason: "Automatic replay blocked to avoid duplicate tool execution",
+            },
+          },
+        },
+      },
+    });
+
+    expect(turnStreamStatusForThread(reconnecting, reconnecting.thread)).toEqual({
+      text: "消息流正在恢复（第 1 次尝试）",
+      liveProgress: true,
+    });
+  });
+
   it("explains when automatic replay stops to avoid duplicate tools", () => {
     const thread: Thread = {
       ...threadWithUserTexts(["hi"]),

--- a/desktop/src/renderer/AppState.ts
+++ b/desktop/src/renderer/AppState.ts
@@ -1023,12 +1023,78 @@ function streamStatusFromLifecycle(
         },
       )
     : attemptText;
+  // While the stream is being retried, this chip is the only place the
+  // failure shows up — name the cause (429, auth refresh, …) instead of the
+  // transport so the single line answers "what is being retried".
+  const cause = reconnectCauseLabel(lifecycle);
+  if (cause) {
+    return {
+      text: waitText
+        ? t("appState.reconnectingCauseAfter", {
+            cause,
+            wait: waitText,
+            progress: progressText,
+          })
+        : t("appState.reconnectingCause", { cause, progress: progressText }),
+      liveProgress: true,
+    };
+  }
   return {
     text: waitText
       ? t("appState.reconnectingAfter", { subject, wait: waitText, progress: progressText })
       : t("appState.reconnecting", { subject, progress: progressText }),
     liveProgress: true,
   };
+}
+
+/**
+ * Short localized label for the failure that triggered a stream reconnect,
+ * or undefined when nothing specific is known (the chip then falls back to
+ * the transport-subject wording). Prefers the lifecycle's structured
+ * `failure_category`; the redacted `reason` summary is only consulted for
+ * app-servers that predate the category field.
+ */
+function reconnectCauseLabel(lifecycle: JsonRecord): string | undefined {
+  const category = stringValue(lifecycle, "failure_category");
+  if (category) {
+    switch (category) {
+      case "authentication":
+        return t("error.authTitle");
+      case "rate_limit":
+      case "quota":
+        return `429 ${t("error.http429")}`;
+      case "overloaded":
+        return t("error.upstreamOverloaded");
+      case "server":
+        return t("error.providerTitle");
+      case "deadline":
+        return t("error.requestTimeout");
+      case "network":
+      case "incomplete_stream":
+        return t("error.networkTitle");
+      default:
+        // A category with no user-meaningful cause (replay_unsafe, budget
+        // limits, context overflow, …) keeps the transport wording.
+        return undefined;
+    }
+  }
+  const reason = stringValue(lifecycle, "reason")?.toLowerCase() ?? "";
+  if (!reason) {
+    return undefined;
+  }
+  if (reason.includes("authentication") || reason.includes("unauthorized")) {
+    return t("error.authTitle");
+  }
+  if (reason.includes("rate limit") || reason.includes("too many requests")) {
+    return `429 ${t("error.http429")}`;
+  }
+  if (reason.includes("overloaded")) {
+    return t("error.upstreamOverloaded");
+  }
+  if (reason.includes("timeout") || reason.includes("deadline")) {
+    return t("error.requestTimeout");
+  }
+  return undefined;
 }
 
 function retryWaitText(retryInMs: number | undefined): string | undefined {

--- a/desktop/src/renderer/AssistantTurnDisplay.tsx
+++ b/desktop/src/renderer/AssistantTurnDisplay.tsx
@@ -239,6 +239,14 @@ function shouldSuppressProcessErrorItem(turn: Turn, item: ThreadItem): boolean {
   if (turn.status === "failed") {
     return true;
   }
+  // A stream error item only lands while a retryable attempt has just failed
+  // terminally. If the turn is still running, the reconnect chip already
+  // names the cause; if it completed, the retry recovered — in both cases a
+  // settled error line would either pile up per attempt or stay behind as
+  // stale noise after a successful recovery.
+  if (turn.status === "in_progress" || turn.status === "completed") {
+    return true;
+  }
   // The turn-level interruption notice already explains user-initiated stops.
   // Rendering the matching cancellation error item here would show the same
   // stop twice in one turn.

--- a/desktop/src/renderer/TurnView.test.tsx
+++ b/desktop/src/renderer/TurnView.test.tsx
@@ -268,6 +268,36 @@ describe("TurnView", () => {
     expect(view.querySelectorAll(".turn-notice button, .turn-notice a")).toHaveLength(0);
   });
 
+  it("hides a transient stream error item while the turn is still retrying", () => {
+    // A retryable attempt that failed terminally lands an error item, but
+    // the turn keeps running (reconnect chip carries the cause). Rendering
+    // the item here would pile up one settled error line per attempt.
+    const view = render(
+      makeTurn("in_progress", [
+        makeCommentary("partial progress"),
+        makeError("HTTP 429: Too Many Requests"),
+      ]),
+    );
+
+    expect(view.querySelectorAll(".turn-notice")).toHaveLength(0);
+    expect(view.textContent).not.toContain("429");
+  });
+
+  it("drops a transient stream error item once the turn recovered and completed", () => {
+    // The retry succeeded: nothing about the superseded failure should stay
+    // behind in the finished turn.
+    const view = render(
+      makeTurn("completed", [
+        makeFinalAnswer("done"),
+        makeError("HTTP 429: Too Many Requests"),
+      ]),
+    );
+
+    expect(view.textContent).toContain("done");
+    expect(view.querySelectorAll(".turn-notice")).toHaveLength(0);
+    expect(view.textContent).not.toContain("429");
+  });
+
   it("renders a single warning chip when a completed turn has commentary but no final answer", () => {
     // Pin the chip-pipeline contract: a completed turn whose items
     // carry only `commentary` (no `final_answer`) now surfaces a

--- a/desktop/src/renderer/UserFacingErrors.test.ts
+++ b/desktop/src/renderer/UserFacingErrors.test.ts
@@ -187,7 +187,9 @@ describe("userFacingErrorForMessage", () => {
 
       expect(display.category).toBe("invalid_request");
       expect(display.tone).toBe("error");
-      expect(display.title).toBe("请求失败 · HTTP 400");
+      // The message-embedded status wins over the structured status_code
+      // fact so the wording survives a history rebuild (tab switch).
+      expect(display.title).toBe("400 请求无效");
       expect(display.detail).toBe("Provider 认为这次请求参数无效。原始错误已留在调试信息中。");
     });
 
@@ -238,6 +240,90 @@ describe("userFacingErrorForMessage", () => {
       expect(display.category).toBe("provider");
       expect(display.title).toBe("上下文超出窗口");
       expect(display).not.toHaveProperty("code");
+    });
+  });
+
+  describe("resume stability (tab switch rebuilds the turn from the persisted message only)", () => {
+    // After a thread resume the app-server rebuilds turn.error from the
+    // terminal history record: only `message` survives — status_code,
+    // code and category are lost. The renderer must derive the same
+    // category and title from the message alone as it did from the
+    // structured TurnError, or the user watches an error rename itself
+    // across a tab switch.
+    function expectResumeStable(input: TurnError, expectedCategory: string) {
+      const live = userFacingErrorForMessage(input, "turn");
+      const resumed = userFacingErrorForMessage(input.message, "turn");
+      expect(resumed.category).toBe(expectedCategory);
+      expect(resumed.title).toBe(live.title);
+      expect(resumed.tone).toBe(live.tone);
+    }
+
+    it("keeps a 429 rate-limit failure identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: 'HTTP 429: {"error":{"type":"rate_limit_error","message":"slow down"}}',
+          code: "rate_limit_error",
+          category: "provider",
+          status_code: 429,
+        },
+        "provider",
+      );
+    });
+
+    it("keeps a 429 whose body carries no provider keywords identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: "HTTP 429: Too Many Requests",
+          category: "provider",
+          status_code: 429,
+        },
+        "provider",
+      );
+    });
+
+    it("keeps a 401 auth failure identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: 'HTTP 401: {"error":{"message":"invalid api key"}}',
+          category: "auth",
+          status_code: 401,
+        },
+        "auth",
+      );
+    });
+
+    it("keeps a 400 invalid_request failure identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: 'HTTP 400: {"error":{"type":"invalid_request_error","message":"max_tokens must be positive"}}',
+          code: "invalid_request_error",
+          category: "invalid_request",
+          status_code: 400,
+        },
+        "invalid_request",
+      );
+    });
+
+    it("keeps a post-200 rate-limit stream error identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: "stream request failed: stream error (rate_limit_error)",
+          code: "rate_limit_error",
+          category: "provider",
+        },
+        "provider",
+      );
+    });
+
+    it("keeps a 503 upstream failure identical across a resume", () => {
+      expectResumeStable(
+        {
+          message: "HTTP 503: service unavailable",
+          category: "network",
+          status_code: 503,
+        },
+        "network",
+      );
     });
   });
 });

--- a/desktop/src/renderer/UserFacingErrors.ts
+++ b/desktop/src/renderer/UserFacingErrors.ts
@@ -147,6 +147,11 @@ function extractSpecificDisplay(
         return { title: t("error.contextExceeded") };
       }
       if (lower.includes("too many tokens")) return { title: t("error.tokenLimitExceeded") };
+      // A status code embedded in the message ("HTTP 429: …") is the one
+      // fact that survives a history rebuild, so it outranks keyword
+      // guesses — resume-safe identity beats phrasing.
+      const code = extractHttpCode(message);
+      if (code) return { title: httpTitle(code) };
       if (lower.includes("content policy") || lower.includes("content_policy")) return { title: t("error.contentPolicy") };
       if (lower.includes("rate_limit") || lower.includes("rate limit")) return { title: t("error.rateLimited") };
       if (lower.includes("model_not_found")) return { title: t("error.modelNotFound") };
@@ -218,9 +223,12 @@ export function userFacingErrorForMessage(
         : "internal"
       : classifyUserFacingError(message, context);
 
-  // Structured transport facts take precedence over inferred category
-  // labels. A post-200 provider failure has no HTTP status, so retain its
-  // provider code when no more specific localized state is available.
+  // Message-derived specifics win over structured transport facts: after a
+  // thread resume the turn snapshot is rebuilt from persisted history, which
+  // retains only the message — not status_code / code. A title that depends
+  // on structured fields would flip wording across a resume (tab switch), so
+  // the traceable title is kept only as the fallback for opaque messages
+  // (e.g. a post-200 provider failure whose message carries no status).
   const structuredCode = structuredProviderCode(structured);
   const specific = extractSpecificDisplay(message, category);
   const specificFromCode = structuredCode
@@ -233,9 +241,9 @@ export function userFacingErrorForMessage(
       ? `${t("error.requestFailedTitle")} · ${structuredCode}`
       : undefined;
   const title =
-    traceableFailureTitle ||
     specific.title ||
     specificFromCode.title ||
+    traceableFailureTitle ||
     defaultTitleForCategory(category);
   // Detail is hover and accessibility copy, not a visible second line.
   const detail =
@@ -343,7 +351,7 @@ function specificDetailForMessage(
   return undefined;
 }
 
-function classifyUserFacingError(message: string, context: UserFacingErrorContext): UserFacingErrorCategory {
+export function classifyUserFacingError(message: string, context: UserFacingErrorContext): UserFacingErrorCategory {
   const normalized = message.toLowerCase();
   if (isCancellationMessage(normalized)) {
     return "cancelled";
@@ -356,6 +364,9 @@ function classifyUserFacingError(message: string, context: UserFacingErrorContex
   }
   if (isProviderBusinessError(normalized)) {
     return "provider";
+  }
+  if (isInvalidRequestError(normalized)) {
+    return "invalid_request";
   }
   if (isNetworkOrUpstreamError(normalized)) {
     return "network";
@@ -394,7 +405,7 @@ function isAuthOrPermissionError(message: string): boolean {
 
 function isNetworkOrUpstreamError(message: string): boolean {
   return (
-    /\b(429|500|502|503|504|529)\b/.test(message) ||
+    /\b(500|502|503|504)\b/.test(message) ||
     message.includes("network") ||
     message.includes("stream request failed") ||
     message.includes("request failed") ||
@@ -417,6 +428,10 @@ function isNetworkOrUpstreamError(message: string): boolean {
 function isProviderBusinessError(message: string): boolean {
   return (
     isResponseCompletedMissingMessage(message) ||
+    // Mirror the Go core's HTTP mapping (categoryFromHTTPError): 413 is a
+    // context-overflow signal, 429/529 are rate limit / overloaded — all
+    // provider-side, never network faults.
+    /\b(413|429|529)\b/.test(message) ||
     message.includes("context_length_exceeded") ||
     message.includes("context window") ||
     message.includes("maximum context length") ||
@@ -428,7 +443,18 @@ function isProviderBusinessError(message: string): boolean {
     message.includes("response failed") ||
     message.includes("response error") ||
     message.includes("content policy") ||
-    message.includes("invalid_request_error")
+    message.includes("rate_limit")
+  );
+}
+
+// Message-only counterpart of the wire `invalid_request` category: keeps a
+// resumed turn (rebuilt from the persisted message, without structured
+// fields) classified the same as the live turn the Go core tagged.
+function isInvalidRequestError(message: string): boolean {
+  return (
+    message.includes("invalid_request") ||
+    message.includes("bad request") ||
+    message.includes("http 400")
   );
 }
 

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -877,6 +877,8 @@ export const enUS = {
   "appState.attemptRequests": "{attempt}, {count} requests sent",
   "appState.reconnectingAfter": "{subject} interrupted temporarily; continuing {wait} ({progress})",
   "appState.reconnecting": "{subject} is recovering ({progress})",
+  "appState.reconnectingCauseAfter": "{cause}; continuing {wait} ({progress})",
+  "appState.reconnectingCause": "{cause}; reconnecting ({progress})",
   "appState.retrySecond": "in about {count} second",
   "appState.retrySeconds": "in about {count} seconds",
   "appState.retryMinute": "in about {count} minute",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -875,6 +875,8 @@ export const zhCN = {
   "appState.attemptRequests": "{attempt}，已发送 {count} 次请求",
   "appState.reconnectingAfter": "{subject}暂时中断，{wait}（{progress}）",
   "appState.reconnecting": "{subject}正在恢复（{progress}）",
+  "appState.reconnectingCauseAfter": "{cause}，{wait}（{progress}）",
+  "appState.reconnectingCause": "{cause}，正在重连中（{progress}）",
   "appState.retrySecond": "约 {count} 秒后继续",
   "appState.retrySeconds": "约 {count} 秒后继续",
   "appState.retryMinute": "约 {count} 分钟后继续",


### PR DESCRIPTION
## What this fixes

Two renderer-side display problems around stream retry/reconnect (backend logic untouched):

1. **Retryable errors spammed the flow.** A terminally failed attempt lands an `error` item in the turn; while the turn kept retrying (or recovered and completed), those items rendered as settled red notices — one per attempt — and stayed behind even after a successful recovery.
2. **Error text was not stable across tab switches.** Switching tabs re-resumes the thread, and the app-server rebuilds `turn.error` from the terminal history record, which persists only the raw message. The live display depended on structured fields (`status_code` / `code` / `category`) that do not survive the rebuild, so the same failure could read A before and B after a tab switch.

## Changes (3 commits)

- **Stable error identity** (`UserFacingErrors`): message-derived specifics now outrank the structured-facts title ("请求失败 · HTTP 401"); the provider branch honors an HTTP status embedded in the message before keyword guesses; the string classifier mirrors the Go core's `categoryFromHTTPError` mapping (400-class → `invalid_request`, 413/429/529 → `provider`). Live and rebuilt turns render the same category/tone/title from the same persisted message.
- **Cause in the reconnect chip** (`AppState` + i18n): the single in-place reconnect chip now names what is being retried, from the lifecycle's `failure_category` (falling back to the redacted `reason` summary on older cores): `429 触发限流，约 5 秒后继续（第 2/6 次尝试）`, `认证失败，正在重连中（第 2 次尝试）`. Unknown categories keep the existing transport wording. The composer status row shares `streamStatus`, so it picks the same text up for free; the shimmer was already there via `live-progress-chip`.
- **No transient error notices** (`AssistantTurnDisplay`): `error` items are suppressed for `in_progress` and `completed` turns. During a retry the chip carries the cause; a failed turn still shows its single turn-level notice; a recovered turn leaves nothing behind — the only allowed non-steady transition.

## Tradeoffs / non-obvious impacts

- Live structured errors whose message contains an HTTP code now read e.g. "401 未授权" instead of "请求失败 · HTTP 401". That is the price of live/resume convergence; the traceable title is kept for opaque messages (post-200 provider failures with no status in the message).
- Residual divergence: if the raw message itself carries no status and no keywords, live (structured) and resumed (message-only) can still differ — the data simply was never persisted. Closing that gap would require persisting the structured `TurnError` into the terminal history record (backend change, deliberately out of scope here).
- `interrupted` turns still render non-cancellation error items (that is the only error signal an interrupted turn has), so interrupting exactly between a terminal stream failure and `turn/error` can reveal one extra notice. Rare and informative, kept intentionally.

## Verification

- Full desktop suite: 186 files / 2160 tests pass; `tsc --noEmit` clean.
- New tests pin: resume-stability (live structured vs message-only produce identical category/tone/title for 400/401/429/503 and post-200 stream errors), single in-place chip updates across attempts, cause labels incl. fallbacks, and error-item suppression for in_progress/completed turns.