### PR TITLE
style(desktop): reuse composer controls in user message edit bubble

### DIFF
--- a/desktop/src/renderer/ComposerTokenGauge.tsx
+++ b/desktop/src/renderer/ComposerTokenGauge.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useI18n } from "./i18n";
+import { FloatingMenuPortal } from "./ComposerFloatingMenu";
 
 // Toolbar gauge. The numeric readout is rendered inline next to the dial
-// so the user can see the current rate without hovering. The needle and
-// the text share the same currentColor so the idle/mid/high color tier
-// applies to both.
+// so the user can see the current rate without hovering when the toolbar is
+// wide enough. When the composer is narrow and the inline label is hidden
+// by the container query, the same value is surfaced through a hover tooltip
+// so the speed remains accessible.
 const MAX_TOKENS_PER_SEC = 100;
 const HIGH_SPEED_THRESHOLD = 70;
 const STALE_HOLD_MS = 1200;
 const STALE_DECAY_MS = 5200;
 const STALE_DECAY_STEP_MS = 100;
+const TOOLTIP_WIDTH = 160;
 
 const GAUGE_ARC_PATH = "M 2.5 17 A 9.5 9.5 0 0 1 21.5 17";
 const GAUGE_ARC_PATH_LENGTH = 100;
@@ -40,6 +43,9 @@ export function ComposerTokenGauge({
   source?: "real" | "estimated" | "none";
 }): JSX.Element {
   const { t, formatNumber } = useI18n();
+  const tooltipID = useId();
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   // CSS transitions smooth the needle and arc between samples. React only
   // updates when the target changes or a stale sample is winding down, so a
   // stable running turn does not keep the renderer on a permanent rAF loop.
@@ -94,15 +100,23 @@ export function ComposerTokenGauge({
   const rounded = Math.round(displayed);
   const isEstimated = source === "estimated";
   const speedLabel = t(isEstimated ? "composer.speed.estimatedShort" : "composer.speed.short", { speed: formatNumber(rounded) });
+  const tooltipLabel = t(isEstimated ? "composer.speed.estimatedLabel" : "composer.speed.label", { speed: formatNumber(rounded) });
 
   return (
     <div
+      ref={anchorRef}
       className="composer-token-gauge"
       data-state={running ? "running" : "idle"}
       role="status"
       aria-live="polite"
-      aria-label={t(isEstimated ? "composer.speed.estimatedLabel" : "composer.speed.label", { speed: formatNumber(rounded) })}
+      aria-label={tooltipLabel}
+      aria-describedby={tooltipOpen ? tooltipID : undefined}
+      tabIndex={0}
       style={{ color }}
+      onBlur={() => setTooltipOpen(false)}
+      onFocus={() => setTooltipOpen(true)}
+      onMouseEnter={() => setTooltipOpen(true)}
+      onMouseLeave={() => setTooltipOpen(false)}
     >
       <svg
         viewBox="0 0 24 24"
@@ -145,6 +159,24 @@ export function ComposerTokenGauge({
         />
       </svg>
       <span className="composer-token-gauge-label">{speedLabel}</span>
+      {tooltipOpen ? (
+        <FloatingMenuPortal
+          anchorRef={anchorRef}
+          owner="composer-token-gauge"
+          placement="above"
+          align="right"
+          offset={8}
+          width={TOOLTIP_WIDTH}
+        >
+          <div
+            id={tooltipID}
+            className="composer-token-gauge-tooltip"
+            role="tooltip"
+          >
+            {tooltipLabel}
+          </div>
+        </FloatingMenuPortal>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/renderer/ComposerTypes.ts
+++ b/desktop/src/renderer/ComposerTypes.ts
@@ -14,6 +14,7 @@ export type FloatingMenuOwner =
   | "composer-runtime"
   | "composer-access"
   | "composer-context-meter"
+  | "composer-token-gauge"
   | "composer-focus"
   | "composer-goal"
   | "composer-plus"

--- a/desktop/src/renderer/ComposerView.test.tsx
+++ b/desktop/src/renderer/ComposerView.test.tsx
@@ -57,7 +57,7 @@ afterEach(() => {
   container.remove();
   document.body
     .querySelectorAll(
-      "[data-floating-menu-owner=\"composer-access\"], [data-floating-menu-owner=\"composer-focus\"], [data-floating-menu-owner=\"composer-plus\"]",
+      "[data-floating-menu-owner=\"composer-access\"], [data-floating-menu-owner=\"composer-focus\"], [data-floating-menu-owner=\"composer-plus\"], [data-floating-menu-owner=\"composer-token-gauge\"]",
     )
     .forEach((element) => element.remove());
 });
@@ -2053,15 +2053,16 @@ describe("ComposerTokenGauge", () => {
     }
   });
 
-  it("keeps the gauge visible with the speed label always shown when idle", () => {
+  it("keeps the gauge visible with the speed label inline and a hidden hover tooltip", () => {
     renderComposer({ running: false, tokensPerSecond: 0 });
     const gauge = container.querySelector(".composer-token-gauge");
     expect(gauge).not.toBeNull();
     expect(gauge?.getAttribute("data-state")).toBe("idle");
     expect(gauge?.getAttribute("aria-label")).toContain("0 token 每秒");
 
-    // The label is now inline next to the dial — no hover portal. It must
-    // be in the DOM from the first render so the user always sees the rate.
+    // The label is still inline next to the dial when the toolbar is wide
+    // enough, but the same value is also available through a hover tooltip
+    // for narrow widths where the inline label is hidden by the container query.
     const label = container.querySelector(".composer-token-gauge-label");
     expect(label).not.toBeNull();
     expect(label?.textContent).toContain("0 tok/s");
@@ -2069,7 +2070,7 @@ describe("ComposerTokenGauge", () => {
     expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
   });
 
-  it("renders a live gauge without scheduling animation frames", () => {
+  it("renders a live gauge without scheduling animation frames and shows the speed on hover", () => {
     const requestAnimationFrame = vi
       .spyOn(window, "requestAnimationFrame")
       .mockImplementation(() => 1);
@@ -2083,17 +2084,20 @@ describe("ComposerTokenGauge", () => {
       expect(gauge?.getAttribute("title")).toBeNull();
       expect(requestAnimationFrame).not.toHaveBeenCalled();
 
-      // Label is inline; no portal, no hover gate. Hovering must not
-      // resurrect a tooltip either.
+      // Label is inline by default; hovering opens the tooltip portal.
       const label = container.querySelector(".composer-token-gauge-label");
       expect(label).not.toBeNull();
       expect(label?.textContent).toContain("18 tok/s");
       expect(label?.textContent).toContain("tok/s");
+      expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
 
       act(() => {
         gauge?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       });
-      expect(document.body.querySelector(".composer-token-gauge-tooltip")).toBeNull();
+      const tooltip = document.body.querySelector(".composer-token-gauge-tooltip");
+      expect(tooltip).not.toBeNull();
+      expect(tooltip?.textContent).toContain("18");
+      expect(tooltip?.textContent).toContain("token 每秒");
 
       // Dial components are still rendered.
       const svg = container.querySelector(".composer-token-gauge-svg");

--- a/desktop/src/renderer/ThreadItemView.tsx
+++ b/desktop/src/renderer/ThreadItemView.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState
 } from "react";
-import { ChevronDown, ChevronUp, PanelRightOpen, Paperclip, Send } from "lucide-react";
+import { ChevronDown, ChevronUp, PanelRightOpen, Plus, Send } from "lucide-react";
 import type { InputFile, InputImage, ThreadItem, Turn } from "../shared/protocol";
 import { agentHandoffDisplayItem } from "./AgentHandoff";
 import { replyCountBadge } from "./AppState";
@@ -669,13 +669,13 @@ function UserMessageInlineEditor({
       <div className="user-message-edit-toolbar">
         <button
           type="button"
-          className="user-message-edit-attach-button"
+          className="composer-tool-button user-message-edit-attach-button"
           aria-label={t("composer.addAttachment")}
           title={t("message.addImageOrPdf")}
           disabled={submitting}
           onClick={() => fileInputRef.current?.click()}
         >
-          <Paperclip aria-hidden="true" />
+          <Plus aria-hidden="true" />
         </button>
         <div className="user-message-edit-spacer" />
         <div className="user-message-edit-actions">
@@ -688,7 +688,7 @@ function UserMessageInlineEditor({
             {t("common.cancel")}
           </button>
           <button
-            className="user-message-edit-button primary"
+            className="composer-action-button composer-send-button"
             type="button"
             aria-label={t("composer.send")}
             title={t("composer.send")}

--- a/desktop/src/renderer/styles/composer-token-gauge.css
+++ b/desktop/src/renderer/styles/composer-token-gauge.css
@@ -5,9 +5,14 @@
   --token-gauge-mid: #d48345;
   --token-gauge-high: var(--accent-warm);
   --token-gauge-track: rgba(138, 142, 145, 0.24);
+  --token-gauge-tooltip-bg: var(--paper);
+  --token-gauge-tooltip-border: rgba(15, 17, 21, 0.08);
+  --token-gauge-tooltip-shadow: 0 6px 22px rgba(15, 17, 21, 0.12);
+  --composer-token-gauge-focus-outline: rgba(95, 99, 104, 0.55);
 }
 
 .composer-token-gauge {
+  position: relative;
   display: inline-flex;
   min-width: 0;
   align-items: center;
@@ -17,9 +22,16 @@
   user-select: none;
   line-height: 1;
   cursor: default;
+  outline: none;
   transition:
     color 420ms var(--ease-out),
     opacity var(--motion-slow) var(--ease-out);
+}
+
+.composer-token-gauge:focus-visible {
+  outline: 2px solid var(--composer-token-gauge-focus-outline);
+  outline-offset: 2px;
+  border-radius: 999px;
 }
 
 .composer-token-gauge .composer-token-gauge-svg {
@@ -83,6 +95,24 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: currentColor;
+}
+
+/* Hover/focus tooltip. Mounted in the shared floating-menu layer so the
+   composer toolbar's overflow clipping cannot hide the value when the
+   inline label is collapsed at narrow widths. */
+.composer-token-gauge-tooltip {
+  width: 160px;
+  padding: 6px 10px;
+  background: var(--token-gauge-tooltip-bg);
+  border: 1px solid var(--token-gauge-tooltip-border);
+  border-radius: 8px;
+  box-shadow: var(--token-gauge-tooltip-shadow);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--ink);
+  text-align: center;
+  pointer-events: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -7,8 +7,6 @@
   --user-message-jump-flash-bg: #eee7da;
   --user-message-jump-shadow-18: rgba(138, 91, 16, 0.18);
   --user-message-jump-shadow-08: rgba(138, 91, 16, 0.08);
-  --user-message-edit-button-primary-hover-bg: var(--gray-800);
-  --user-message-edit-button-disabled-fg: rgba(255, 255, 255, 0.86);
   --message-copy-bg: rgba(255, 255, 255, 0.72);
   --message-file-bg: rgba(255, 255, 255, 0.82);
   --message-file-fg: var(--gray-800);
@@ -434,7 +432,7 @@
   border-radius: var(--radius-lg);
   background: var(--surface-2);
   border: 1px solid var(--hairline-soft);
-  padding: 12px 16px 12px;
+  padding: 10px 12px;
   color: var(--ink);
   transition: background-color var(--motion-base) var(--ease-out), border-color var(--motion-base) var(--ease-out), box-shadow var(--motion-base) var(--ease-out);
 }
@@ -511,11 +509,16 @@
   gap: 8px;
 }
 
-/* Paperclip-only attach button, identical footprint to composer-tool-button. */
-.user-message-edit-attach-button {
+/*
+ * Toolbar controls reuse the composer's visual language: the attach button
+ * uses the Plus icon and composer-tool-button footprint; send uses the
+ * accent composer-send-button. The cancel text button is a low-key ghost.
+ * All are shrunk from 32px to 28px so the draft surface stays compact.
+ */
+.user-message-edit .user-message-edit-attach-button {
   display: grid;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   place-items: center;
   border-radius: var(--radius-sm);
   border: 0;
@@ -525,26 +528,22 @@
   transition: background-color var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out);
 }
 
-.user-message-edit-attach-button:hover:not(:disabled) {
+.user-message-edit .user-message-edit-attach-button:hover:not(:disabled) {
   background: var(--surface-3);
   color: var(--ink);
 }
 
-.user-message-edit-attach-button:disabled {
+.user-message-edit .user-message-edit-attach-button:disabled {
   cursor: default;
   opacity: 0.45;
 }
 
-.user-message-edit-attach-button svg {
+.user-message-edit .user-message-edit-attach-button svg {
   width: 16px;
   height: 16px;
+  stroke-width: var(--icon-stroke);
 }
 
-/*
- * Cancel is a low-key ghost text button; Send is a circular dark icon button
- * carrying the paper-plane glyph — the same primary-action language as the
- * main composer's send button, so the two surfaces read as one product.
- */
 .user-message-edit-button {
   display: inline-flex;
   align-items: center;
@@ -557,28 +556,13 @@
 }
 
 .user-message-edit-button.secondary {
-  height: 32px;
-  min-width: 60px;
-  padding: 0 12px;
+  height: 28px;
+  min-width: 52px;
+  padding: 0 10px;
   border-radius: var(--radius-sm);
   border: 0;
   background: transparent;
   color: var(--ink-soft);
-}
-
-.user-message-edit-button.primary {
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-pill);
-  border: 0;
-  background: var(--ink);
-  color: var(--paper);
-}
-
-.user-message-edit-button.primary svg {
-  width: 16px;
-  height: 16px;
-  stroke-width: 2.25;
 }
 
 .user-message-edit-button.secondary:hover:not(:disabled) {
@@ -586,19 +570,9 @@
   color: var(--ink);
 }
 
-.user-message-edit-button.primary:hover:not(:disabled) {
-  background: var(--user-message-edit-button-primary-hover-bg);
-}
-
 .user-message-edit-button:focus-visible {
   outline: 0;
   box-shadow: 0 0 0 3px var(--ink-overlay-8);
-}
-
-.user-message-edit-button.primary:disabled {
-  cursor: default;
-  background: var(--surface-4);
-  color: var(--user-message-edit-button-disabled-fg);
 }
 
 .user-message-edit-button.secondary:disabled {
@@ -785,6 +759,15 @@
 .message-actions.user-message-actions .message-action-button {
   width: 20px;
   height: 20px;
+}
+
+/* Two user queries can land back-to-back in the same turn (steer/queue).
+ * The first query's hover action row hangs 22px below its bubble
+ * (20px controls + 2px hover bridge), but the turn item gap is only 8px,
+ * so the row overlaps the second query. Push the next query down by the
+ * difference so the action row clears it. */
+.user-message-block-with-actions + .user-message-block {
+  margin-top: calc(22px - var(--conversation-turn-item-gap));
 }
 
 .message-images {


### PR DESCRIPTION
- Replace the paperclip attach button with the composer's Plus icon.
- Use composer-send-button for the send action.
- Shrink toolbar buttons from 32px to 28px.
- Reduce edit container padding to 10px 12px to free up space.