### PR TITLE
fix(compact): recover model-aware summary output limits

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -239,6 +239,7 @@ func RunToolLoop(
 				TokensBefore:   before,
 				MessagesBefore: msgsBefore,
 				Error:          cerr.Error(),
+				OutputLimit:    compact.IsSummaryOutputLimit(cerr),
 			}, usageBefore))
 		case compactChanged(messages, compacted):
 			if compactOperationID := lineage.LastOperationID(); compactOperationID != "" && compactOperationID != lastAgentOperationID {
@@ -483,6 +484,7 @@ func RunToolLoop(
 						TokensBefore:   before,
 						MessagesBefore: msgsBefore,
 						Error:          cerr.Error(),
+						OutputLimit:    compact.IsSummaryOutputLimit(cerr),
 					}, usageBefore))
 				}
 			}

--- a/internal/agent/step.go
+++ b/internal/agent/step.go
@@ -129,6 +129,7 @@ type CompactAttemptInfo struct {
 	MessagesBefore    int
 	MessagesAfter     int
 	Error             string
+	OutputLimit       bool
 }
 
 // ToolBatchRejectionInfo describes a whole assistant tool-call batch that was

--- a/internal/agent/stream_runner.go
+++ b/internal/agent/stream_runner.go
@@ -1157,6 +1157,8 @@ func formatCompactNotice(info CompactInfo) string {
 
 func formatCompactAttemptNotice(info CompactAttemptInfo) (string, bool) {
 	switch {
+	case info.Status == CompactAttemptFailed && info.OutputLimit:
+		return "Context compaction still exceeded the model's summary output limit after retry; history is unchanged. Retry compaction or switch to a model with a larger output limit.", true
 	case info.Reason == CompactReasonProactive && info.Status == CompactAttemptFailed:
 		return "Context compaction failed; continuing without compacting history.", true
 	case info.Reason == CompactReasonOverflow && info.Status == CompactAttemptFailed:

--- a/internal/agent/stream_runner_test.go
+++ b/internal/agent/stream_runner_test.go
@@ -1337,6 +1337,22 @@ func TestFormatCompactAttemptNoticeClosesVisibleProgress(t *testing.T) {
 	}
 }
 
+func TestFormatCompactAttemptNoticeExplainsOutputLimitRecovery(t *testing.T) {
+	notice, ok := formatCompactAttemptNotice(CompactAttemptInfo{
+		Reason:      CompactReasonManual,
+		Status:      CompactAttemptFailed,
+		OutputLimit: true,
+	})
+	if !ok {
+		t.Fatal("output-limit failure must emit a terminal notice")
+	}
+	for _, want := range []string{"after retry", "history is unchanged", "Retry compaction", "larger output limit"} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("notice %q does not contain %q", notice, want)
+		}
+	}
+}
+
 func TestStreamRunner_StopsProactiveCompactAfterRepeatedFailures(t *testing.T) {
 	client := &mockStreamClient{
 		events: []providers.StreamEvent{

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -28,13 +28,29 @@ const defaultCompactTimeout = 20 * time.Minute
 // the context window, defeating the purpose of compaction.
 const maxCompactOutputChars = 80_000
 const (
-	compactSummaryMaxTokens       = 4096
-	compactSummaryInputMaxTokens  = 80_000
-	compactSummaryInputMinTokens  = 4_000
-	compactSummaryInputFraction   = 0.5
-	compactPromptContentMaxChars  = 500
-	compactPromptToolArgsMaxChars = 200
+	compactSummaryFallbackMaxTokens = 4096
+	compactSummaryInputMaxTokens    = 80_000
+	compactSummaryInputMinTokens    = 4_000
+	compactSummaryInputFraction     = 0.5
+	compactPromptContentMaxChars    = 500
+	compactPromptToolArgsMaxChars   = 200
 )
+
+// A length-limited summary is unusable. Retry once from the same history with
+// a stricter compression instruction, then fail without replacing history.
+const maxCompactLengthRetries = 1
+
+var errCompactSummaryOutputLimit = errors.New("compact summary reached the output limit before completion")
+
+// IsSummaryOutputLimit reports whether compaction failed because the provider
+// explicitly ended a summary at its output limit.
+func IsSummaryOutputLimit(err error) bool {
+	return errors.Is(err, errCompactSummaryOutputLimit)
+}
+
+const compactLengthRecoveryInstruction = `
+
+The previous summary attempt reached its output limit. Produce one complete replacement summary within the same output budget. Compress aggressively: keep only decision-critical requirements, current state, external effects, verification, and next steps. Do not mention this retry and do not end mid-section.`
 
 const (
 	// ConversationSummaryPrefix marks the synthetic summary installed after
@@ -233,7 +249,7 @@ func summarizeCompactHistory(ctx context.Context, client providers.Client, model
 			n = 1
 		}
 		chunk := remaining[:n]
-		next, err := summarizeCompactChunk(ctx, client, model, options, chunk, summary)
+		next, err := summarizeCompactChunk(ctx, client, model, budget, options, chunk, summary)
 		if err != nil {
 			return "", err
 		}
@@ -254,27 +270,51 @@ func limitSummaryOutput(summary string) string {
 	return summary[:cut]
 }
 
-func summarizeCompactChunk(ctx context.Context, client providers.Client, model string, options map[string]any, messages []providers.ChatMessage, previousSummary string) (string, error) {
+func summarizeCompactChunk(ctx context.Context, client providers.Client, model string, budget Budget, options map[string]any, messages []providers.ChatMessage, previousSummary string) (string, error) {
 	toSummarize := messages
-	for attempt := 0; ; attempt++ {
-		summaryReq := compactSummaryRequest(model, buildSummaryPrompt(toSummarize, previousSummary), options)
-		resp, err := summarizeCompact(ctx, client, summaryReq)
-		if err != nil {
-			// If the summary request itself overflowed the model's
-			// context window, drop the oldest message from this chunk and try
-			// again. The chunker prevents normal huge histories from reaching
-			// this path; this remains a backstop for provider-specific counting.
-			if providers.IsContextOverflow(err) && attempt < maxCompactRetries && len(toSummarize) > 1 {
+	maxTokens := compactSummaryMaxTokensForBudget(budget)
+	outputLimitCount := 0
+	for overflowAttempt := 0; ; overflowAttempt++ {
+		prompt := buildSummaryPrompt(toSummarize, previousSummary)
+		for {
+			attemptPrompt := prompt
+			if outputLimitCount > 0 {
+				attemptPrompt += compactLengthRecoveryInstruction
+			}
+			summaryReq := compactSummaryRequest(model, attemptPrompt, maxTokens, options)
+			resp, err := summarizeCompact(ctx, client, summaryReq)
+			if err == nil {
+				return resp.Content, nil
+			}
+			if errors.Is(err, errCompactSummaryOutputLimit) {
+				outputLimitCount++
+				if outputLimitCount <= maxCompactLengthRetries {
+					continue
+				}
+				return "", fmt.Errorf("compact summary failed after %d output attempts with max_tokens=%d: %w", outputLimitCount, maxTokens, err)
+			}
+			// If the summary request itself overflowed the model's context
+			// window, drop the oldest message from this chunk and try again.
+			// The chunker prevents normal huge histories from reaching this
+			// path; this remains a backstop for provider-specific counting.
+			if providers.IsContextOverflow(err) && outputLimitCount == 0 && overflowAttempt < maxCompactRetries && len(toSummarize) > 1 {
 				toSummarize = toSummarize[1:]
-				continue
+				break
 			}
 			return "", fmt.Errorf("compact summary failed: %w", err)
 		}
-		return resp.Content, nil
 	}
 }
 
-func compactSummaryRequest(model, prompt string, options map[string]any) providers.ChatRequest {
+func compactSummaryMaxTokensForBudget(budget Budget) int {
+	preferred := compactReservedMaxTokens * 4 / 5
+	if budget.OutputReserveTokens <= 0 {
+		return compactSummaryFallbackMaxTokens
+	}
+	return min(preferred, budget.OutputReserveTokens)
+}
+
+func compactSummaryRequest(model, prompt string, maxTokens int, options map[string]any) providers.ChatRequest {
 	return providers.ChatRequest{
 		Model:     model,
 		Operation: providers.NewInferenceOperation(providers.InferenceOperationCompaction, providers.InferenceProfileContinuationCritical),
@@ -283,7 +323,7 @@ func compactSummaryRequest(model, prompt string, options map[string]any) provide
 			{Role: "user", Content: prompt},
 		},
 		Temperature:     0.3,
-		MaxTokens:       compactSummaryMaxTokens,
+		MaxTokens:       maxTokens,
 		ProviderOptions: compactSummaryProviderOptions(options),
 	}
 }
@@ -432,15 +472,15 @@ func finishCompactFailure(execution *providers.InferenceExecution, err error) er
 }
 
 func validateCompactResponse(resp providers.ChatResponse) error {
-	if strings.TrimSpace(resp.Content) == "" {
-		return errors.New("compact summary was empty")
-	}
 	finish := resp.FinishReason
 	if finish == "" {
 		finish = providers.NormalizeFinishReason(resp.StopReason, resp.Truncated, len(resp.ToolCalls) > 0)
 	}
 	if resp.Truncated || finish == providers.FinishReasonLength {
-		return errors.New("compact summary reached the output limit before completion")
+		return errCompactSummaryOutputLimit
+	}
+	if strings.TrimSpace(resp.Content) == "" {
+		return errors.New("compact summary was empty")
 	}
 	return nil
 }

--- a/internal/compact/compact_test.go
+++ b/internal/compact/compact_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"image"
 	"image/png"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +105,91 @@ type mockCompactClient struct {
 func (m *mockCompactClient) Chat(_ context.Context, req providers.ChatRequest) (providers.ChatResponse, error) {
 	m.lastRequest = req
 	return providers.ChatResponse{Content: m.response}, nil
+}
+
+type scriptedCompactClient struct {
+	responses  []providers.ChatResponse
+	requests   []providers.ChatRequest
+	executions []*providers.InferenceExecution
+}
+
+func (c *scriptedCompactClient) Chat(ctx context.Context, req providers.ChatRequest) (providers.ChatResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return providers.ChatResponse{}, err
+	}
+	index := len(c.requests)
+	if index >= len(c.responses) {
+		return providers.ChatResponse{}, fmt.Errorf("unexpected compact request %d", index+1)
+	}
+	resp := c.responses[index]
+	c.requests = append(c.requests, req)
+	c.executions = append(c.executions, req.Execution)
+	if req.Attempt.Valid() {
+		submission, err := req.Attempt.RecordSubmission(providers.InferenceSubmissionMeta{
+			Provider:  "scripted",
+			Protocol:  "test",
+			Transport: "memory",
+		})
+		if err != nil {
+			return providers.ChatResponse{}, err
+		}
+		submission.CompleteSuccess(resp.Usage)
+	}
+	return resp, nil
+}
+
+type failingCompactClient struct {
+	err   error
+	calls int
+}
+
+func (c *failingCompactClient) Chat(context.Context, providers.ChatRequest) (providers.ChatResponse, error) {
+	c.calls++
+	return providers.ChatResponse{}, c.err
+}
+
+type recordingCompactJournal struct {
+	operations  []providers.InferenceOperationJournalRecord
+	submissions map[string]providers.InferenceSubmissionJournalRecord
+	terminals   []providers.InferenceOperationTerminalRecord
+}
+
+func (j *recordingCompactJournal) PrepareOperation(record providers.InferenceOperationJournalRecord) error {
+	j.operations = append(j.operations, record)
+	return nil
+}
+
+func (*recordingCompactJournal) PrepareAttempt(providers.InferenceAttemptJournalRecord) error {
+	return nil
+}
+
+func (j *recordingCompactJournal) UpsertSubmission(record providers.InferenceSubmissionJournalRecord) error {
+	if j.submissions == nil {
+		j.submissions = make(map[string]providers.InferenceSubmissionJournalRecord)
+	}
+	j.submissions[record.ID] = record
+	return nil
+}
+
+func (*recordingCompactJournal) MarkAttemptFirstEvent(string, string, string, time.Time) error {
+	return nil
+}
+
+func (*recordingCompactJournal) CompleteAttempt(providers.InferenceAttemptTerminalRecord) error {
+	return nil
+}
+
+func (*recordingCompactJournal) PrepareRecoveryAttempt(context.Context, providers.InferenceRecoveryAttemptJournalRecord) error {
+	return nil
+}
+
+func (j *recordingCompactJournal) CompleteOperation(record providers.InferenceOperationTerminalRecord) error {
+	j.terminals = append(j.terminals, record)
+	return nil
+}
+
+func (*recordingCompactJournal) CompleteWorkflow(providers.InferenceWorkflowTerminalRecord) error {
+	return nil
 }
 
 type chunkRecordingCompactClient struct {
@@ -372,12 +458,13 @@ func TestCompact_SetsSummaryOutputControls(t *testing.T) {
 
 	client := &mockCompactClient{response: "summary of older turns"}
 	options := map[string]any{"temperatureSupported": false, "textVerbosity": "high"}
-	_, err := CompactWithBudgetAndOptions(context.Background(), messages, client, "gpt-5.5", Budget{}, options)
+	budget := Budget{OutputReserveTokens: 128_000}
+	_, err := CompactWithBudgetAndOptions(context.Background(), messages, client, "gpt-5.5", budget, options)
 	if err != nil {
 		t.Fatalf("Compact: %v", err)
 	}
-	if client.lastRequest.MaxTokens != compactSummaryMaxTokens {
-		t.Fatalf("expected compact MaxTokens=%d, got %d", compactSummaryMaxTokens, client.lastRequest.MaxTokens)
+	if want := compactReservedMaxTokens * 4 / 5; client.lastRequest.MaxTokens != want {
+		t.Fatalf("expected compact MaxTokens=%d, got %d", want, client.lastRequest.MaxTokens)
 	}
 	if got := client.lastRequest.ProviderOptions["textVerbosity"]; got != "low" {
 		t.Fatalf("expected low text verbosity, got %#v", got)
@@ -387,6 +474,212 @@ func TestCompact_SetsSummaryOutputControls(t *testing.T) {
 	}
 	if got := options["textVerbosity"]; got != "high" {
 		t.Fatalf("compact request mutated caller options, got %#v", got)
+	}
+}
+
+func TestCompactSummaryMaxTokensForBudget(t *testing.T) {
+	preferred := compactReservedMaxTokens * 4 / 5
+	cases := []struct {
+		name   string
+		budget Budget
+		want   int
+	}{
+		{name: "large output model", budget: Budget{OutputReserveTokens: 131_072}, want: preferred},
+		{name: "small output model", budget: Budget{OutputReserveTokens: 2_048}, want: 2_048},
+		{name: "unknown output capability", budget: Budget{}, want: compactSummaryFallbackMaxTokens},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compactSummaryMaxTokensForBudget(tc.budget); got != tc.want {
+				t.Fatalf("compact summary max tokens = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeCompactChunk_LengthRecoveryUsesOriginalHistoryAndFreshOperation(t *testing.T) {
+	messages := make([]providers.ChatMessage, 0, 276)
+	for i := 0; i < 276; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		messages = append(messages, providers.ChatMessage{
+			Role:    role,
+			Content: fmt.Sprintf("incident-message-%03d %s", i, strings.Repeat("detail ", 62)),
+		})
+	}
+	firstUsage := &providers.TokenUsage{InputTokens: 32_837, OutputTokens: 4_096}
+	secondUsage := &providers.TokenUsage{InputTokens: 32_910, OutputTokens: 3_100}
+	client := &scriptedCompactClient{responses: []providers.ChatResponse{
+		{Content: "partial handoff that must be discarded", FinishReason: providers.FinishReasonLength, Usage: firstUsage},
+		{Content: "complete compact handoff", FinishReason: providers.FinishReasonStop, Usage: secondUsage},
+	}}
+	journal := &recordingCompactJournal{}
+	ctx := providers.WithInferenceJournal(context.Background(), journal)
+
+	summary, err := summarizeCompactChunk(
+		ctx,
+		client,
+		"k3",
+		Budget{OutputReserveTokens: 131_072},
+		nil,
+		messages,
+		"anchored previous summary",
+	)
+	if err != nil {
+		t.Fatalf("summarizeCompactChunk: %v", err)
+	}
+	if summary != "complete compact handoff" {
+		t.Fatalf("summary = %q, want recovered complete handoff", summary)
+	}
+	if len(client.requests) != 2 || len(client.executions) != 2 {
+		t.Fatalf("requests/executions = %d/%d, want 2/2", len(client.requests), len(client.executions))
+	}
+	preferred := compactReservedMaxTokens * 4 / 5
+	for i, req := range client.requests {
+		if req.MaxTokens != preferred {
+			t.Fatalf("request %d MaxTokens = %d, want %d", i+1, req.MaxTokens, preferred)
+		}
+		if req.Execution == nil {
+			t.Fatalf("request %d has no inference execution", i+1)
+		}
+		cost := req.Execution.Snapshot().CostSummary()
+		wantUsage := firstUsage
+		if i == 1 {
+			wantUsage = secondUsage
+		}
+		if cost.KnownSubmissions != 1 || cost.KnownUsage.InputTokens != wantUsage.InputTokens || cost.KnownUsage.OutputTokens != wantUsage.OutputTokens {
+			t.Fatalf("request %d usage = %+v, want %+v", i+1, cost, *wantUsage)
+		}
+	}
+	if first, second := client.requests[0].Operation, client.requests[1].Operation; first.ID == "" || second.ID == "" || first.ID == second.ID {
+		t.Fatalf("semantic recovery must use fresh operations, got %+v / %+v", first, second)
+	}
+	if len(journal.operations) != 2 || len(journal.submissions) != 2 || len(journal.terminals) != 2 {
+		t.Fatalf("durable operations/submissions/terminals = %d/%d/%d, want 2/2/2", len(journal.operations), len(journal.submissions), len(journal.terminals))
+	}
+	for id, submission := range journal.submissions {
+		if submission.ReportedUsage == nil || submission.ReportedUsage.OutputTokens == 0 {
+			t.Fatalf("durable submission %q has no reported usage: %+v", id, submission)
+		}
+	}
+	terminalOutcomes := make(map[string]providers.InferenceTerminalOutcome, len(journal.terminals))
+	for _, terminal := range journal.terminals {
+		terminalOutcomes[terminal.OperationID] = terminal.Outcome
+	}
+	if got := terminalOutcomes[client.requests[0].Operation.ID]; got != providers.InferenceOutcomeFailed {
+		t.Fatalf("first operation outcome = %q, want failed", got)
+	}
+	if got := terminalOutcomes[client.requests[1].Operation.ID]; got != providers.InferenceOutcomeSucceeded {
+		t.Fatalf("recovery operation outcome = %q, want succeeded", got)
+	}
+	firstPrompt := client.requests[0].Messages[1].Content
+	secondPrompt := client.requests[1].Messages[1].Content
+	if tokens := EstimateTokens(firstPrompt); tokens < 30_000 || tokens > 40_000 {
+		t.Fatalf("incident-shaped summary input = %d tokens, want about 33k", tokens)
+	}
+	for _, marker := range []string{"incident-message-000", "incident-message-275", "anchored previous summary"} {
+		if !strings.Contains(firstPrompt, marker) || !strings.Contains(secondPrompt, marker) {
+			t.Fatalf("recovery did not reuse original input marker %q", marker)
+		}
+	}
+	if strings.Contains(firstPrompt, compactLengthRecoveryInstruction) || !strings.Contains(secondPrompt, compactLengthRecoveryInstruction) {
+		t.Fatal("length recovery instruction must appear only on the second attempt")
+	}
+}
+
+func TestSummarizeCompactChunk_EmptyLengthResponseRetries(t *testing.T) {
+	client := &scriptedCompactClient{responses: []providers.ChatResponse{
+		{FinishReason: providers.FinishReasonLength},
+		{Content: "complete replacement summary", FinishReason: providers.FinishReasonStop},
+	}}
+	summary, err := summarizeCompactChunk(
+		context.Background(),
+		client,
+		"test",
+		Budget{OutputReserveTokens: 16_000},
+		nil,
+		[]providers.ChatMessage{{Role: "user", Content: "history to summarize"}},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("summarizeCompactChunk: %v", err)
+	}
+	if summary != "complete replacement summary" || len(client.requests) != 2 {
+		t.Fatalf("summary/calls = %q/%d, want complete replacement/2", summary, len(client.requests))
+	}
+}
+
+func TestCompact_LengthRecoveryFailureLeavesHistoryUnchanged(t *testing.T) {
+	messages := []providers.ChatMessage{
+		{Role: "user", Content: "first"},
+		{Role: "assistant", Content: "first reply"},
+		{Role: "user", Content: "second"},
+		{Role: "assistant", Content: "second reply"},
+		{Role: "user", Content: "third"},
+		{Role: "assistant", Content: "third reply"},
+	}
+	original := providers.CloneChatMessages(messages)
+	client := &scriptedCompactClient{responses: []providers.ChatResponse{
+		{Content: "first incomplete summary", FinishReason: providers.FinishReasonLength},
+		{Content: "second incomplete summary", FinishReason: providers.FinishReasonLength},
+	}}
+
+	result, err := CompactWithBudget(context.Background(), messages, client, "k3", Budget{OutputReserveTokens: 131_072})
+	if err == nil || !IsSummaryOutputLimit(err) {
+		t.Fatalf("CompactWithBudget error = %v, want output-limit failure", err)
+	}
+	for _, want := range []string{"2 output attempts", "max_tokens=16000"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("terminal error %q does not contain %q", err, want)
+		}
+	}
+	if len(client.requests) != 2 {
+		t.Fatalf("compact requests = %d, want bounded total of 2", len(client.requests))
+	}
+	if !reflect.DeepEqual(result, original) || !reflect.DeepEqual(messages, original) {
+		t.Fatalf("failed compaction changed history:\nresult=%#v\noriginal=%#v", result, original)
+	}
+}
+
+func TestSummarizeCompactChunk_CancellationDoesNotRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &cancelingStreamCompactClient{cancel: cancel}
+	_, err := summarizeCompactChunk(
+		ctx,
+		client,
+		"test",
+		Budget{OutputReserveTokens: 16_000},
+		nil,
+		[]providers.ChatMessage{{Role: "user", Content: "history to summarize"}},
+		"",
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("summarizeCompactChunk error = %v, want context canceled", err)
+	}
+	if client.streamCalls != 1 || client.chatCalls != 0 {
+		t.Fatalf("provider calls = stream %d chat %d, want 1/0", client.streamCalls, client.chatCalls)
+	}
+}
+
+func TestSummarizeCompactChunk_NonLengthErrorDoesNotRetry(t *testing.T) {
+	wantErr := errors.New("authentication failed")
+	client := &failingCompactClient{err: wantErr}
+	_, err := summarizeCompactChunk(
+		context.Background(),
+		client,
+		"test",
+		Budget{OutputReserveTokens: 16_000},
+		nil,
+		[]providers.ChatMessage{{Role: "user", Content: "history to summarize"}},
+		"",
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("summarizeCompactChunk error = %v, want authentication failure", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("provider calls = %d, want 1", client.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- derive compaction summary output tokens from the resolved model output capability and the existing compaction reserve instead of applying 4096 to every model
- retry exactly once when a summary explicitly ends at `length`/`max_tokens`, discarding the partial output and rebuilding from the same chunk and previous summary with a stricter compression instruction
- preserve history after terminal failure, record each physical summary operation and its usage, and show an actionable retry/switch-model notice

## Budget policy

- preferred summary output: 80% of the existing 20k compaction reserve (16k)
- known smaller model output limit: clamp to that limit
- unknown output capability: retain 4096 as a compatibility fallback
- no new Desktop or config setting

## Verification

- `go test ./internal/compact ./internal/modelbudget ./internal/providers ./internal/agent ./internal/appserver`
- `make check-go`
- `git diff --check`
- `go test ./...` passes all packages except the pre-existing local-only `internal/tools.TestBashBackgroundGitAttributionUsesWrapper` failure, reproduced unchanged before this patch

Closes #141