### PR TITLE
fix(goal): wait for background completion wakeups

### DIFF
--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -5050,6 +5050,126 @@ func TestServerGoalContinuationSkipsQueuedAgentCompletionWork(t *testing.T) {
 	assertFakeClientRequestCount(t, client, 0)
 }
 
+func TestServerGoalContinuationWaitsForRunningBackgroundProcess(t *testing.T) {
+	client := &fakeClient{response: providers.ChatResponse{Content: "should not run"}}
+	srv, _, threadID, threadRuntime := startThreadWithRuntimeGoal(t, client, "goal-process-running")
+	manager, err := process.NewManager(srv.rt.RootDir, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("process.NewManager: %v", err)
+	}
+	threadRuntime.ProcessManager = manager
+	background, err := manager.Start(context.Background(), process.StartOptions{
+		Command:        "sleep 30",
+		OwnerKind:      process.OwnerMainAgent,
+		OwnerID:        threadID,
+		Lifecycle:      process.LifecycleManaged,
+		CompletionMode: process.CompletionModeResume,
+	})
+	if err != nil {
+		t.Fatalf("start background process: %v", err)
+	}
+	t.Cleanup(func() { _, _ = manager.Stop(background.ID) })
+
+	started, err := srv.startGoalContinuationTurn(context.Background(), threadID)
+	if err != nil {
+		t.Fatalf("startGoalContinuationTurn: %v", err)
+	}
+	if started {
+		t.Fatal("goal continuation should wait for a running background process to wake the thread")
+	}
+	assertFakeClientRequestCount(t, client, 0)
+}
+
+func TestServerGoalContinuationWaitsForRunningSubagent(t *testing.T) {
+	client := &fakeClient{response: providers.ChatResponse{Content: "integrated result"}}
+	srv, out, threadID, threadRuntime := startThreadWithRuntimeGoal(t, client, "goal-agent-running")
+	workerClient := newBlockingStreamClient("agent done")
+	control, err := agentcontrol.New(agentcontrol.Config{
+		Client:       workerClient,
+		DefaultModel: "fake-model",
+		ParentRepo:   srv.rt.RootDir,
+		WorktreeRoot: filepath.Join(srv.rt.RootDir, ".wuu", "worktrees"),
+		SessionID:    threadID,
+		WorkerFactory: func(string, agentcontrol.WorkerType, agentthread.Metadata) (agent.ToolExecutor, error) {
+			return noopToolExecutor{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("agentcontrol.New: %v", err)
+	}
+	th := srv.thread(threadID)
+	th.mu.Lock()
+	oldSubscription := th.runtimeSubscription
+	th.runtimeSubscription = nil
+	th.mu.Unlock()
+	releaseThreadRuntimeSubscription(threadRuntime, oldSubscription)
+	threadRuntime.AgentControl = control
+	th.mu.Lock()
+	th.runtimeSubscription = srv.subscribeThreadRuntime(threadID, threadRuntime)
+	th.mu.Unlock()
+	var releaseWorker sync.Once
+	t.Cleanup(func() {
+		releaseWorker.Do(func() { close(workerClient.release) })
+		releaseThreadRuntime(th)
+		control.StopAll()
+		control.Close()
+	})
+
+	spawned, err := control.Spawn(context.Background(), agentcontrol.SpawnRequest{
+		Type:        agentcontrol.DefaultSubagentType,
+		TaskName:    "goal_waiting_worker",
+		Description: "finish after release",
+		Prompt:      "wait until released",
+		Isolation:   string(agentcontrol.IsolationInplace),
+	})
+	if err != nil {
+		t.Fatalf("spawn background agent: %v", err)
+	}
+	select {
+	case <-workerClient.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background agent did not start")
+	}
+
+	startReq := fmt.Sprintf(`{"id":"turn","method":"turn/start","params":{"thread_id":%q,"prompt":"wait for the worker"}}`, threadID)
+	if err := srv.handleLine(context.Background(), []byte(startReq)); err != nil {
+		t.Fatalf("turn/start: %v", err)
+	}
+	waitForTurnCompletedCountForThread(t, out, threadID, 1)
+	time.Sleep(100 * time.Millisecond)
+	if got := turnCompletedCountForThread(t, out, threadID); got != 1 {
+		t.Fatalf("active goal started a turn while waiting for the subagent: completed turns=%d", got)
+	}
+	assertFakeClientRequestCount(t, client, 1)
+
+	if _, err := threadRuntime.GoalRuntime.Complete(time.Now().UTC()); err != nil {
+		t.Fatalf("complete goal before worker wake: %v", err)
+	}
+	releaseWorker.Do(func() { close(workerClient.release) })
+	waitForTurnCompletedCountForThread(t, out, threadID, 2)
+	time.Sleep(50 * time.Millisecond)
+	if got := turnCompletedCountForThread(t, out, threadID); got != 2 {
+		t.Fatalf("subagent completion should wake exactly one turn, got %d", got)
+	}
+	assertFakeClientRequestCount(t, client, 2)
+
+	client.mu.Lock()
+	requests := append([]providers.ChatRequest(nil), client.requests...)
+	client.mu.Unlock()
+	if got := goalCompletionMessageForTest(requests[1].Messages, spawned.AgentID); got == "" {
+		t.Fatalf("subagent wake request missing completion result for %s: %+v", spawned.AgentID, requests[1].Messages)
+	}
+}
+
+func goalCompletionMessageForTest(messages []providers.ChatMessage, agentID string) string {
+	for _, msg := range messages {
+		if msg.Role == "user" && strings.Contains(msg.Content, agentID) && strings.Contains(msg.Content, "agent done") {
+			return msg.Content
+		}
+	}
+	return ""
+}
+
 func TestServerTurnErrorStopsActiveGoal(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -1270,6 +1270,14 @@ func threadRuntimeHasOutstandingAgentWork(threadRuntime *runtime.ThreadRuntime) 
 	return false
 }
 
+func threadRuntimeAwaitsAutoContinuation(threadID string, threadRuntime *runtime.ThreadRuntime) bool {
+	if threadRuntime == nil {
+		return false
+	}
+	return threadRuntimeHasOutstandingAgentWork(threadRuntime) ||
+		threadHasOutstandingProcessCompletion(threadID, threadRuntime.AgentControl, threadRuntime.ProcessManager)
+}
+
 func threadRuntimeHasOutstandingWork(threadID string, threadRuntime *runtime.ThreadRuntime) bool {
 	if threadRuntimeHasOutstandingAgentWork(threadRuntime) {
 		return true
@@ -2254,9 +2262,7 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	// Local queue drains are kicked only after this write, preserving terminal
 	// before successor ordering on this server without making an immediate user
 	// turn spuriously fail as busy.
-	awaitingAutoContinuation := err == nil && threadRuntime != nil &&
-		(threadRuntimeHasOutstandingAgentWork(threadRuntime) ||
-			threadHasOutstandingProcessCompletion(th.ID, threadRuntime.AgentControl, threadRuntime.ProcessManager))
+	awaitingAutoContinuation := err == nil && threadRuntimeAwaitsAutoContinuation(th.ID, threadRuntime)
 	if runID := strings.TrimSpace(turnRuntime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
 		if completeErr := s.rt.AutomationManager.CompleteRun(runID, th.ID, turnID, err); completeErr != nil {
 			providers.DebugLogf("complete automation run %q: %v", runID, completeErr)
@@ -3682,7 +3688,7 @@ func (s *Server) startGoalContinuationTurn(ctx context.Context, threadID string)
 
 	// The goal and all queue gates may have changed while another app-server
 	// owned the thread. Evaluate them only after acquiring ownership.
-	decision, err := threadRuntime.GoalRuntime.DecideContinuation(s.goalContinuationInput(th, threadID))
+	decision, err := threadRuntime.GoalRuntime.DecideContinuation(s.goalContinuationInput(th, threadID, threadRuntime))
 	if err != nil {
 		releaseAdmission()
 		return false, err
@@ -3745,7 +3751,7 @@ func (s *Server) startGoalContinuationTurn(ctx context.Context, threadID string)
 	return true, nil
 }
 
-func (s *Server) goalContinuationInput(th *threadState, threadID string) goalruntime.ContinuationInput {
+func (s *Server) goalContinuationInput(th *threadState, threadID string, threadRuntime *runtime.ThreadRuntime) goalruntime.ContinuationInput {
 	var running, readOnly bool
 	if th != nil {
 		th.mu.Lock()
@@ -3754,11 +3760,12 @@ func (s *Server) goalContinuationInput(th *threadState, threadID string) goalrun
 		th.mu.Unlock()
 	}
 	return goalruntime.ContinuationInput{
-		ThreadIdle:      !running,
-		ActiveTurn:      running,
-		QueuedUserWork:  s.hasQueuedUserWork(threadID),
-		QueuedAgentWork: s.hasQueuedAgentCompletionWork(threadID),
-		ReadOnly:        readOnly,
+		ThreadIdle:             !running,
+		ActiveTurn:             running,
+		QueuedUserWork:         s.hasQueuedUserWork(threadID),
+		QueuedAgentWork:        s.hasQueuedAgentCompletionWork(threadID),
+		AwaitingBackgroundWork: threadRuntimeAwaitsAutoContinuation(threadID, threadRuntime),
+		ReadOnly:               readOnly,
 	}
 }
 

--- a/internal/goalruntime/runtime.go
+++ b/internal/goalruntime/runtime.go
@@ -11,13 +11,14 @@ type Runtime struct {
 }
 
 type ContinuationInput struct {
-	ThreadIdle          bool
-	ActiveTurn          bool
-	QueuedUserWork      bool
-	QueuedAgentWork     bool
-	ReadOnly            bool
-	PlanMode            bool
-	UnsafeProtocolState bool
+	ThreadIdle             bool
+	ActiveTurn             bool
+	QueuedUserWork         bool
+	QueuedAgentWork        bool
+	AwaitingBackgroundWork bool
+	ReadOnly               bool
+	PlanMode               bool
+	UnsafeProtocolState    bool
 }
 
 type ContinuationDecision struct {
@@ -34,6 +35,7 @@ const (
 	ContinuationBlockedBusy                ContinuationBlockReason = "busy"
 	ContinuationBlockedQueuedUserWork      ContinuationBlockReason = "queued_user_work"
 	ContinuationBlockedQueuedAgentWork     ContinuationBlockReason = "queued_agent_work"
+	ContinuationBlockedAwaitingBackground  ContinuationBlockReason = "awaiting_background_work"
 	ContinuationBlockedReadOnly            ContinuationBlockReason = "read_only"
 	ContinuationBlockedPlanMode            ContinuationBlockReason = "plan_mode"
 	ContinuationBlockedUnsafeProtocolState ContinuationBlockReason = "unsafe_protocol_state"
@@ -161,6 +163,9 @@ func DecideContinuation(goal Goal, input ContinuationInput) ContinuationDecision
 	}
 	if input.QueuedAgentWork {
 		return blockedContinuation(goal.Status, ContinuationBlockedQueuedAgentWork)
+	}
+	if input.AwaitingBackgroundWork {
+		return blockedContinuation(goal.Status, ContinuationBlockedAwaitingBackground)
 	}
 	if input.ReadOnly {
 		return blockedContinuation(goal.Status, ContinuationBlockedReadOnly)

--- a/internal/goalruntime/runtime_test.go
+++ b/internal/goalruntime/runtime_test.go
@@ -50,6 +50,11 @@ func TestRuntimeDecideContinuationRejectsUnsafeConditions(t *testing.T) {
 			want:  ContinuationBlockedQueuedAgentWork,
 		},
 		{
+			name:  "awaiting background work",
+			input: ContinuationInput{ThreadIdle: true, AwaitingBackgroundWork: true},
+			want:  ContinuationBlockedAwaitingBackground,
+		},
+		{
 			name:  "read only",
 			input: ContinuationInput{ThreadIdle: true, ReadOnly: true},
 			want:  ContinuationBlockedReadOnly,


### PR DESCRIPTION
## Summary
- prevent active goal continuation from starting while resume-mode background work is still running
- cover background commands and subagents, including the single completion wakeup path

## Verification
- `go test ./internal/appserver -count=1`
- `go test ./internal/goalruntime -count=1`
- `gofmt -d ...`
- `git diff --check`