### PR TITLE
feat(desktop): drag files and workspace paths into composers

### DIFF
--- a/desktop/src/renderer/ComposerDraftState.test.tsx
+++ b/desktop/src/renderer/ComposerDraftState.test.tsx
@@ -159,6 +159,26 @@ describe("useComposerDraftState", () => {
     expect(hook.get().composerImages).toEqual([]);
   });
 
+  it("rejects PDFs over the 20MB limit with a reason and skips reading them", async () => {
+    const hook = await renderComposerDraftState();
+    const pdf = new File(["%PDF-1.7"], "huge.pdf", { type: "application/pdf" });
+    Object.defineProperty(pdf, "size", { configurable: true, value: 21 * 1024 * 1024 });
+    const arrayBuffer = vi.fn();
+    Object.defineProperty(pdf, "arrayBuffer", { configurable: true, value: arrayBuffer });
+
+    await act(async () => {
+      await hook.get().attachComposerAttachmentFiles([pdf]);
+      await flushEffects();
+    });
+
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(resolveLocalizedText(hook.setStatus.mock.calls[0][0] as string)).toBe(
+      "「huge.pdf」超过 PDF 20MB 大小上限",
+    );
+    expect(hook.get().composerFiles).toEqual([]);
+    expect(hook.get().composerImages).toEqual([]);
+  });
+
   it("keeps split composer drafts isolated and can move one draft back to the primary composer", async () => {
     const hook = await renderComposerDraftState();
     const file = pdfFile();

--- a/desktop/src/renderer/ComposerInputSections.tsx
+++ b/desktop/src/renderer/ComposerInputSections.tsx
@@ -8,10 +8,12 @@ import {
   Square,
   X
 } from "lucide-react";
-import { type KeyboardEvent as ReactKeyboardEvent, useRef } from "react";
+import { type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, useRef, useState } from "react";
 import { useImagePreview } from "./ImagePreview";
 import { isComposerTextComposing } from "./ComposerSlashCommands";
 import {
+  WORKSPACE_FILE_DRAG_MIME,
+  appendWorkspacePathToPrompt,
   clipboardAttachmentFiles,
   imageSource,
   queuedMessagePreview,
@@ -126,6 +128,7 @@ export function SplitPaneComposer({
   const { t } = useI18n();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const [dropActive, setDropActive] = useState(false);
   const hasAttachments = images.length > 0 || files.length > 0;
   const hasDraft = prompt.trim().length > 0 || hasAttachments;
   // Match the dock composer: the button is a stop control only while running
@@ -146,6 +149,62 @@ export function SplitPaneComposer({
 
   function focusComposerSoon(): void {
     window.requestAnimationFrame(() => textareaRef.current?.focus());
+  }
+
+  function focusComposerAtEndSoon(): void {
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) {
+        return;
+      }
+      textarea.focus();
+      const end = textarea.value.length;
+      textarea.setSelectionRange(end, end);
+    });
+  }
+
+  // Mirrors the dock composer: a drop carries either a workspace path
+  // reference (inserted as plain text) or external files (forwarded to the
+  // attachment pipeline). Anything else keeps its native behavior.
+  function handleDragOver(event: ReactDragEvent<HTMLDivElement>): void {
+    if (readOnly) {
+      return;
+    }
+    const types = Array.from(event.dataTransfer.types ?? []);
+    if (!types.includes(WORKSPACE_FILE_DRAG_MIME) && !types.includes("Files")) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setDropActive(true);
+  }
+
+  function handleDragLeave(event: ReactDragEvent<HTMLDivElement>): void {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+    setDropActive(false);
+  }
+
+  function handleDrop(event: ReactDragEvent<HTMLDivElement>): void {
+    setDropActive(false);
+    if (readOnly) {
+      return;
+    }
+    const workspacePath = event.dataTransfer.getData(WORKSPACE_FILE_DRAG_MIME);
+    if (workspacePath) {
+      event.preventDefault();
+      resetQueryHistoryNavigation();
+      setPrompt(appendWorkspacePathToPrompt(prompt, workspacePath));
+      focusComposerAtEndSoon();
+      return;
+    }
+    const dropped = Array.from(event.dataTransfer.files ?? []);
+    if (dropped.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    onPasteAttachmentFiles(dropped);
   }
 
   function submitComposer(): void {
@@ -169,7 +228,12 @@ export function SplitPaneComposer({
 
   return (
     <footer className="split-composer">
-      <div className="split-composer-shell">
+      <div
+        className={`split-composer-shell${dropActive ? " split-composer-shell-drop-active" : ""}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
         <ComposerAttachmentStrip files={files} images={images} onRemoveFile={onRemoveFile} onRemoveImage={onRemoveImage} />
         <input
           ref={attachmentInputRef}

--- a/desktop/src/renderer/ComposerMessages.ts
+++ b/desktop/src/renderer/ComposerMessages.ts
@@ -19,6 +19,28 @@ import { formatCurrentNumber, translateCurrent } from "./i18n";
 const IMAGE_MAX_DIMENSION = 2000;
 const IMAGE_TARGET_BYTES = (5 * 1024 * 1024 * 3) / 4;
 
+// PDFs are inlined whole: read fully into renderer memory and base64'd
+// (+33%), so an unbounded pick can OOM the renderer or blow past provider
+// limits. Cap at 20MB raw (~27MB encoded), inside Anthropic's 32MB
+// single-file ceiling with headroom; stricter providers should lower this.
+export const COMPOSER_PDF_MAX_BYTES = 20 * 1024 * 1024;
+export const COMPOSER_PDF_MAX_MB = 20;
+
+// Custom drag MIME carrying a workspace-relative path from the file tree.
+// Path drops insert plain text into the composer — a reference the model
+// resolves with its own tools, never file content.
+export const WORKSPACE_FILE_DRAG_MIME = "application/x-wuu-workspace-path";
+
+/**
+ * Append a workspace path reference to a composer prompt as plain text,
+ * keeping exactly one separating space and one trailing space so the user
+ * can keep typing without editing around the inserted reference.
+ */
+export function appendWorkspacePathToPrompt(prompt: string, path: string): string {
+  const separator = prompt.length > 0 && !/\s$/.test(prompt) ? " " : "";
+  return `${prompt}${separator}${path} `;
+}
+
 export type ComposerImage = InputImage & {
   id: string;
   /**
@@ -121,6 +143,14 @@ export async function composerImageFromFile(file: File): Promise<ComposerImage> 
 export async function composerFileFromFile(file: File): Promise<ComposerFile> {
   if (!isPDFFile(file)) {
     throw new Error(translateCurrent("composer.attachment.pdfOnly"));
+  }
+  if (file.size > COMPOSER_PDF_MAX_BYTES) {
+    throw new Error(
+      translateCurrent("composer.attachment.pdfTooLarge", {
+        name: file.name.trim() || "attachment.pdf",
+        limit: COMPOSER_PDF_MAX_MB
+      })
+    );
   }
   const data = await bufferToBase64(await file.arrayBuffer());
   return {

--- a/desktop/src/renderer/ComposerView.test.tsx
+++ b/desktop/src/renderer/ComposerView.test.tsx
@@ -12,7 +12,7 @@ import {
   type PermissionMode,
 } from "./ComposerView";
 import { ImagePreviewProvider } from "./ImagePreview";
-import type { QueuedComposerMessage } from "./ComposerMessages";
+import { WORKSPACE_FILE_DRAG_MIME, type QueuedComposerMessage } from "./ComposerMessages";
 import type {
   DesktopProject,
   ComposerGoalSummary,
@@ -244,11 +244,82 @@ function renderSplitPaneComposer(props: {
   });
 }
 
+function renderStatefulSplitPaneComposer(props: {
+  initialPrompt?: string;
+  readOnly?: boolean;
+  onPasteAttachmentFiles?: (files: File[]) => void;
+}): void {
+  function Harness(): JSX.Element {
+    const [prompt, setPrompt] = useState(props.initialPrompt ?? "");
+    return (
+      <ImagePreviewProvider>
+        <SplitPaneComposer
+          prompt={prompt}
+          setPrompt={setPrompt}
+          files={[]}
+          images={[]}
+          running={false}
+          readOnly={props.readOnly ?? false}
+          status="ready"
+          onPasteAttachmentFiles={props.onPasteAttachmentFiles ?? (() => {})}
+          onRemoveFile={() => {}}
+          onRemoveImage={() => {}}
+          onSend={() => {}}
+          onInterrupt={() => {}}
+        />
+      </ImagePreviewProvider>
+    );
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(<Harness />);
+  });
+}
+
+function mockDataTransfer(init: {
+  types: string[];
+  files?: File[];
+  pathData?: string;
+}): DataTransfer {
+  const data = new Map<string, string>();
+  if (init.pathData !== undefined) {
+    data.set(WORKSPACE_FILE_DRAG_MIME, init.pathData);
+  }
+  return {
+    types: init.types,
+    files: init.files ?? [],
+    getData: (type: string) => data.get(type) ?? "",
+    setData: (type: string, value: string) => {
+      data.set(type, value);
+    },
+    dropEffect: "none",
+    effectAllowed: "all",
+  } as unknown as DataTransfer;
+}
+
+function dispatchDrag(
+  target: Element,
+  type: "dragover" | "dragleave" | "drop",
+  dataTransfer: DataTransfer,
+  relatedTarget?: EventTarget | null,
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  if (relatedTarget !== undefined) {
+    Object.defineProperty(event, "relatedTarget", { value: relatedTarget });
+  }
+  target.dispatchEvent(event);
+}
+
 function renderStatefulComposer(props: {
   initialPrompt?: string;
   onSend?: (prompt: string) => void;
   showUltraToggle?: boolean;
   activeContext?: RuntimeContext;
+  readOnly?: boolean;
+  textOnly?: boolean;
+  onPasteAttachmentFiles?: (files: File[]) => void;
 }): void {
   const codexModels: CodexModelLoadState = {
     loading: false,
@@ -272,7 +343,8 @@ function renderStatefulComposer(props: {
           ultraEnabled={ultraEnabled}
           onToggleUltra={props.showUltraToggle ? setUltraEnabled : undefined}
           status="ready"
-          readOnly={false}
+          readOnly={props.readOnly ?? false}
+          textOnly={props.textOnly}
           initialized={initialized()}
           projects={[]}
           activeContext={props.activeContext}
@@ -302,7 +374,7 @@ function renderStatefulComposer(props: {
           onOpenProject={() => {}}
           onStartNewThread={() => {}}
           onOpenWorkspaceTool={() => {}}
-          onPasteAttachmentFiles={() => {}}
+          onPasteAttachmentFiles={props.onPasteAttachmentFiles ?? (() => {})}
           onRemoveFile={() => {}}
           onRemoveImage={() => {}}
           onRemoveQueuedMessage={() => {}}
@@ -2159,5 +2231,188 @@ describe("Composer expand button", () => {
     expect(composerCSS).not.toMatch(
       /--composer-input-header-inline-padding:\s*14px;/,
     );
+  });
+});
+
+describe("composer drag and drop", () => {
+  function composerFrame(): HTMLElement {
+    const frame = container.querySelector<HTMLElement>(".composer-frame");
+    if (!frame) throw new Error("missing composer frame");
+    return frame;
+  }
+
+  it("appends a dragged workspace path to the prompt as plain text", () => {
+    renderStatefulComposer({ initialPrompt: "看看这个文件" });
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: [WORKSPACE_FILE_DRAG_MIME, "text/plain"],
+        pathData: "src/index.ts",
+      }));
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(
+      "看看这个文件 src/index.ts ",
+    );
+  });
+
+  it("inserts a path into an empty prompt without a leading space", () => {
+    renderStatefulComposer({});
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: [WORKSPACE_FILE_DRAG_MIME],
+        pathData: "src/components/",
+      }));
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(
+      "src/components/ ",
+    );
+  });
+
+  it("forwards dropped external files to the attachment pipeline", () => {
+    const onPasteAttachmentFiles = vi.fn();
+    renderStatefulComposer({ onPasteAttachmentFiles });
+    const image = new File(["png"], "shot.png", { type: "image/png" });
+    const pdf = new File(["%PDF"], "brief.pdf", { type: "application/pdf" });
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: ["Files"],
+        files: [image, pdf],
+      }));
+    });
+
+    expect(onPasteAttachmentFiles).toHaveBeenCalledTimes(1);
+    expect(onPasteAttachmentFiles.mock.calls[0][0]).toEqual([image, pdf]);
+  });
+
+  it("ignores drops while read-only", () => {
+    const onPasteAttachmentFiles = vi.fn();
+    renderStatefulComposer({ initialPrompt: "draft", readOnly: true, onPasteAttachmentFiles });
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: [WORKSPACE_FILE_DRAG_MIME],
+        pathData: "src/index.ts",
+      }));
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: ["Files"],
+        files: [new File(["png"], "shot.png", { type: "image/png" })],
+      }));
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("draft");
+    expect(onPasteAttachmentFiles).not.toHaveBeenCalled();
+  });
+
+  it("accepts path drops on a text-only composer but ignores external files", () => {
+    const onPasteAttachmentFiles = vi.fn();
+    renderStatefulComposer({ textOnly: true, onPasteAttachmentFiles });
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: [WORKSPACE_FILE_DRAG_MIME],
+        pathData: "src/index.ts",
+      }));
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("src/index.ts ");
+
+    act(() => {
+      dispatchDrag(composerFrame(), "drop", mockDataTransfer({
+        types: ["Files"],
+        files: [new File(["png"], "shot.png", { type: "image/png" })],
+      }));
+    });
+
+    expect(onPasteAttachmentFiles).not.toHaveBeenCalled();
+  });
+
+  it("highlights the frame during an accepted dragover and clears on dragleave and drop", () => {
+    renderStatefulComposer({});
+    const frame = composerFrame();
+
+    act(() => {
+      dispatchDrag(frame, "dragover", mockDataTransfer({ types: ["Files"] }));
+    });
+    expect(container.querySelector(".composer-frame-drop-active")).not.toBeNull();
+
+    // Moving between children keeps the highlight: the related target is
+    // still inside the frame.
+    const child = frame.querySelector("textarea");
+    act(() => {
+      dispatchDrag(frame, "dragleave", mockDataTransfer({ types: ["Files"] }), child);
+    });
+    expect(container.querySelector(".composer-frame-drop-active")).not.toBeNull();
+
+    act(() => {
+      dispatchDrag(frame, "dragleave", mockDataTransfer({ types: ["Files"] }), document.body);
+    });
+    expect(container.querySelector(".composer-frame-drop-active")).toBeNull();
+
+    act(() => {
+      dispatchDrag(frame, "dragover", mockDataTransfer({ types: ["Files"] }));
+    });
+    expect(container.querySelector(".composer-frame-drop-active")).not.toBeNull();
+    act(() => {
+      dispatchDrag(frame, "drop", mockDataTransfer({ types: [WORKSPACE_FILE_DRAG_MIME], pathData: "a.ts" }));
+    });
+    expect(container.querySelector(".composer-frame-drop-active")).toBeNull();
+  });
+
+  it("does not highlight for payloads the composer does not accept", () => {
+    renderStatefulComposer({});
+    const frame = composerFrame();
+
+    act(() => {
+      dispatchDrag(frame, "dragover", mockDataTransfer({ types: ["text/plain"] }));
+    });
+
+    expect(container.querySelector(".composer-frame-drop-active")).toBeNull();
+  });
+
+  it("keeps the frame border highlight style in the stylesheet", () => {
+    expect(composerCSS).toContain(".composer-frame.composer-frame-drop-active");
+    expect(workspaceCSS).toContain(".split-composer-shell.split-composer-shell-drop-active");
+  });
+
+  it("appends a dragged workspace path in the split pane composer", () => {
+    renderStatefulSplitPaneComposer({ initialPrompt: "review" });
+    const shell = container.querySelector<HTMLElement>(".split-composer-shell");
+    if (!shell) throw new Error("missing split composer shell");
+
+    act(() => {
+      dispatchDrag(shell, "drop", mockDataTransfer({
+        types: [WORKSPACE_FILE_DRAG_MIME],
+        pathData: "src/Button.tsx",
+      }));
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(
+      "review src/Button.tsx ",
+    );
+  });
+
+  it("forwards dropped files in the split pane composer and highlights its shell", () => {
+    const onPasteAttachmentFiles = vi.fn();
+    renderStatefulSplitPaneComposer({ onPasteAttachmentFiles });
+    const shell = container.querySelector<HTMLElement>(".split-composer-shell");
+    if (!shell) throw new Error("missing split composer shell");
+
+    act(() => {
+      dispatchDrag(shell, "dragover", mockDataTransfer({ types: ["Files"] }));
+    });
+    expect(container.querySelector(".split-composer-shell-drop-active")).not.toBeNull();
+
+    const image = new File(["png"], "shot.png", { type: "image/png" });
+    act(() => {
+      dispatchDrag(shell, "drop", mockDataTransfer({ types: ["Files"], files: [image] }));
+    });
+
+    expect(onPasteAttachmentFiles).toHaveBeenCalledTimes(1);
+    expect(onPasteAttachmentFiles.mock.calls[0][0]).toEqual([image]);
+    expect(container.querySelector(".split-composer-shell-drop-active")).toBeNull();
   });
 });

--- a/desktop/src/renderer/ComposerView.tsx
+++ b/desktop/src/renderer/ComposerView.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import {
   type ClipboardEvent as ReactClipboardEvent,
+  type DragEvent as ReactDragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type Ref,
@@ -45,6 +46,8 @@ import {
 } from "./ComposerSlashCommands";
 import { translateCurrent as translate, useI18n } from "./i18n";
 import {
+  WORKSPACE_FILE_DRAG_MIME,
+  appendWorkspacePathToPrompt,
   clipboardAttachmentFiles,
   type ComposerFile,
   type ComposerImage,
@@ -306,6 +309,7 @@ export function Composer({
   const collapsedPromptListRef = useRef<HTMLDivElement>(null);
   const collapsedPromptBlockIDRef = useRef(0);
   const [isComposerExpanded, setIsComposerExpanded] = useState(false);
+  const [dropActive, setDropActive] = useState(false);
   const [ultraAnimationCycle, setUltraAnimationCycle] = useState(0);
   const previousUltraEnabledRef = useRef(ultraEnabled);
   const [collapsedPromptBlocks, setCollapsedPromptBlocks] = useState<CollapsedComposerPromptBlock[]>([]);
@@ -592,6 +596,61 @@ export function Composer({
     focusComposerSoon();
   }
 
+  // A drop carries either a workspace path reference (file tree drag) or
+  // external files (Finder/Desktop). Path drops insert plain text and stay
+  // available on text-only composers; file drops reuse the paste pipeline.
+  // During dragover only dataTransfer.types is readable, so acceptance is
+  // decided by MIME alone — anything else keeps its native behavior (e.g.
+  // dragging selected text into the textarea).
+  function composerDropAcceptsPayload(dataTransfer: DataTransfer): boolean {
+    const types = Array.from(dataTransfer.types ?? []);
+    if (types.includes(WORKSPACE_FILE_DRAG_MIME)) {
+      return true;
+    }
+    return !textOnly && types.includes("Files");
+  }
+
+  function handleComposerDragOver(event: ReactDragEvent<HTMLDivElement>): void {
+    if (readOnly || !composerDropAcceptsPayload(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setDropActive(true);
+  }
+
+  function handleComposerDragLeave(event: ReactDragEvent<HTMLDivElement>): void {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+    setDropActive(false);
+  }
+
+  function handleComposerDrop(event: ReactDragEvent<HTMLDivElement>): void {
+    setDropActive(false);
+    if (readOnly) {
+      return;
+    }
+    const workspacePath = event.dataTransfer.getData(WORKSPACE_FILE_DRAG_MIME);
+    if (workspacePath) {
+      event.preventDefault();
+      resetQueryHistoryNavigation();
+      setSlashDismissedValue("");
+      setPrompt(appendWorkspacePathToPrompt(prompt, workspacePath));
+      focusComposerAtEndSoon();
+      return;
+    }
+    if (textOnly) {
+      return;
+    }
+    const dropped = Array.from(event.dataTransfer.files ?? []);
+    if (dropped.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    onPasteAttachmentFiles(dropped);
+  }
+
   function revealCollapsedPromptBlock(index: number): void {
     if (!hasCollapsedPromptBlocks) {
       return;
@@ -839,8 +898,11 @@ export function Composer({
           </>
         ) : null}
         <div
-          className={`composer-frame${ultraEnabled ? " is-ultra" : ""}`}
+          className={`composer-frame${ultraEnabled ? " is-ultra" : ""}${dropActive ? " composer-frame-drop-active" : ""}`}
           ref={composerFrameRef}
+          onDragOver={handleComposerDragOver}
+          onDragLeave={handleComposerDragLeave}
+          onDrop={handleComposerDrop}
         >
           {goalSummary || guideMessages.length > 0 || queuedMessages.length > 0 ? (
             <div className="composer-input-header">

--- a/desktop/src/renderer/WorkspaceFiles.test.tsx
+++ b/desktop/src/renderer/WorkspaceFiles.test.tsx
@@ -6,6 +6,7 @@ import type {
   WorkspaceDirectoryListResult,
   WorkspaceFileReadResult,
 } from "../shared/protocol";
+import { WORKSPACE_FILE_DRAG_MIME } from "./ComposerMessages";
 import { WorkspaceFilePreview, WorkspaceFileTree } from "./WorkspaceFiles";
 
 vi.mock("./WorkspaceMonacoEditor", () => ({
@@ -241,6 +242,48 @@ describe("WorkspaceFileTree", () => {
     expect(listWorkspaceDirectory).toHaveBeenCalledWith("src/components", "/repo");
     const selected = treeShadowRoot().querySelector("[aria-selected='true']");
     expect(selected?.getAttribute("data-item-path")).toBe("src/components/Button.tsx");
+  });
+
+  it("marks tree rows as drag sources carrying the workspace-relative path", async () => {
+    await render(
+      <WorkspaceFileTree activeContext={activeContext} open onOpenFile={() => {}} />,
+    );
+    await settleDirectoryLoads();
+
+    const row = rowButtonByTitle("README.md");
+    expect(row.draggable).toBe(true);
+
+    const setData = vi.fn();
+    const dataTransfer = { effectAllowed: "uninitialized", setData };
+    const event = new Event("dragstart", { bubbles: true, composed: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { configurable: true, value: dataTransfer });
+    await act(async () => {
+      row.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(dataTransfer.effectAllowed).toBe("copy");
+    expect(setData).toHaveBeenCalledWith(WORKSPACE_FILE_DRAG_MIME, "README.md");
+    expect(setData).toHaveBeenCalledWith("text/plain", "README.md");
+  });
+
+  it("keeps the trailing slash when a directory row is dragged", async () => {
+    await render(
+      <WorkspaceFileTree activeContext={activeContext} open onOpenFile={() => {}} />,
+    );
+    await settleDirectoryLoads();
+
+    const row = rowButtonByTitle("src/");
+    const setData = vi.fn();
+    const dataTransfer = { effectAllowed: "uninitialized", setData };
+    const event = new Event("dragstart", { bubbles: true, composed: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { configurable: true, value: dataTransfer });
+    await act(async () => {
+      row.dispatchEvent(event);
+      await Promise.resolve();
+    });
+
+    expect(setData).toHaveBeenCalledWith(WORKSPACE_FILE_DRAG_MIME, "src/");
   });
 
   it("does not reopen the previous file when an external tab changes the tree selection", async () => {

--- a/desktop/src/renderer/WorkspaceFiles.tsx
+++ b/desktop/src/renderer/WorkspaceFiles.tsx
@@ -9,6 +9,7 @@ import type {
   WorkspaceFileTreeEntry
 } from "../shared/protocol";
 import type { WorkspaceFileSelection } from "./LinkTargets";
+import { WORKSPACE_FILE_DRAG_MIME } from "./ComposerMessages";
 import { RichContent } from "./RichContent";
 import type { WorkspaceMonacoViewState } from "./WorkspaceMonacoEditor";
 import { desktopApiErrorMessage } from "./WorkspaceReviewHelpers";
@@ -221,17 +222,40 @@ const WorkspaceFileTreeView = memo(function WorkspaceFileTreeView({ directories,
   useEffect(() => {
     const host = treeFrameRef.current?.querySelector<HTMLElement>("file-tree-container");
     if (!host?.shadowRoot) return undefined;
-    const localizeTreeControls = (): void => {
+    const enhanceShadowTree = (): void => {
       const search = host.shadowRoot?.querySelector<HTMLInputElement>("[data-file-tree-search-input]");
       if (search) search.placeholder = t("workspace.files.searchPlaceholder");
       const options = host.shadowRoot?.querySelector<HTMLButtonElement>("[data-type='context-menu-trigger']");
       if (options) options.setAttribute("aria-label", t("workspace.files.options"));
+      // Rows render without draggable (the library's own drag-and-drop stays
+      // off — it would reselect rows and mutate the tree model). Mark them
+      // as drag sources here so a row can carry its workspace-relative path
+      // into the composer. React does not rewrite props whose value never
+      // changes, so this survives re-renders and only needs re-applying when
+      // virtualization remounts a row — which this observer covers.
+      for (const row of host.shadowRoot?.querySelectorAll<HTMLElement>("[data-item-path]") ?? []) {
+        row.draggable = true;
+      }
     };
-    localizeTreeControls();
-    const observer = new MutationObserver(localizeTreeControls);
+    enhanceShadowTree();
+    const observer = new MutationObserver(enhanceShadowTree);
     observer.observe(host.shadowRoot, { childList: true, subtree: true });
     return () => observer.disconnect();
   }, [locale]);
+
+  useEffect(() => {
+    const frame = treeFrameRef.current;
+    if (!frame) return undefined;
+    const handleDragStart = (event: DragEvent): void => {
+      const path = workspaceTreeDragPath(event.composedPath());
+      if (!path || !event.dataTransfer) return;
+      event.dataTransfer.effectAllowed = "copy";
+      event.dataTransfer.setData(WORKSPACE_FILE_DRAG_MIME, path);
+      event.dataTransfer.setData("text/plain", path);
+    };
+    frame.addEventListener("dragstart", handleDragStart);
+    return () => frame.removeEventListener("dragstart", handleDragStart);
+  }, []);
 
   return (
     <div className="workspace-file-tree-frame" ref={treeFrameRef}>
@@ -411,6 +435,21 @@ function WorkspaceTreeContextMenu({
 
 function absoluteWorkspacePath(root: string, path: string): string {
   return `${root.replace(/[\\/]+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+/**
+ * Resolve the workspace-relative path carried by a tree row drag. Rows live
+ * in the tree's shadow root, so walk the composed path instead of reading
+ * event.target, which is retargeted to the shadow host. Tree paths are
+ * already workspace-relative; directories keep their trailing slash.
+ */
+export function workspaceTreeDragPath(eventPath: readonly EventTarget[]): string | undefined {
+  for (const target of eventPath) {
+    if (target instanceof HTMLElement && target.dataset.itemPath) {
+      return target.dataset.itemPath;
+    }
+  }
+  return undefined;
 }
 
 function normalizeSelectedWorkspaceFilePath(path: string | undefined, workspaceRoot: string | undefined): string | undefined {

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -1493,6 +1493,7 @@ export const enUS = {
   "composer.preview.empty": "Empty message",
   "composer.compactingContext": "Compacting context",
   "composer.attachment.imagesAndPdfOnly": "Only images and PDFs are supported",
+  "composer.attachment.pdfTooLarge": "\"{name}\" exceeds the {limit}MB PDF size limit",
   "composer.attachment.addFailed": "Failed to add attachment",
   "turn.interrupted.title": "Response interrupted",
   "turn.stopped.title": "Stopped",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -1491,6 +1491,7 @@ export const zhCN = {
   "composer.preview.empty": "空消息",
   "composer.compactingContext": "正在压缩上下文",
   "composer.attachment.imagesAndPdfOnly": "仅支持图片和 PDF",
+  "composer.attachment.pdfTooLarge": "「{name}」超过 PDF {limit}MB 大小上限",
   "composer.attachment.addFailed": "附件添加失败",
   "turn.interrupted.title": "回复已中断",
   "turn.stopped.title": "已停止",

--- a/desktop/src/renderer/main.tsx
+++ b/desktop/src/renderer/main.tsx
@@ -34,6 +34,19 @@ applyMessageFlowFontSize(
   window.wuu?.initialMessageFlowFontSize ?? MESSAGE_FLOW_FONT_SIZE_RANGE.default,
 );
 
+// Chromium's default for a file dropped anywhere without a drop handler is
+// to navigate the window to it, replacing the whole UI. Composers handle
+// (and prevent) their own file drops; this keeps stray file drops
+// everywhere else inert. Text drags pass through so native textarea
+// drag-and-drop keeps working.
+const ignoreStrayFileDrop = (event: DragEvent): void => {
+  if (event.dataTransfer?.types.includes("Files")) {
+    event.preventDefault();
+  }
+};
+window.addEventListener("dragover", ignoreStrayFileDrop);
+window.addEventListener("drop", ignoreStrayFileDrop);
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <I18nProvider><App /></I18nProvider>,
 );

--- a/desktop/src/renderer/styles/composer.css
+++ b/desktop/src/renderer/styles/composer.css
@@ -120,6 +120,11 @@
   pointer-events: none;
 }
 
+.composer-frame.composer-frame-drop-active::after {
+  border-color: var(--ink);
+  box-shadow: inset 0 0 0 1px var(--ink-overlay-18);
+}
+
 .composer-ultra-button {
   position: absolute;
   top: -11px;

--- a/desktop/src/renderer/styles/workspace.css
+++ b/desktop/src/renderer/styles/workspace.css
@@ -3613,6 +3613,13 @@ html.resizing-workspace-terminal-split * {
   box-shadow: 0 10px 26px var(--split-composer-shadow);
 }
 
+.split-composer-shell.split-composer-shell-drop-active {
+  border-color: var(--ink);
+  box-shadow:
+    0 10px 26px var(--split-composer-shadow),
+    inset 0 0 0 1px var(--ink-overlay-18);
+}
+
 .split-composer textarea {
   width: 100%;
   height: 60px;


### PR DESCRIPTION
Closes #130.

Two drag sources, per the issue's settled design:

- **File tree → path reference.** Workspace tree rows are drag sources carrying their workspace-relative path under a custom MIME (`application/x-wuu-workspace-path`). Dropping one on a composer appends the path to the prompt as plain text — editable, zero protocol change, and the model resolves it with its own tools. The tree library's own drag-and-drop stays disabled (it reselects rows on drag start and mutates the tree model on internal drops); rows are marked `draggable` imperatively in the shadow root via the existing MutationObserver.
- **Finder/Desktop → content copy.** External files go through the same `attachComposerAttachmentFiles` pipeline as paste and the picker: `image/*` + `application/pdf` only, multi-file, folders and unsupported types rejected with the same status message. Files dragged in from inside the workspace are treated the same — one gesture, one semantics.

Also in scope:

- PDF attachments are now capped at 20MB raw (~27MB after base64, inside Anthropic's 32MB single-file ceiling). Oversized files are rejected with an explicit reason before any bytes are read.
- Dock/hero and split-pane composers highlight while an acceptable payload hovers (same `relatedTarget` guard as the message-edit drop zone). Path drops work on the text-only side-thread composer; external files follow each surface's attachment support and the read-only gate, matching paste.
- A window-level guard keeps Chromium from navigating the window to a file dropped outside any target; text drags pass through so native textarea drag-and-drop is unaffected.

Tests: `tsc --noEmit`, `test:unit` (174 files / 1835 tests), `test:perf`, `test:dev-launcher` all pass. New coverage: tree drag payload + directory trailing slash, path insertion (main + split + text-only), file-drop forwarding, read-only gating, hover highlight lifecycle, oversized-PDF rejection.
