### PR TITLE
feat: add app-server Run control for exec

### DIFF
--- a/cmd/wuu/main.go
+++ b/cmd/wuu/main.go
@@ -144,10 +144,21 @@ func runExecutionRuns(args []string) error {
 	workdir := fs.String("workdir", "", "workspace directory")
 	status := fs.String("status", "", "filter by status")
 	limit := fs.Int("limit", 50, "maximum number of runs")
-	if err := fs.Parse(args); err != nil {
+	readID := ""
+	parseArgs := args
+	if len(args) > 0 && args[0] == "read" {
+		if len(args) < 2 {
+			return errors.New("usage: wuu runs read RUN_ID [flags]")
+		}
+		readID = args[1]
+		parseArgs = args[2:]
+	}
+	if err := fs.Parse(parseArgs); err != nil {
 		return err
 	}
-	if fs.NArg() > 2 || (fs.NArg() > 0 && fs.Arg(0) != "read") || (fs.NArg() == 1) {
+	if readID == "" && fs.NArg() == 2 && fs.Arg(0) == "read" {
+		readID = fs.Arg(1)
+	} else if fs.NArg() != 0 {
 		return errors.New("usage: wuu runs [read RUN_ID] [flags]")
 	}
 	home, err := statepath.Home("")
@@ -158,8 +169,8 @@ func runExecutionRuns(args []string) error {
 	if err != nil {
 		return err
 	}
-	if fs.NArg() == 2 {
-		return runExecutionRead(store, fs.Arg(1), *jsonOutput)
+	if readID != "" {
+		return runExecutionRead(store, readID, *jsonOutput)
 	}
 	var workspaceRoot string
 	if !*allWorkspaces {

--- a/cmd/wuu/main.go
+++ b/cmd/wuu/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/appserver"
 	"github.com/blueberrycongee/wuu/internal/config"
 	wuuexec "github.com/blueberrycongee/wuu/internal/exec"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/gitattribution"
 	"github.com/blueberrycongee/wuu/internal/providers/codex"
 	"github.com/blueberrycongee/wuu/internal/runtime"
@@ -71,6 +72,8 @@ func run(args []string) error {
 		return runModels(args[1:])
 	case "run":
 		return runLegacyRun(args[1:])
+	case "runs":
+		return runExecutionRuns(args[1:])
 	case "exec":
 		return runExec(args[1:])
 	case "probe-title":
@@ -130,6 +133,69 @@ func runVersion(args []string) error {
 	}
 
 	fmt.Println(info.String())
+	return nil
+}
+
+func runExecutionRuns(args []string) error {
+	fs := flag.NewFlagSet("runs", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOutput := fs.Bool("json", false, "output runs as JSON")
+	allWorkspaces := fs.Bool("all-workspaces", false, "include runs from every workspace")
+	workdir := fs.String("workdir", "", "workspace directory")
+	status := fs.String("status", "", "filter by status")
+	limit := fs.Int("limit", 50, "maximum number of runs")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 2 || (fs.NArg() > 0 && fs.Arg(0) != "read") || (fs.NArg() == 1) {
+		return errors.New("usage: wuu runs [read RUN_ID] [flags]")
+	}
+	home, err := statepath.Home("")
+	if err != nil {
+		return err
+	}
+	store, err := execution.NewStore(statepath.SessionsDir(home))
+	if err != nil {
+		return err
+	}
+	if fs.NArg() == 2 {
+		return runExecutionRead(store, fs.Arg(1), *jsonOutput)
+	}
+	var workspaceRoot string
+	if !*allWorkspaces {
+		workspaceRoot, err = resolveWorkdir(*workdir)
+		if err != nil {
+			return err
+		}
+	}
+	runs, err := store.List(context.Background(), execution.ListOptions{
+		WorkspaceRoot: workspaceRoot, Status: execution.Status(strings.TrimSpace(*status)), Limit: *limit,
+	})
+	if err != nil {
+		return err
+	}
+	if *jsonOutput {
+		return printJSON(map[string]any{"runs": runs})
+	}
+	for _, run := range runs {
+		fmt.Printf("%s\t%s\t%s\t%s\n", run.ID, run.Status, run.ThreadID, run.UpdatedAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+func runExecutionRead(store *execution.Store, id string, jsonOutput bool) error {
+	run, err := store.Get(context.Background(), strings.TrimSpace(id))
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return printJSON(run)
+	}
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
 	return nil
 }
 
@@ -2178,6 +2244,11 @@ Session commands:
                    replay a session trace artifact
   search [--json] QUERY [--workdir DIR]
                    search session metadata and history
+
+Execution runs:
+  runs [--json] [--workdir DIR] [--status STATUS]
+                   list persisted execution Run manifests
+  runs read RUN_ID  inspect one execution Run manifest
   archive [--json] THREAD_ID
                    hide a session from default lists
   delete [--json] THREAD_ID

--- a/docs/en/automation/exec.md
+++ b/docs/en/automation/exec.md
@@ -132,7 +132,8 @@ Default mode is automation-safe:
 
 - stdout contains only the final agent message.
 - stderr contains run metadata such as provider, model, workspace, thread id,
-  turn id, tool progress, and trace path.
+  turn id, tool progress, and trace path. JSONL events also carry the execution
+  `run_id` when they are associated with a Run.
 - stdout does not contain banners, progress lines, terminal control codes, or
   debug logs.
 
@@ -204,8 +205,9 @@ MCP servers. `--env KEY=VALUE` is repeatable and applies only to the current
 run. `--max-turns` caps the
 model/tool loop for the current user turn.
 `--output-schema` reads a JSON Schema file, instructs the agent to return only
-JSON, validates the final answer locally, and gives the agent a limited number
-of correction turns when the result does not match the schema. JSONL `result`
+JSON, and validates the final answer as part of the app-server execution Run.
+Correction turns are created by the app-server inside that same Run, so a
+structured-output invocation never starts a second lifecycle. JSONL `result`
 events include `structured_result` after successful validation.
 
 With neither option, `wuu exec` uses the user config at

--- a/internal/appserver/model.go
+++ b/internal/appserver/model.go
@@ -354,6 +354,7 @@ func (th *threadState) releaseTurnExecutionLocked(turnID string) {
 	th.running = false
 	th.currentTurn = ""
 	th.currentTurnKind = ""
+	th.currentExecutionRunID = ""
 	th.currentTurnResumed = false
 	th.runningProviderName = ""
 	th.runningModel = ""

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -1430,7 +1430,8 @@ type RunListResult struct {
 }
 
 type RunInterruptParams struct {
-	RunID string `json:"run_id"`
+	RunID  string `json:"run_id"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type RunInterruptResult struct {

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
 	"github.com/blueberrycongee/wuu/internal/automation"
 	"github.com/blueberrycongee/wuu/internal/capability"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/extensions"
 	"github.com/blueberrycongee/wuu/internal/insight"
 	"github.com/blueberrycongee/wuu/internal/modelroles"
@@ -92,6 +93,10 @@ const (
 	MethodTurnSteer        = "turn/steer"
 	MethodTurnUnsteer      = "turn/unsteer"
 	MethodTurnInterrupt    = "turn/interrupt"
+	MethodRunStart         = "run/start"
+	MethodRunRead          = "run/read"
+	MethodRunList          = "run/list"
+	MethodRunInterrupt     = "run/interrupt"
 	MethodProcessList      = "process/list"
 	MethodProcessRead      = "process/read"
 	MethodProcessWrite     = "process/write"
@@ -143,6 +148,8 @@ const (
 	NotificationTurnEvent              = "turn/event"
 	NotificationTurnError              = "turn/error"
 	NotificationTurnCompleted          = "turn/completed"
+	NotificationRunStarted             = "run/started"
+	NotificationRunUpdated             = "run/updated"
 	NotificationSideThreadEvent        = "sideThread/event"
 	NotificationActivityStarted        = "activity/started"
 	NotificationActivityUpdated        = "activity/updated"
@@ -1378,6 +1385,64 @@ type TurnStartFile struct {
 
 type TurnStartResult struct {
 	Turn Turn `json:"turn"`
+}
+
+// Run is the public control and observation boundary for one agent invocation.
+// Its Turns refer to canonical Thread/Turn records rather than copying them.
+type Run = execution.Run
+
+type RunStartParams struct {
+	ThreadID       string            `json:"thread_id"`
+	Prompt         string            `json:"prompt"`
+	Images         []TurnStartImage  `json:"images,omitempty"`
+	Files          []TurnStartFile   `json:"files,omitempty"`
+	PermissionMode *string           `json:"permission_mode,omitempty"`
+	Request        execution.Request `json:"request"`
+	OutputSchema   json.RawMessage   `json:"output_schema,omitempty"`
+}
+
+type RunStartResult struct {
+	Run Run `json:"run"`
+}
+
+type RunReadParams struct {
+	RunID string `json:"run_id"`
+}
+
+type RunView struct {
+	Run      Run     `json:"run"`
+	Thread   *Thread `json:"thread,omitempty"`
+	Attached bool    `json:"attached"`
+}
+
+type RunReadResult = RunView
+
+type RunListParams struct {
+	WorkspaceID   string           `json:"workspace_id,omitempty"`
+	WorkspaceRoot string           `json:"workspace_root,omitempty"`
+	ThreadID      string           `json:"thread_id,omitempty"`
+	Status        execution.Status `json:"status,omitempty"`
+	Limit         int              `json:"limit,omitempty"`
+}
+
+type RunListResult struct {
+	Runs []Run `json:"runs"`
+}
+
+type RunInterruptParams struct {
+	RunID string `json:"run_id"`
+}
+
+type RunInterruptResult struct {
+	Run Run `json:"run"`
+}
+
+type RunStartedNotification struct {
+	Run Run `json:"run"`
+}
+
+type RunUpdatedNotification struct {
+	Run Run `json:"run"`
 }
 
 type ThreadCompactStartParams struct {

--- a/internal/appserver/run_handlers.go
+++ b/internal/appserver/run_handlers.go
@@ -11,13 +11,15 @@ import (
 	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/runtime"
+	"github.com/blueberrycongee/wuu/internal/structuredoutput"
 	"github.com/blueberrycongee/wuu/internal/version"
 )
 
 type runTracker struct {
-	id           string
-	threadID     string
-	outputSchema json.RawMessage
+	id        string
+	threadID  string
+	validator *structuredoutput.Validator
+	retries   int
 }
 
 func (s *Server) handleRunStart(ctx context.Context, req Request) error {
@@ -50,6 +52,10 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 	if isManualCompactPrompt(params.Prompt) {
 		return s.writeRunError(req.ID, "invalid_params", errors.New("execution runs do not accept compact commands"))
 	}
+	validator, err := structuredoutput.New(params.OutputSchema)
+	if err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
 	th, err := s.ensureThreadLoaded(params.ThreadID)
 	if err != nil {
 		return s.writeRunError(req.ID, "thread_not_found", err)
@@ -58,7 +64,11 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 	if err != nil {
 		return s.writeRunError(req.ID, "invalid_params", err)
 	}
-	userMsg, err := userMessageFromPrompt(params.Prompt, images, files, s.rt.ExperimentalHelpMe)
+	prompt := params.Prompt
+	if validator != nil {
+		prompt = validator.InitialPrompt(prompt)
+	}
+	userMsg, err := userMessageFromPrompt(prompt, images, files, s.rt.ExperimentalHelpMe)
 	if err != nil {
 		return s.writeRunError(req.ID, "invalid_params", err)
 	}
@@ -118,7 +128,7 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 		_, _ = s.runStore.Fail(ctx, run.ID, execution.StatusFailed, execution.Result{}, execution.Error{Code: "manifest_update_failed", Category: "internal", Message: err.Error()}, time.Now().UTC())
 		return s.writeRunError(req.ID, "internal_error", errors.Join(err, persistErr))
 	}
-	s.registerExecutionRun(run, params.OutputSchema)
+	s.registerExecutionRun(run, validator)
 
 	launch, accepted := s.reserveBackground(func() {
 		s.runTurn(started.ctx, th, threadRuntime, started.turnID, started.runtime, started.history)
@@ -275,10 +285,10 @@ func (s *Server) executionFactsForThread(th *threadState, threadRuntime *runtime
 	}, ephemeral
 }
 
-func (s *Server) registerExecutionRun(run execution.Run, outputSchema json.RawMessage) {
+func (s *Server) registerExecutionRun(run execution.Run, validator *structuredoutput.Validator) {
 	s.runMu.Lock()
 	defer s.runMu.Unlock()
-	tracker := &runTracker{id: run.ID, threadID: run.ThreadID, outputSchema: append(json.RawMessage(nil), outputSchema...)}
+	tracker := &runTracker{id: run.ID, threadID: run.ThreadID, validator: validator}
 	s.runs[run.ID] = tracker
 	s.activeRunByThread[run.ThreadID] = run.ID
 }
@@ -294,6 +304,23 @@ func (s *Server) activeExecutionRunID(threadID string) string {
 	s.runMu.Lock()
 	defer s.runMu.Unlock()
 	return s.activeRunByThread[strings.TrimSpace(threadID)]
+}
+
+func (s *Server) executionRunSchemaOutcome(runID, content string) (retryPrompt string, retry bool, validationErr error) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	tracker := s.runs[runID]
+	if tracker == nil || tracker.validator == nil {
+		return "", false, nil
+	}
+	if err := tracker.validator.Validate(content); err == nil {
+		return "", false, nil
+	} else if tracker.retries < structuredoutput.MaxRetries {
+		tracker.retries++
+		return tracker.validator.RetryPrompt(content, err), true, nil
+	} else {
+		return "", false, err
+	}
 }
 
 func (s *Server) attachExecutionTurn(runID, threadID, turnID string, at time.Time) error {
@@ -350,6 +377,44 @@ func (s *Server) executionRunAwaitsContinuation(threadID string, threadRuntime *
 		return true
 	}
 	return ok && goal.CanAutoContinue()
+}
+
+func (s *Server) startExecutionSchemaRetry(ctx context.Context, th *threadState, snapshot turnRuntimeSnapshot, prompt string) error {
+	if th == nil || strings.TrimSpace(snapshot.ExecutionRunID) == "" {
+		return errors.New("structured-output retry requires an attached execution run")
+	}
+	userMsg, err := userMessageFromPrompt(prompt, nil, nil, s.rt.ExperimentalHelpMe)
+	if err != nil {
+		return err
+	}
+	var threadRuntime *runtime.ThreadRuntime
+	started, ok, err := s.startThreadUserTurnWithAdmission(ctx, th, userMsg, snapshot, true, turnReadOnlyIgnore,
+		turnAdmissionHooks{afterLease: func(admitted *threadState, _ *providers.ChatMessage) error {
+			var runtimeErr error
+			threadRuntime, runtimeErr = s.ensureThreadRuntimeAfterAdmission(admitted)
+			return runtimeErr
+		}},
+	)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("thread %q is busy during structured-output retry", th.ID)
+	}
+	if err := s.attachExecutionTurn(started.runtime.ExecutionRunID, th.ID, started.turnID, started.admittedAt); err != nil {
+		return errors.Join(err, s.abortStartedThreadTurnDurably(th, started, err))
+	}
+	if err := s.writeNotification(NotificationTurnStarted, TurnStartedNotification{ThreadID: th.ID, Turn: started.turn}); err != nil {
+		return errors.Join(err, s.abortStartedThreadTurnDurably(th, started, err))
+	}
+	launch, accepted := s.reserveBackground(func() {
+		s.runTurn(started.ctx, th, threadRuntime, started.turnID, started.runtime, started.history)
+	})
+	if !accepted {
+		return errors.Join(errServerClosed, s.abortStartedThreadTurnDurably(th, started, errServerClosed))
+	}
+	launch.Commit()
+	return nil
 }
 
 func (s *Server) detachExecutionRun(runID string) {

--- a/internal/appserver/run_handlers.go
+++ b/internal/appserver/run_handlers.go
@@ -136,24 +136,24 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 	})
 	if !accepted {
 		persistErr := s.abortStartedThreadTurnDurably(th, started, errServerClosed)
-		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
+		_, _ = s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
 		return s.writeRunError(req.ID, "server_closed", errors.Join(errServerClosed, persistErr))
 	}
 	defer launch.Cancel()
 
 	if err := s.writeResponse(req.ID, RunStartResult{Run: run}, nil); err != nil {
 		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
-		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "response_failed", "protocol", err)
+		_, _ = s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "response_failed", "protocol", err)
 		return errors.Join(err, persistErr)
 	}
 	if err := s.writeNotification(NotificationRunStarted, RunStartedNotification{Run: run}); err != nil {
 		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
-		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
+		_, _ = s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
 		return errors.Join(err, persistErr)
 	}
 	if err := s.writeNotification(NotificationTurnStarted, TurnStartedNotification{ThreadID: params.ThreadID, Turn: started.turn}); err != nil {
 		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
-		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
+		_, _ = s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
 		return errors.Join(err, persistErr)
 	}
 	launch.Commit()
@@ -220,11 +220,24 @@ func (s *Server) handleRunInterrupt(ctx context.Context, req Request) error {
 	if strings.EqualFold(strings.TrimSpace(params.Reason), "timeout") {
 		interruptStatus = execution.StatusTimedOut
 	}
-	turnActive, err := s.interruptThreadExecution(view.Run.ThreadID)
+	// Record the caller's reason before cancellation. A fast provider can settle
+	// the Turn synchronously with cancel, so writing this afterward races the
+	// terminal Run update and can misclassify a timeout as a generic interrupt.
+	s.setExecutionRunInterruptStatus(runID, interruptStatus)
+	turnActive, err := s.interruptThreadExecution(view.Run.ThreadID, runID)
 	if err != nil {
+		if errors.Is(err, errExecutionRunChanged) {
+			latest, readErr := s.readExecutionRun(ctx, runID)
+			if readErr == nil && latest.Run.Status.Terminal() {
+				return s.writeResponse(req.ID, RunInterruptResult{Run: latest.Run}, nil)
+			}
+			if readErr != nil {
+				return s.writeRunError(req.ID, "internal_error", readErr)
+			}
+			return s.writeRunError(req.ID, "run_not_attached", err)
+		}
 		return s.writeRunError(req.ID, "internal_error", err)
 	}
-	s.setExecutionRunInterruptStatus(runID, interruptStatus)
 	if !turnActive {
 		status := interruptStatus
 		code, category, message := "interrupted", "cancelled", "execution run interrupted"
@@ -232,7 +245,10 @@ func (s *Server) handleRunInterrupt(ctx context.Context, req Request) error {
 			status = execution.StatusTimedOut
 			code, category, message = "timeout", "timeout", "execution run timed out"
 		}
-		view.Run = s.failAndDetachExecutionRun(runID, status, code, category, errors.New(message))
+		view.Run, err = s.failAndDetachExecutionRun(runID, status, code, category, errors.New(message))
+		if err != nil {
+			return s.writeRunError(req.ID, "internal_error", err)
+		}
 	}
 	return s.writeResponse(req.ID, RunInterruptResult{Run: view.Run}, nil)
 }
@@ -396,16 +412,30 @@ func (s *Server) settleExecutionRunTurn(runID, turnID, tracePath string, turn Tu
 	return run, terminal, nil
 }
 
-func (s *Server) executionRunAwaitsContinuation(threadID string, threadRuntime *runtime.ThreadRuntime) bool {
+func (s *Server) executionRunAwaitsContinuation(threadID string, threadRuntime *runtime.ThreadRuntime) (bool, error) {
 	if threadRuntimeAwaitsAutoContinuation(threadID, threadRuntime) {
-		return true
+		return true, nil
 	}
 	goal, ok, err := s.currentRuntimeGoal(threadID)
 	if err != nil {
-		providers.DebugLogf("inspect execution run goal continuation for thread %q: %v", threadID, err)
-		return true
+		return false, fmt.Errorf("inspect execution run goal continuation for thread %q: %w", threadID, err)
 	}
-	return ok && goal.CanAutoContinue()
+	return ok && goal.CanAutoContinue(), nil
+}
+
+func (s *Server) executionRunSuccessfulTurnOutcome(runID, threadID string, threadRuntime *runtime.ThreadRuntime, content string) (awaitingContinuation bool, retryPrompt string, validationErr error) {
+	awaitingContinuation, err := s.executionRunAwaitsContinuation(threadID, threadRuntime)
+	if err != nil {
+		return false, "", err
+	}
+	if awaitingContinuation {
+		return true, "", nil
+	}
+	prompt, retry, err := s.executionRunSchemaOutcome(runID, content)
+	if retry {
+		return true, prompt, nil
+	}
+	return false, "", err
 }
 
 func (s *Server) startExecutionSchemaRetry(ctx context.Context, th *threadState, snapshot turnRuntimeSnapshot, prompt string) error {
@@ -456,18 +486,22 @@ func (s *Server) detachExecutionRun(runID string) {
 	}
 }
 
-func (s *Server) failAndDetachExecutionRun(runID string, status execution.Status, code, category string, cause error) execution.Run {
+func (s *Server) failAndDetachExecutionRun(runID string, status execution.Status, code, category string, cause error) (execution.Run, error) {
 	message := "execution run failed"
 	if cause != nil {
 		message = cause.Error()
 	}
 	run, err := s.runStore.Fail(context.Background(), runID, status, execution.Result{ExitCode: executionExitCode(status)}, execution.Error{Code: code, Category: category, Message: message}, time.Now().UTC())
 	if err != nil {
-		providers.DebugLogf("settle execution run %q: %v", runID, err)
+		current, readErr := s.runStore.Get(context.Background(), runID)
+		if readErr != nil || !current.Status.Terminal() {
+			return execution.Run{}, fmt.Errorf("settle execution run %q: %w", runID, err)
+		}
+		run = current
 	}
 	s.detachExecutionRun(runID)
 	s.kickQueuedTurnDrain(run.ThreadID)
-	return run
+	return run, nil
 }
 
 func executionExitCode(status execution.Status) int {
@@ -491,7 +525,7 @@ func (s *Server) interruptAttachedRunsOnClose() {
 	}
 	s.runMu.Unlock()
 	for _, id := range ids {
-		s.failAndDetachExecutionRun(id, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
+		_, _ = s.failAndDetachExecutionRun(id, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
 	}
 }
 

--- a/internal/appserver/run_handlers.go
+++ b/internal/appserver/run_handlers.go
@@ -16,10 +16,11 @@ import (
 )
 
 type runTracker struct {
-	id        string
-	threadID  string
-	validator *structuredoutput.Validator
-	retries   int
+	id              string
+	threadID        string
+	validator       *structuredoutput.Validator
+	retries         int
+	interruptStatus execution.Status
 }
 
 func (s *Server) handleRunStart(ctx context.Context, req Request) error {
@@ -215,12 +216,23 @@ func (s *Server) handleRunInterrupt(ctx context.Context, req Request) error {
 	if !view.Attached {
 		return s.writeRunError(req.ID, "run_not_attached", fmt.Errorf("run %q is not attached to this app-server", runID))
 	}
+	interruptStatus := execution.StatusInterrupted
+	if strings.EqualFold(strings.TrimSpace(params.Reason), "timeout") {
+		interruptStatus = execution.StatusTimedOut
+	}
 	turnActive, err := s.interruptThreadExecution(view.Run.ThreadID)
 	if err != nil {
 		return s.writeRunError(req.ID, "internal_error", err)
 	}
+	s.setExecutionRunInterruptStatus(runID, interruptStatus)
 	if !turnActive {
-		view.Run = s.failAndDetachExecutionRun(runID, execution.StatusInterrupted, "interrupted", "cancelled", errors.New("execution run interrupted"))
+		status := interruptStatus
+		code, category, message := "interrupted", "cancelled", "execution run interrupted"
+		if strings.EqualFold(strings.TrimSpace(params.Reason), "timeout") {
+			status = execution.StatusTimedOut
+			code, category, message = "timeout", "timeout", "execution run timed out"
+		}
+		view.Run = s.failAndDetachExecutionRun(runID, status, code, category, errors.New(message))
 	}
 	return s.writeResponse(req.ID, RunInterruptResult{Run: view.Run}, nil)
 }
@@ -323,6 +335,23 @@ func (s *Server) executionRunSchemaOutcome(runID, content string) (retryPrompt s
 	}
 }
 
+func (s *Server) setExecutionRunInterruptStatus(runID string, status execution.Status) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	if tracker := s.runs[strings.TrimSpace(runID)]; tracker != nil {
+		tracker.interruptStatus = status
+	}
+}
+
+func (s *Server) executionRunInterruptStatus(runID string) execution.Status {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	if tracker := s.runs[strings.TrimSpace(runID)]; tracker != nil && tracker.interruptStatus != "" {
+		return tracker.interruptStatus
+	}
+	return execution.StatusInterrupted
+}
+
 func (s *Server) attachExecutionTurn(runID, threadID, turnID string, at time.Time) error {
 	if strings.TrimSpace(runID) == "" {
 		return nil
@@ -343,7 +372,7 @@ func (s *Server) settleExecutionRunTurn(runID, turnID, tracePath string, turn Tu
 	if turnErr != nil {
 		status := execution.StatusFailed
 		if turn.Status == TurnStatusInterrupted || errors.Is(turnErr, context.Canceled) {
-			status = execution.StatusInterrupted
+			status = s.executionRunInterruptStatus(runID)
 		}
 		result.ExitCode = executionExitCode(status)
 		runError := execution.Error{Code: "turn_failed", Category: "unknown", Message: turnErr.Error()}

--- a/internal/appserver/run_handlers.go
+++ b/internal/appserver/run_handlers.go
@@ -1,0 +1,407 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/execution"
+	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/runtime"
+	"github.com/blueberrycongee/wuu/internal/version"
+)
+
+type runTracker struct {
+	id           string
+	threadID     string
+	outputSchema json.RawMessage
+}
+
+func (s *Server) handleRunStart(ctx context.Context, req Request) error {
+	var params RunStartParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	if s.runStore == nil || s.rt == nil || s.rt.InferenceJournalRuntime == nil {
+		return s.writeRunError(req.ID, "internal_error", errors.New("execution run store is unavailable"))
+	}
+	params.ThreadID = strings.TrimSpace(params.ThreadID)
+	params.Prompt = strings.TrimSpace(params.Prompt)
+	if params.Request.Mode == "" {
+		params.Request.Mode = execution.ModeStart
+	}
+	if params.ThreadID == "" {
+		return s.writeRunError(req.ID, "invalid_params", errors.New("thread_id is required"))
+	}
+	images, err := normalizeTurnStartImages(params.Images)
+	if err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	files, err := normalizeTurnStartFiles(params.Files)
+	if err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	if params.Prompt == "" && len(images) == 0 && len(files) == 0 {
+		return s.writeRunError(req.ID, "invalid_params", errors.New("prompt or attachment is required"))
+	}
+	if isManualCompactPrompt(params.Prompt) {
+		return s.writeRunError(req.ID, "invalid_params", errors.New("execution runs do not accept compact commands"))
+	}
+	th, err := s.ensureThreadLoaded(params.ThreadID)
+	if err != nil {
+		return s.writeRunError(req.ID, "thread_not_found", err)
+	}
+	permissions, err := s.resolveThreadTurnPermissions(th, params.PermissionMode)
+	if err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	userMsg, err := userMessageFromPrompt(params.Prompt, images, files, s.rt.ExperimentalHelpMe)
+	if err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+
+	params.Request.HasPrompt = params.Prompt != ""
+	params.Request.ImageCount = len(images)
+	params.Request.FileCount = len(files)
+	params.Request.StructuredOutput = len(params.OutputSchema) > 0
+	workspace, initialRuntime, ephemeral := s.executionFactsForThread(th, nil, turnRuntimeSnapshot{}.withPermissions(permissions))
+	run, err := s.runStore.Create(ctx, execution.CreateParams{
+		RuntimeID: s.rt.InferenceJournalRuntime.RuntimeID(),
+		Request:   params.Request,
+		Runtime:   initialRuntime,
+		Workspace: workspace,
+		ThreadID:  params.ThreadID,
+		Ephemeral: ephemeral,
+	})
+	if err != nil {
+		code := "internal_error"
+		if errors.Is(err, execution.ErrConflict) {
+			code = "thread_busy"
+		}
+		return s.writeRunError(req.ID, code, err)
+	}
+
+	snapshot := turnRuntimeSnapshot{}.withPermissions(permissions)
+	snapshot.PermissionExplicit = params.PermissionMode != nil
+	snapshot.Ultra = s.rt.UltraMode()
+	snapshot.ExecutionRunID = run.ID
+	var threadRuntime *runtime.ThreadRuntime
+	started, ok, admissionErr := s.startThreadUserTurnWithAdmission(
+		ctx, th, userMsg, snapshot, true, turnReadOnlyIgnore,
+		turnAdmissionHooks{afterLease: func(admitted *threadState, _ *providers.ChatMessage) error {
+			var runtimeErr error
+			threadRuntime, runtimeErr = s.ensureThreadRuntimeAfterAdmission(admitted)
+			if runtimeErr == nil {
+				s.foldFrozenWorkerTree(admitted, threadRuntime)
+			}
+			return runtimeErr
+		}},
+	)
+	if admissionErr != nil || !ok {
+		if admissionErr == nil {
+			admissionErr = fmt.Errorf("thread %q already has a running turn", params.ThreadID)
+		}
+		_, _ = s.runStore.Fail(ctx, run.ID, execution.StatusCancelled, execution.Result{}, execution.Error{Code: "admission_failed", Category: "cancelled", Message: admissionErr.Error()}, time.Now().UTC())
+		return s.writeRunError(req.ID, "thread_busy", admissionErr)
+	}
+
+	workspace, resolvedRuntime, _ := s.executionFactsForThread(th, threadRuntime, started.runtime)
+	run, err = s.runStore.Resolve(ctx, run.ID, resolvedRuntime, workspace, time.Now().UTC())
+	if err == nil {
+		run, err = s.runStore.AttachTurn(ctx, run.ID, params.ThreadID, started.turnID, started.admittedAt)
+	}
+	if err != nil {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
+		_, _ = s.runStore.Fail(ctx, run.ID, execution.StatusFailed, execution.Result{}, execution.Error{Code: "manifest_update_failed", Category: "internal", Message: err.Error()}, time.Now().UTC())
+		return s.writeRunError(req.ID, "internal_error", errors.Join(err, persistErr))
+	}
+	s.registerExecutionRun(run, params.OutputSchema)
+
+	launch, accepted := s.reserveBackground(func() {
+		s.runTurn(started.ctx, th, threadRuntime, started.turnID, started.runtime, started.history)
+	})
+	if !accepted {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, errServerClosed)
+		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
+		return s.writeRunError(req.ID, "server_closed", errors.Join(errServerClosed, persistErr))
+	}
+	defer launch.Cancel()
+
+	if err := s.writeResponse(req.ID, RunStartResult{Run: run}, nil); err != nil {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
+		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "response_failed", "protocol", err)
+		return errors.Join(err, persistErr)
+	}
+	if err := s.writeNotification(NotificationRunStarted, RunStartedNotification{Run: run}); err != nil {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
+		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
+		return errors.Join(err, persistErr)
+	}
+	if err := s.writeNotification(NotificationTurnStarted, TurnStartedNotification{ThreadID: params.ThreadID, Turn: started.turn}); err != nil {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
+		s.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "notification_failed", "protocol", err)
+		return errors.Join(err, persistErr)
+	}
+	launch.Commit()
+	return nil
+}
+
+func (s *Server) handleRunRead(ctx context.Context, req Request) error {
+	var params RunReadParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	view, err := s.readExecutionRun(ctx, strings.TrimSpace(params.RunID))
+	if err != nil {
+		code := "internal_error"
+		if errors.Is(err, execution.ErrNotFound) {
+			code = "run_not_found"
+		}
+		return s.writeRunError(req.ID, code, err)
+	}
+	return s.writeResponse(req.ID, RunReadResult(view), nil)
+}
+
+func (s *Server) handleRunList(ctx context.Context, req Request) error {
+	var params RunListParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	if s.runStore == nil {
+		return s.writeRunError(req.ID, "internal_error", errors.New("execution run store is unavailable"))
+	}
+	runs, err := s.runStore.List(ctx, execution.ListOptions{
+		WorkspaceID: strings.TrimSpace(params.WorkspaceID), WorkspaceRoot: strings.TrimSpace(params.WorkspaceRoot),
+		ThreadID: strings.TrimSpace(params.ThreadID), Status: params.Status, Limit: params.Limit,
+	})
+	if err != nil {
+		return s.writeRunError(req.ID, "internal_error", err)
+	}
+	return s.writeResponse(req.ID, RunListResult{Runs: runs}, nil)
+}
+
+func (s *Server) handleRunInterrupt(ctx context.Context, req Request) error {
+	var params RunInterruptParams
+	if err := decodeParams(req.Params, &params); err != nil {
+		return s.writeRunError(req.ID, "invalid_params", err)
+	}
+	runID := strings.TrimSpace(params.RunID)
+	if runID == "" {
+		return s.writeRunError(req.ID, "invalid_params", errors.New("run_id is required"))
+	}
+	view, err := s.readExecutionRun(ctx, runID)
+	if err != nil {
+		if errors.Is(err, execution.ErrNotFound) {
+			return s.writeRunError(req.ID, "run_not_found", err)
+		}
+		return s.writeRunError(req.ID, "internal_error", err)
+	}
+	if view.Run.Status.Terminal() {
+		return s.writeResponse(req.ID, RunInterruptResult{Run: view.Run}, nil)
+	}
+	if !view.Attached {
+		return s.writeRunError(req.ID, "run_not_attached", fmt.Errorf("run %q is not attached to this app-server", runID))
+	}
+	turnActive, err := s.interruptThreadExecution(view.Run.ThreadID)
+	if err != nil {
+		return s.writeRunError(req.ID, "internal_error", err)
+	}
+	if !turnActive {
+		view.Run = s.failAndDetachExecutionRun(runID, execution.StatusInterrupted, "interrupted", "cancelled", errors.New("execution run interrupted"))
+	}
+	return s.writeResponse(req.ID, RunInterruptResult{Run: view.Run}, nil)
+}
+
+func (s *Server) readExecutionRun(ctx context.Context, runID string) (RunView, error) {
+	if s == nil || s.runStore == nil {
+		return RunView{}, errors.New("execution run store is unavailable")
+	}
+	run, err := s.runStore.Get(ctx, runID)
+	if err != nil {
+		return RunView{}, err
+	}
+	view := RunView{Run: run}
+	if th := s.thread(run.ThreadID); th != nil {
+		th.mu.Lock()
+		thread := th.snapshotLocked()
+		th.mu.Unlock()
+		view.Thread = &thread
+		view.Attached = s.executionRunAttached(run.ID)
+		return view, nil
+	}
+	if !run.Ephemeral {
+		if th, loadErr := s.loadPersistedThreadState(run.ThreadID, time.Now().UTC()); loadErr == nil {
+			th.mu.Lock()
+			thread := th.snapshotLocked()
+			th.mu.Unlock()
+			view.Thread = &thread
+		}
+	}
+	return view, nil
+}
+
+func (s *Server) executionFactsForThread(th *threadState, threadRuntime *runtime.ThreadRuntime, snapshot turnRuntimeSnapshot) (execution.WorkspaceRef, execution.RuntimeManifest, bool) {
+	workspace := execution.WorkspaceRef{Root: s.rt.RootDir}
+	selection := execution.Selection{Provider: s.rt.ProviderName, Model: s.rt.Model, PermissionMode: snapshot.PermissionMode}
+	ephemeral := false
+	if th != nil {
+		th.mu.Lock()
+		workspace = execution.WorkspaceRef{ID: th.WorkspaceID, Root: firstNonEmpty(th.CWD, s.rt.RootDir)}
+		selection.Provider = firstNonEmpty(th.ModelProvider, selection.Provider)
+		selection.Model = firstNonEmpty(th.Model, selection.Model)
+		selection.Variant = th.ModelVariant
+		selection.Effort = th.ModelEffort
+		selection.PermissionMode = firstNonEmpty(snapshot.PermissionMode, th.PermissionMode, s.rt.Permissions.Mode)
+		ephemeral = th.Ephemeral
+		th.mu.Unlock()
+	}
+	runner := s.rt.StreamRunner
+	if threadRuntime != nil && threadRuntime.StreamRunner != nil {
+		runner = threadRuntime.StreamRunner
+	}
+	if runner != nil {
+		selection.Provider = firstNonEmpty(runner.ProviderName, selection.Provider)
+		selection.Model = firstNonEmpty(runner.Model, selection.Model)
+		selection.Variant = runner.Variant
+		selection.Effort = runner.Effort
+	}
+	core := version.Info()
+	return workspace, execution.RuntimeManifest{
+		Resolved: selection, ProtocolVersion: ProtocolVersion, CoreVersion: core.Version, CoreCommit: core.Commit,
+		Ultra: snapshot.Ultra, MaxParallel: s.rt.MaxParallel(),
+	}, ephemeral
+}
+
+func (s *Server) registerExecutionRun(run execution.Run, outputSchema json.RawMessage) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	tracker := &runTracker{id: run.ID, threadID: run.ThreadID, outputSchema: append(json.RawMessage(nil), outputSchema...)}
+	s.runs[run.ID] = tracker
+	s.activeRunByThread[run.ThreadID] = run.ID
+}
+
+func (s *Server) executionRunAttached(runID string) bool {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	_, ok := s.runs[runID]
+	return ok
+}
+
+func (s *Server) activeExecutionRunID(threadID string) string {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	return s.activeRunByThread[strings.TrimSpace(threadID)]
+}
+
+func (s *Server) attachExecutionTurn(runID, threadID, turnID string, at time.Time) error {
+	if strings.TrimSpace(runID) == "" {
+		return nil
+	}
+	_, err := s.runStore.AttachTurn(context.Background(), runID, threadID, turnID, at)
+	return err
+}
+
+func (s *Server) settleExecutionRunTurn(runID, turnID, tracePath string, turn Turn, structured *TurnError, turnErr error, awaitingContinuation bool, at time.Time) (execution.Run, bool, error) {
+	if strings.TrimSpace(runID) == "" {
+		return execution.Run{}, false, nil
+	}
+	run, err := s.runStore.FinishTurn(context.Background(), runID, turnID, execution.TurnTerminal{TracePath: tracePath, At: at})
+	if err != nil {
+		return execution.Run{}, false, err
+	}
+	result := execution.Result{FinalTurnID: turnID, TracePath: tracePath}
+	if turnErr != nil {
+		status := execution.StatusFailed
+		if turn.Status == TurnStatusInterrupted || errors.Is(turnErr, context.Canceled) {
+			status = execution.StatusInterrupted
+		}
+		result.ExitCode = executionExitCode(status)
+		runError := execution.Error{Code: "turn_failed", Category: "unknown", Message: turnErr.Error()}
+		if structured != nil {
+			runError = execution.Error{
+				Code: structured.Code, Category: string(structured.Category), Message: structured.Message,
+				Provider: structured.Provider, StatusCode: structured.StatusCode,
+			}
+		}
+		run, err = s.runStore.Fail(context.Background(), runID, status, result, runError, at)
+	} else if !awaitingContinuation {
+		run, err = s.runStore.Complete(context.Background(), runID, result, at)
+	}
+	if err != nil {
+		return execution.Run{}, false, err
+	}
+	terminal := run.Status.Terminal()
+	if terminal {
+		s.detachExecutionRun(runID)
+	}
+	return run, terminal, nil
+}
+
+func (s *Server) executionRunAwaitsContinuation(threadID string, threadRuntime *runtime.ThreadRuntime) bool {
+	if threadRuntimeAwaitsAutoContinuation(threadID, threadRuntime) {
+		return true
+	}
+	goal, ok, err := s.currentRuntimeGoal(threadID)
+	if err != nil {
+		providers.DebugLogf("inspect execution run goal continuation for thread %q: %v", threadID, err)
+		return true
+	}
+	return ok && goal.CanAutoContinue()
+}
+
+func (s *Server) detachExecutionRun(runID string) {
+	s.runMu.Lock()
+	defer s.runMu.Unlock()
+	tracker := s.runs[runID]
+	delete(s.runs, runID)
+	if tracker != nil && s.activeRunByThread[tracker.threadID] == runID {
+		delete(s.activeRunByThread, tracker.threadID)
+	}
+}
+
+func (s *Server) failAndDetachExecutionRun(runID string, status execution.Status, code, category string, cause error) execution.Run {
+	message := "execution run failed"
+	if cause != nil {
+		message = cause.Error()
+	}
+	run, err := s.runStore.Fail(context.Background(), runID, status, execution.Result{ExitCode: executionExitCode(status)}, execution.Error{Code: code, Category: category, Message: message}, time.Now().UTC())
+	if err != nil {
+		providers.DebugLogf("settle execution run %q: %v", runID, err)
+	}
+	s.detachExecutionRun(runID)
+	s.kickQueuedTurnDrain(run.ThreadID)
+	return run
+}
+
+func executionExitCode(status execution.Status) int {
+	switch status {
+	case execution.StatusCompleted:
+		return 0
+	case execution.StatusInterrupted, execution.StatusCancelled:
+		return 5
+	case execution.StatusTimedOut:
+		return 4
+	default:
+		return 1
+	}
+}
+
+func (s *Server) interruptAttachedRunsOnClose() {
+	s.runMu.Lock()
+	ids := make([]string, 0, len(s.runs))
+	for id := range s.runs {
+		ids = append(ids, id)
+	}
+	s.runMu.Unlock()
+	for _, id := range ids {
+		s.failAndDetachExecutionRun(id, execution.StatusInterrupted, "server_closed", "cancelled", errServerClosed)
+	}
+}
+
+func (s *Server) writeRunError(id json.RawMessage, code string, err error) error {
+	resp := Response{ID: id, Error: &ResponseError{Code: code, Message: err.Error()}}
+	return s.writeJSON(resp)
+}

--- a/internal/appserver/run_handlers_test.go
+++ b/internal/appserver/run_handlers_test.go
@@ -3,13 +3,18 @@ package appserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/execution"
+	"github.com/blueberrycongee/wuu/internal/goalruntime"
 	"github.com/blueberrycongee/wuu/internal/hooks"
 	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/runtime"
 	"github.com/blueberrycongee/wuu/internal/session"
 	"github.com/blueberrycongee/wuu/internal/structuredoutput"
 )
@@ -126,4 +131,158 @@ func TestExecutionRunSchemaOutcomeRetriesWithinOneRun(t *testing.T) {
 	if _, retry, validationErr := srv.executionRunSchemaOutcome("run-schema", `{"ok":true}`); retry || validationErr != nil {
 		t.Fatalf("valid outcome = retry %v, error %v", retry, validationErr)
 	}
+}
+
+func TestExecutionRunDefersSchemaValidationUntilContinuationSettles(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	srv := New(rt, &lockedBuffer{})
+	defer srv.Close()
+	validator, err := structuredoutput.New(json.RawMessage(`{"type":"object","required":["ok"]}`))
+	if err != nil {
+		t.Fatalf("New validator: %v", err)
+	}
+	const threadID = "thread-schema-continuation"
+	srv.registerExecutionRun(execution.Run{ID: "run-schema-continuation", ThreadID: threadID}, validator)
+	goalRuntime := goalruntime.NewRuntime(goalruntime.NewStore(filepath.Join(t.TempDir(), "goal.json")))
+	srv.threads[threadID] = &threadState{ID: threadID, execRuntime: &runtime.ThreadRuntime{GoalRuntime: goalRuntime}}
+	if _, err := goalRuntime.Create(goalruntime.Spec{ThreadID: threadID, GoalID: "goal-schema", Objective: "finish the structured task"}); err != nil {
+		t.Fatalf("Create goal: %v", err)
+	}
+
+	awaiting, retryPrompt, validationErr := srv.executionRunSuccessfulTurnOutcome("run-schema-continuation", threadID, nil, `{"wrong":true}`)
+	if !awaiting || retryPrompt != "" || validationErr != nil {
+		t.Fatalf("active goal outcome = awaiting %v, prompt %q, error %v", awaiting, retryPrompt, validationErr)
+	}
+	if retries := srv.runs["run-schema-continuation"].retries; retries != 0 {
+		t.Fatalf("schema retries while continuation pending = %d", retries)
+	}
+
+	if err := goalRuntime.Store().Clear(); err != nil {
+		t.Fatalf("Clear goal: %v", err)
+	}
+	awaiting, retryPrompt, validationErr = srv.executionRunSuccessfulTurnOutcome("run-schema-continuation", threadID, nil, `{"wrong":true}`)
+	if !awaiting || retryPrompt == "" || validationErr != nil {
+		t.Fatalf("final invalid outcome = awaiting %v, prompt %q, error %v", awaiting, retryPrompt, validationErr)
+	}
+}
+
+func TestExecutionRunGoalReadFailureBecomesSettlementError(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	srv := New(rt, &lockedBuffer{})
+	defer srv.Close()
+	const threadID = "thread-corrupt-goal"
+	goalPath := filepath.Join(t.TempDir(), "goal.json")
+	if err := os.MkdirAll(filepath.Dir(goalPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(goalPath, []byte("{not-json\n"), 0o644); err != nil {
+		t.Fatalf("Write corrupt goal: %v", err)
+	}
+	goalRuntime := goalruntime.NewRuntime(goalruntime.NewStore(goalPath))
+	srv.threads[threadID] = &threadState{ID: threadID, execRuntime: &runtime.ThreadRuntime{GoalRuntime: goalRuntime}}
+	run := createEphemeralExecutionRun(t, srv, threadID)
+	if _, err := srv.runStore.AttachTurn(context.Background(), run.ID, threadID, "turn-goal-error", time.Now().UTC()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	srv.registerExecutionRun(run, nil)
+
+	awaiting, retryPrompt, err := srv.executionRunSuccessfulTurnOutcome(run.ID, threadID, nil, `{"ok":true}`)
+	if err == nil || awaiting || retryPrompt != "" {
+		t.Fatalf("corrupt goal outcome = awaiting %v, prompt %q, error %v", awaiting, retryPrompt, err)
+	}
+	settled, terminal, settleErr := srv.settleExecutionRunTurn(run.ID, "turn-goal-error", "/trace/goal-error.jsonl", Turn{ID: "turn-goal-error", Status: TurnStatusCompleted}, nil, err, false, time.Now().UTC())
+	if settleErr != nil {
+		t.Fatalf("settleExecutionRunTurn: %v", settleErr)
+	}
+	if !terminal || settled.Status != execution.StatusFailed || srv.executionRunAttached(run.ID) {
+		t.Fatalf("goal read failure settlement = terminal %v, run %+v, attached %v", terminal, settled, srv.executionRunAttached(run.ID))
+	}
+}
+
+func TestFailAndDetachExecutionRunReturnsExistingTerminalRun(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	srv := New(rt, &lockedBuffer{})
+	defer srv.Close()
+	run := createEphemeralExecutionRun(t, srv, "thread-terminal-race")
+	if _, err := srv.runStore.AttachTurn(context.Background(), run.ID, run.ThreadID, "turn-terminal-race", time.Now().UTC()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	srv.registerExecutionRun(run, nil)
+	completed, err := srv.runStore.Complete(context.Background(), run.ID, execution.Result{FinalTurnID: "turn-terminal-race"}, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	got, err := srv.failAndDetachExecutionRun(run.ID, execution.StatusInterrupted, "interrupted", "cancelled", context.Canceled)
+	if err != nil {
+		t.Fatalf("failAndDetachExecutionRun: %v", err)
+	}
+	if got.ID != completed.ID || got.Status != execution.StatusCompleted {
+		t.Fatalf("race result = %+v, want completed Run %+v", got, completed)
+	}
+	if srv.executionRunAttached(run.ID) {
+		t.Fatal("terminal Run remained attached")
+	}
+}
+
+func TestRunInterruptRecordsTimeoutBeforeCancellingTurn(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	defer srv.Close()
+	run := createEphemeralExecutionRun(t, srv, "thread-timeout-order")
+	if _, err := srv.runStore.AttachTurn(context.Background(), run.ID, run.ThreadID, "turn-timeout-order", time.Now().UTC()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	srv.registerExecutionRun(run, nil)
+	th := newThreadState(run.ThreadID, []providers.ChatMessage{{Role: "system", Content: "system"}}, rt.ProviderName, rt.Model, rt.RootDir, false, time.Now().UTC())
+	observed := execution.Status("")
+	th.cancel = func() { observed = srv.executionRunInterruptStatus(run.ID) }
+	th.currentExecutionRunID = run.ID
+	srv.threads[run.ThreadID] = th
+
+	req := Request{ID: json.RawMessage(`"interrupt"`), Method: MethodRunInterrupt, Params: mustJSON(RunInterruptParams{RunID: run.ID, Reason: "timeout"})}
+	if err := srv.handleRunInterrupt(context.Background(), req); err != nil {
+		t.Fatalf("run/interrupt: %v", err)
+	}
+	if observed != execution.StatusTimedOut {
+		t.Fatalf("interrupt status observed by cancel = %q, want %q", observed, execution.StatusTimedOut)
+	}
+}
+
+func TestRunInterruptDoesNotCancelSuccessorRun(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	srv := New(rt, &lockedBuffer{})
+	defer srv.Close()
+	const threadID = "thread-successor-run"
+	th := newThreadState(threadID, []providers.ChatMessage{{Role: "system", Content: "system"}}, rt.ProviderName, rt.Model, rt.RootDir, false, time.Now().UTC())
+	cancelled := false
+	th.cancel = func() { cancelled = true }
+	th.currentExecutionRunID = "run-successor"
+	srv.threads[threadID] = th
+
+	turnActive, err := srv.interruptThreadExecution(threadID, "run-original")
+	if !errors.Is(err, errExecutionRunChanged) || turnActive {
+		t.Fatalf("interrupt successor = active %v, error %v", turnActive, err)
+	}
+	if cancelled {
+		t.Fatal("stale interrupt cancelled the successor Run")
+	}
+}
+
+func createEphemeralExecutionRun(t *testing.T, srv *Server, threadID string) execution.Run {
+	t.Helper()
+	run, err := srv.runStore.Create(context.Background(), execution.CreateParams{
+		RuntimeID: "test-runtime", Ephemeral: true, ThreadID: threadID,
+		Request: execution.Request{Mode: execution.ModeStart, HasPrompt: true},
+		Runtime: execution.RuntimeManifest{
+			ProtocolVersion: "wuu-app-server/v0.1",
+			Resolved:        execution.Selection{Provider: "fake-provider", Model: "fake-model"},
+		},
+		Workspace: execution.WorkspaceRef{Root: srv.rt.RootDir},
+	})
+	if err != nil {
+		t.Fatalf("Create execution Run: %v", err)
+	}
+	return run
 }

--- a/internal/appserver/run_handlers_test.go
+++ b/internal/appserver/run_handlers_test.go
@@ -1,0 +1,105 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/agent"
+	"github.com/blueberrycongee/wuu/internal/execution"
+	"github.com/blueberrycongee/wuu/internal/hooks"
+	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/session"
+)
+
+func TestRunStartSettlesManifestBeforeRunRead(t *testing.T) {
+	client := &fakeClient{response: providersResponse("run-protocol-ok")}
+	rt := newTestRuntime(t, client)
+	runtimeJournal, err := session.NewInferenceJournalRuntime(rt.SessionDir, "run-test")
+	if err != nil {
+		t.Fatalf("NewInferenceJournalRuntime: %v", err)
+	}
+	rt.InferenceJournalRuntime = runtimeJournal
+	defer runtimeJournal.Close()
+	rt.StreamRunner = &agent.StreamRunner{
+		Client:       providers.AdaptStreamClient(client),
+		ProviderName: rt.ProviderName,
+		Model:        rt.Model,
+		SystemPrompt: "system",
+	}
+	rt.HookDispatcher = hooks.NewDispatcher(nil)
+
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	defer srv.Close()
+	thread := newThreadState("ephemeral-run-thread", []providers.ChatMessage{{Role: "system", Content: "system"}}, rt.ProviderName, rt.Model, rt.RootDir, false, time.Now().UTC())
+	thread.Ephemeral = true
+	srv.threads[thread.ID] = thread
+
+	request := Request{ID: json.RawMessage(`"start"`), Method: MethodRunStart, Params: mustJSON(RunStartParams{
+		ThreadID: thread.ID,
+		Prompt:   "reply with exactly: run-protocol-ok",
+		Request:  execution.Request{Mode: execution.ModeStart, Requested: execution.Selection{Provider: "fake-provider", Model: "fake-model"}},
+	})}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.handleLine(context.Background(), raw); err != nil {
+		t.Fatalf("run/start: %v", err)
+	}
+	startResult := remarshal[RunStartResult](t, responseByID(t, parseOutput(t, out.String()), "start")["result"])
+	run := startResult.Run
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		stored, getErr := srv.runStore.Get(context.Background(), run.ID)
+		if getErr == nil {
+			run = stored
+			if run.Status.Terminal() {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if run.ID == "" {
+		t.Fatalf("run/start did not return a Run: %s", out.String())
+	}
+	if run.Status != execution.StatusCompleted {
+		t.Fatalf("Run status = %q, output: %s", run.Status, out.String())
+	}
+	if len(run.Turns) != 1 || run.Turns[0].TurnID == "" {
+		t.Fatalf("Run turn refs = %+v", run.Turns)
+	}
+	if run.Request.HasPrompt != true || run.Request.ImageCount != 0 {
+		t.Fatalf("Run request facts = %+v", run.Request)
+	}
+	if run.Runtime.Resolved.Provider != "fake-provider" || run.Runtime.Resolved.Model != "fake-model" {
+		t.Fatalf("Run runtime facts = %+v", run.Runtime)
+	}
+	if run.Result == nil || run.Result.FinalTurnID != run.Turns[0].TurnID {
+		t.Fatalf("Run result = %+v", run.Result)
+	}
+
+	readRaw := mustJSON(Request{ID: json.RawMessage(`"read"`), Method: MethodRunRead, Params: mustJSON(RunReadParams{RunID: run.ID})})
+	if err := srv.handleLine(context.Background(), readRaw); err != nil {
+		t.Fatalf("run/read: %v", err)
+	}
+	readResult := remarshal[RunReadResult](t, responseByID(t, parseOutput(t, out.String()), "read")["result"])
+	if readResult.Run.Status != execution.StatusCompleted || readResult.Thread == nil {
+		t.Fatalf("run/read result = %+v", readResult)
+	}
+	if readResult.Attached {
+		t.Fatalf("terminal Run should not remain attached")
+	}
+
+	listRaw := mustJSON(Request{ID: json.RawMessage(`"list"`), Method: MethodRunList, Params: mustJSON(RunListParams{ThreadID: thread.ID})})
+	if err := srv.handleLine(context.Background(), listRaw); err != nil {
+		t.Fatalf("run/list: %v", err)
+	}
+	listResult := remarshal[RunListResult](t, responseByID(t, parseOutput(t, out.String()), "list")["result"])
+	if len(listResult.Runs) != 1 || listResult.Runs[0].ID != run.ID {
+		t.Fatalf("run/list result = %+v", listResult)
+	}
+}

--- a/internal/appserver/run_handlers_test.go
+++ b/internal/appserver/run_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/hooks"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/session"
+	"github.com/blueberrycongee/wuu/internal/structuredoutput"
 )
 
 func TestRunStartSettlesManifestBeforeRunRead(t *testing.T) {
@@ -101,5 +102,28 @@ func TestRunStartSettlesManifestBeforeRunRead(t *testing.T) {
 	listResult := remarshal[RunListResult](t, responseByID(t, parseOutput(t, out.String()), "list")["result"])
 	if len(listResult.Runs) != 1 || listResult.Runs[0].ID != run.ID {
 		t.Fatalf("run/list result = %+v", listResult)
+	}
+}
+
+func TestExecutionRunSchemaOutcomeRetriesWithinOneRun(t *testing.T) {
+	srv := &Server{runs: make(map[string]*runTracker), activeRunByThread: make(map[string]string)}
+	validator, err := structuredoutput.New(json.RawMessage(`{"type":"object","required":["ok"]}`))
+	if err != nil {
+		t.Fatalf("New validator: %v", err)
+	}
+	srv.registerExecutionRun(execution.Run{ID: "run-schema", ThreadID: "thread-schema"}, validator)
+
+	for attempt := 0; attempt < structuredoutput.MaxRetries; attempt++ {
+		prompt, retry, validationErr := srv.executionRunSchemaOutcome("run-schema", `{"wrong":true}`)
+		if !retry || validationErr != nil || prompt == "" {
+			t.Fatalf("attempt %d outcome = prompt %q, retry %v, error %v", attempt, prompt, retry, validationErr)
+		}
+	}
+	_, retry, validationErr := srv.executionRunSchemaOutcome("run-schema", `{"wrong":true}`)
+	if retry || validationErr == nil {
+		t.Fatalf("exhausted outcome = retry %v, error %v", retry, validationErr)
+	}
+	if _, retry, validationErr := srv.executionRunSchemaOutcome("run-schema", `{"ok":true}`); retry || validationErr != nil {
+		t.Fatalf("valid outcome = retry %v, error %v", retry, validationErr)
 	}
 }

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	errServerClosed = errors.New("app-server is closed")
-	errShutdown     = errors.New("app-server shutdown requested")
+	errServerClosed        = errors.New("app-server is closed")
+	errShutdown            = errors.New("app-server shutdown requested")
+	errExecutionRunChanged = errors.New("thread execution belongs to a different Run")
 )
 
 type threadState struct {
@@ -76,18 +77,19 @@ type threadState struct {
 	runtimeSelectionMutation bool
 	runtimeSubscription      *threadRuntimeSubscription
 
-	mu                  sync.Mutex
-	running             bool
-	currentTurn         string
-	currentTurnKind     TurnKind
-	currentTurnResumed  bool
-	runningProviderName string
-	runningModel        string
-	cancel              context.CancelFunc
-	executionLease      *session.ThreadExecutionLease
-	admissionReserved   bool
-	pendingSteers       []providers.ChatMessage
-	interrupting        bool
+	mu                    sync.Mutex
+	running               bool
+	currentTurn           string
+	currentTurnKind       TurnKind
+	currentExecutionRunID string
+	currentTurnResumed    bool
+	runningProviderName   string
+	runningModel          string
+	cancel                context.CancelFunc
+	executionLease        *session.ThreadExecutionLease
+	admissionReserved     bool
+	pendingSteers         []providers.ChatMessage
+	interrupting          bool
 	// Worker-tree freeze (turn/interrupt): while set, agent-completion drains
 	// hold their pending synthetic turns. The next user-initiated turn folds
 	// the whole-tree snapshot into its request (frozenTreeContext) and marks

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/agentcontrol"
 	"github.com/blueberrycongee/wuu/internal/config"
 	"github.com/blueberrycongee/wuu/internal/credentialstore"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/mcp"
 	"github.com/blueberrycongee/wuu/internal/participant"
 	"github.com/blueberrycongee/wuu/internal/process"
@@ -166,6 +167,11 @@ type Server struct {
 	mu      sync.Mutex
 	threads map[string]*threadState
 
+	runMu             sync.Mutex
+	runStore          *execution.Store
+	runs              map[string]*runTracker
+	activeRunByThread map[string]string
+
 	agentTerminalFinalizationMu sync.Mutex
 	agentTerminalFinalizations  map[agentTerminalFinalizationKey]struct{}
 
@@ -256,6 +262,8 @@ func NewWithCredentialStore(rt *runtime.Session, out io.Writer, store credential
 		inferenceMaintenanceStop:     make(chan struct{}),
 		sideTurns:                    make(map[string]*sideThreadTurn),
 		clientCalls:                  make(map[string]chan clientResponse),
+		runs:                         make(map[string]*runTracker),
+		activeRunByThread:            make(map[string]string),
 	}
 	bootOwner := false
 	if rt != nil && strings.TrimSpace(rt.SessionDir) != "" {
@@ -269,6 +277,12 @@ func NewWithCredentialStore(rt *runtime.Session, out io.Writer, store credential
 	}
 	if rt != nil && strings.TrimSpace(rt.SessionDir) != "" {
 		s.sideThreadStore = sidethread.NewStore(filepath.Join(rt.SessionDir, "sidethreads"))
+		runStore, err := execution.NewStore(rt.SessionDir)
+		if err != nil {
+			s.startupErr = fmt.Errorf("open execution run store: %w", err)
+			return s
+		}
+		s.runStore = runStore
 	}
 	if bootOwner {
 		s.recoverSideThreadsOnBoot()
@@ -340,6 +354,14 @@ func (s *Server) settleOnBoot() {
 			providers.DebugLogf("settleOnBoot pass5 (inference journal retention): %v", pruneErr)
 		} else if pruned > 0 {
 			providers.DebugLogf("settleOnBoot pass5: pruned %d old inference operation(s)", pruned)
+		}
+		if s.runStore != nil {
+			recovered, err := s.runStore.ReconcileOrphans(context.Background(), s.rt.InferenceJournalRuntime.RuntimeID(), now)
+			if err != nil {
+				providers.DebugLogf("settleOnBoot pass6 (execution runs): %v", err)
+			} else if len(recovered) > 0 {
+				providers.DebugLogf("settleOnBoot pass6: interrupted %d orphan execution run(s)", len(recovered))
+			}
 		}
 	}
 }
@@ -506,6 +528,7 @@ func (s *Server) Close() {
 		clear(s.drainingGoalContinuation)
 		s.goalContinuationMu.Unlock()
 		s.waitForOwnedShutdown(threads, controls)
+		s.interruptAttachedRunsOnClose()
 		for _, th := range threads {
 			releaseThreadRuntime(th)
 		}
@@ -805,6 +828,14 @@ func (s *Server) handleLine(ctx context.Context, raw []byte) error {
 		return s.handleTurnUnsteer(req)
 	case MethodTurnInterrupt:
 		return s.handleTurnInterrupt(req)
+	case MethodRunStart:
+		return s.handleRunStart(ctx, req)
+	case MethodRunRead:
+		return s.handleRunRead(ctx, req)
+	case MethodRunList:
+		return s.handleRunList(ctx, req)
+	case MethodRunInterrupt:
+		return s.handleRunInterrupt(ctx, req)
 	case MethodProcessList:
 		return s.handleProcessList(req)
 	case MethodProcessRead:

--- a/internal/appserver/thread_handlers.go
+++ b/internal/appserver/thread_handlers.go
@@ -509,6 +509,7 @@ func (s *Server) handleThreadEditMessage(req Request) error {
 	th.Turns = turnsFromHistory(th.ID, committedHistory, now)
 	th.UpdatedAt = now
 	th.currentTurn = ""
+	th.currentExecutionRunID = ""
 	th.currentTurnResumed = false
 	th.nextItemIndex = 0
 	th.activeAgentItemID = ""

--- a/internal/appserver/turn_execution_lease.go
+++ b/internal/appserver/turn_execution_lease.go
@@ -79,6 +79,7 @@ func (s *Server) refreshDurableThreadHistoryLocked(th *threadState) error {
 	th.Turns = applyTokenUsageMetasToTurns(th.Turns, loaded.tokenMetas)
 	th.currentTurn = ""
 	th.currentTurnKind = ""
+	th.currentExecutionRunID = ""
 	th.currentTurnResumed = false
 	th.nextItemIndex = 0
 	th.activeAgentItemID = ""

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/config"
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
 	"github.com/blueberrycongee/wuu/internal/contextbudget"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/goalruntime"
 	"github.com/blueberrycongee/wuu/internal/imageproc"
 	"github.com/blueberrycongee/wuu/internal/insight"
@@ -2139,7 +2140,8 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	if executionRetryPrompt != "" {
 		if retryErr := s.startExecutionSchemaRetry(context.Background(), th, turnRuntime, executionRetryPrompt); retryErr != nil {
 			providers.DebugLogf("start structured-output retry for run %q: %v", turnRuntime.ExecutionRunID, retryErr)
-			_, _, _ = s.settleExecutionRunTurn(turnRuntime.ExecutionRunID, turnID, tracePath, turn, structured, retryErr, false, time.Now())
+			failedRun := s.failAndDetachExecutionRun(turnRuntime.ExecutionRunID, execution.StatusFailed, "structured_output_retry_failed", "internal", retryErr)
+			notify(NotificationRunUpdated, RunUpdatedNotification{Run: failedRun})
 		}
 		return
 	}

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -106,6 +106,7 @@ type turnRuntimeSnapshot struct {
 	// the snapshot so queueing and wakeups keep the admitted value.
 	Ultra           bool
 	AutomationRunID string
+	ExecutionRunID  string
 	RequestContext  []agent.ContextSegment
 }
 
@@ -1259,9 +1260,18 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 		return s.writeResponse(req.ID, nil, err)
 	}
 	threadID := strings.TrimSpace(params.ThreadID)
+	_, err := s.interruptThreadExecution(threadID)
+	return s.writeResponse(req.ID, OKResult{OK: err == nil}, err)
+}
+
+// interruptThreadExecution is the shared interruption core for turn/interrupt
+// and run/interrupt. The bool reports whether an active Turn will perform the
+// terminal settlement; false means the caller interrupted only between-turn
+// background work.
+func (s *Server) interruptThreadExecution(threadID string) (bool, error) {
 	th := s.thread(threadID)
 	if th == nil {
-		return s.writeResponse(req.ID, nil, fmt.Errorf("thread %q not found", params.ThreadID))
+		return false, fmt.Errorf("thread %q not found", threadID)
 	}
 	th.mu.Lock()
 	cancel := th.cancel
@@ -1276,9 +1286,9 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 			threadRuntime.AgentControl.FreezeWorkerTree()
 		}
 		if err := s.stopResumeProcessesForThread(threadID, threadRuntime); err != nil {
-			return s.writeResponse(req.ID, nil, err)
+			return false, err
 		}
-		return s.writeResponse(req.ID, OKResult{OK: true}, nil)
+		return false, nil
 	}
 	pendingSteers := queuedTurnsFromSteers(th.pendingSteers)
 	for index := range pendingSteers {
@@ -1305,7 +1315,7 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 		s.pendingQueuedTurns[threadID] = append(queued, s.pendingQueuedTurns[threadID]...)
 		s.queuedTurnMu.Unlock()
 		th.mu.Unlock()
-		return s.writeResponse(req.ID, nil, err)
+		return false, err
 	}
 	th.pendingSteers = nil
 	th.interrupting = true
@@ -1322,14 +1332,11 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 		control.FreezeWorkerTree()
 	}
 	if err := s.stopResumeProcessesForThread(threadID, threadRuntime); err != nil {
-		return s.writeResponse(req.ID, nil, err)
-	}
-	if err := s.writeResponse(req.ID, OKResult{OK: true}, nil); err != nil {
-		return err
+		return true, err
 	}
 	s.notifyQueuedTurnsDequeued(threadID, automationIDs)
 	s.notifyHeldUserTurns(threadID, held)
-	return nil
+	return true, nil
 }
 
 // stopResumeProcessesForThread stops only processes whose completion would
@@ -2056,6 +2063,18 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	// before successor ordering on this server without making an immediate user
 	// turn spuriously fail as busy.
 	awaitingAutoContinuation := err == nil && threadRuntimeAwaitsAutoContinuation(th.ID, threadRuntime)
+	var runUpdate Run
+	hasRunUpdate := false
+	if runID := strings.TrimSpace(turnRuntime.ExecutionRunID); runID != "" {
+		awaitingAutoContinuation = err == nil && s.executionRunAwaitsContinuation(th.ID, threadRuntime)
+		settled, _, settleErr := s.settleExecutionRunTurn(runID, turnID, tracePath, turn, structured, err, awaitingAutoContinuation, now)
+		if settleErr != nil {
+			providers.DebugLogf("settle execution run %q turn %q: %v", runID, turnID, settleErr)
+		} else {
+			runUpdate = settled
+			hasRunUpdate = true
+		}
+	}
 	if runID := strings.TrimSpace(turnRuntime.AutomationRunID); runID != "" && s.rt != nil && s.rt.AutomationManager != nil {
 		if completeErr := s.rt.AutomationManager.CompleteRun(runID, th.ID, turnID, err); completeErr != nil {
 			providers.DebugLogf("complete automation run %q: %v", runID, completeErr)
@@ -2088,6 +2107,9 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 			TracePath:                tracePath,
 			AwaitingAutoContinuation: awaitingAutoContinuation,
 		})
+	}
+	if hasRunUpdate {
+		notify(NotificationRunUpdated, RunUpdatedNotification{Run: runUpdate})
 	}
 	if completionClaimFailed {
 		s.scheduleThreadExecutionLeaseRetry(func() {
@@ -2426,6 +2448,9 @@ func (s *Server) kickQueuedTurnDrain(threadID string) {
 	if threadID == "" {
 		return
 	}
+	if s.activeExecutionRunID(threadID) != "" {
+		return
+	}
 
 	s.queuedTurnMu.Lock()
 	if s.closed.Load() {
@@ -2726,6 +2751,7 @@ func (s *Server) startThreadUserTurnWithAdmission(ctx context.Context, th *threa
 	}
 	turnRuntime.Ultra = snapshot.Ultra
 	turnRuntime.AutomationRunID = snapshot.AutomationRunID
+	turnRuntime.ExecutionRunID = snapshot.ExecutionRunID
 	turnRuntime.RequestContext = cloneContextSegments(snapshot.RequestContext)
 	th.mu.Unlock()
 
@@ -3162,7 +3188,7 @@ func (s *Server) startSyntheticTurn(ctx context.Context, threadID string, userMs
 		ctx,
 		th,
 		userMsg,
-		turnRuntimeSnapshot{AgentCompletionResultIDs: completionResultIDs, ProcessCompletionIDs: processCompletionIDs, Ultra: completionUltra},
+		turnRuntimeSnapshot{AgentCompletionResultIDs: completionResultIDs, ProcessCompletionIDs: processCompletionIDs, Ultra: completionUltra, ExecutionRunID: s.activeExecutionRunID(threadID)},
 		false,
 		turnReadOnlySkip,
 		turnAdmissionHooks{
@@ -3241,6 +3267,10 @@ func (s *Server) startSyntheticTurn(ctx context.Context, threadID string, userMs
 	}
 	if err != nil || !ok {
 		return ok, err
+	}
+	if err := s.attachExecutionTurn(started.runtime.ExecutionRunID, threadID, started.turnID, started.admittedAt); err != nil {
+		persistErr := s.abortStartedThreadTurnDurably(th, started, err)
+		return false, errors.Join(err, persistErr)
 	}
 
 	_ = s.writeNotification(NotificationTurnStarted, TurnStartedNotification{
@@ -3499,7 +3529,12 @@ func (s *Server) startGoalContinuationTurn(ctx context.Context, threadID string)
 	turn := th.startInternalTurnLocked(turnID, now)
 	turnRuntime := turnRuntimeSnapshotLocked(th)
 	turnRuntime.HistoryBaselineSeq = th.historyHeadSeq
+	turnRuntime.ExecutionRunID = s.activeExecutionRunID(threadID)
 	th.mu.Unlock()
+	if err := s.attachExecutionTurn(turnRuntime.ExecutionRunID, threadID, turnID, now); err != nil {
+		abortStartedThreadTurn(th, startedThreadTurn{ctx: turnCtx, cancel: cancel, turnID: turnID, turn: turn, runtime: turnRuntime, history: history}, err)
+		return false, err
+	}
 
 	_ = s.writeNotification(NotificationTurnStarted, TurnStartedNotification{
 		ThreadID: threadID,

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -2063,11 +2063,21 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	// before successor ordering on this server without making an immediate user
 	// turn spuriously fail as busy.
 	awaitingAutoContinuation := err == nil && threadRuntimeAwaitsAutoContinuation(th.ID, threadRuntime)
+	executionRetryPrompt := ""
+	executionRunError := err
 	var runUpdate Run
 	hasRunUpdate := false
 	if runID := strings.TrimSpace(turnRuntime.ExecutionRunID); runID != "" {
 		awaitingAutoContinuation = err == nil && s.executionRunAwaitsContinuation(th.ID, threadRuntime)
-		settled, _, settleErr := s.settleExecutionRunTurn(runID, turnID, tracePath, turn, structured, err, awaitingAutoContinuation, now)
+		if err == nil && turn.Status == TurnStatusCompleted {
+			if retryPrompt, retry, validationErr := s.executionRunSchemaOutcome(runID, res.Content); retry {
+				executionRetryPrompt = retryPrompt
+				awaitingAutoContinuation = true
+			} else if validationErr != nil {
+				executionRunError = validationErr
+			}
+		}
+		settled, _, settleErr := s.settleExecutionRunTurn(runID, turnID, tracePath, turn, structured, executionRunError, awaitingAutoContinuation, now)
 		if settleErr != nil {
 			providers.DebugLogf("settle execution run %q turn %q: %v", runID, turnID, settleErr)
 		} else {
@@ -2124,6 +2134,13 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	if err != nil {
 		s.kickAgentCompletionDrain(th.ID)
 		s.kickQueuedTurnDrain(th.ID)
+		return
+	}
+	if executionRetryPrompt != "" {
+		if retryErr := s.startExecutionSchemaRetry(context.Background(), th, turnRuntime, executionRetryPrompt); retryErr != nil {
+			providers.DebugLogf("start structured-output retry for run %q: %v", turnRuntime.ExecutionRunID, retryErr)
+			_, _, _ = s.settleExecutionRunTurn(turnRuntime.ExecutionRunID, turnID, tracePath, turn, structured, retryErr, false, time.Now())
+		}
 		return
 	}
 	if !turnRuntime.CompactOnly {

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -334,6 +334,7 @@ func (s *Server) startThreadCompactTurn(ctx context.Context, req Request, th *th
 	th.cancel = cancel
 	turn := th.startCompactTurnLocked(turnID, displayMsg, now)
 	turnRuntime := turnRuntimeSnapshotLocked(th)
+	th.currentExecutionRunID = turnRuntime.ExecutionRunID
 	turnRuntime.ForceCompact = true
 	turnRuntime.CompactOnly = true
 	turnRuntime.HistoryBaselineSeq = th.historyHeadSeq
@@ -1261,7 +1262,7 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 		return s.writeResponse(req.ID, nil, err)
 	}
 	threadID := strings.TrimSpace(params.ThreadID)
-	_, err := s.interruptThreadExecution(threadID)
+	_, err := s.interruptThreadExecution(threadID, "")
 	return s.writeResponse(req.ID, OKResult{OK: err == nil}, err)
 }
 
@@ -1269,7 +1270,7 @@ func (s *Server) handleTurnInterrupt(req Request) error {
 // and run/interrupt. The bool reports whether an active Turn will perform the
 // terminal settlement; false means the caller interrupted only between-turn
 // background work.
-func (s *Server) interruptThreadExecution(threadID string) (bool, error) {
+func (s *Server) interruptThreadExecution(threadID, expectedRunID string) (bool, error) {
 	th := s.thread(threadID)
 	if th == nil {
 		return false, fmt.Errorf("thread %q not found", threadID)
@@ -1277,6 +1278,11 @@ func (s *Server) interruptThreadExecution(threadID string) (bool, error) {
 	th.mu.Lock()
 	cancel := th.cancel
 	threadRuntime := th.execRuntime
+	if cancel != nil && strings.TrimSpace(expectedRunID) != "" && th.currentExecutionRunID != strings.TrimSpace(expectedRunID) {
+		currentRunID := th.currentExecutionRunID
+		th.mu.Unlock()
+		return false, fmt.Errorf("%w: expected %q, current %q", errExecutionRunChanged, expectedRunID, currentRunID)
+	}
 	if cancel == nil {
 		hasAgentWork := threadRuntimeHasOutstandingAgentWork(threadRuntime)
 		if hasAgentWork {
@@ -2069,14 +2075,8 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	var runUpdate Run
 	hasRunUpdate := false
 	if runID := strings.TrimSpace(turnRuntime.ExecutionRunID); runID != "" {
-		awaitingAutoContinuation = err == nil && s.executionRunAwaitsContinuation(th.ID, threadRuntime)
 		if err == nil && turn.Status == TurnStatusCompleted {
-			if retryPrompt, retry, validationErr := s.executionRunSchemaOutcome(runID, res.Content); retry {
-				executionRetryPrompt = retryPrompt
-				awaitingAutoContinuation = true
-			} else if validationErr != nil {
-				executionRunError = validationErr
-			}
+			awaitingAutoContinuation, executionRetryPrompt, executionRunError = s.executionRunSuccessfulTurnOutcome(runID, th.ID, threadRuntime, res.Content)
 		}
 		settled, _, settleErr := s.settleExecutionRunTurn(runID, turnID, tracePath, turn, structured, executionRunError, awaitingAutoContinuation, now)
 		if settleErr != nil {
@@ -2140,8 +2140,12 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 	if executionRetryPrompt != "" {
 		if retryErr := s.startExecutionSchemaRetry(context.Background(), th, turnRuntime, executionRetryPrompt); retryErr != nil {
 			providers.DebugLogf("start structured-output retry for run %q: %v", turnRuntime.ExecutionRunID, retryErr)
-			failedRun := s.failAndDetachExecutionRun(turnRuntime.ExecutionRunID, execution.StatusFailed, "structured_output_retry_failed", "internal", retryErr)
-			notify(NotificationRunUpdated, RunUpdatedNotification{Run: failedRun})
+			failedRun, settleErr := s.failAndDetachExecutionRun(turnRuntime.ExecutionRunID, execution.StatusFailed, "structured_output_retry_failed", "internal", retryErr)
+			if settleErr != nil {
+				providers.DebugLogf("settle structured-output retry failure for run %q: %v", turnRuntime.ExecutionRunID, settleErr)
+			} else {
+				notify(NotificationRunUpdated, RunUpdatedNotification{Run: failedRun})
+			}
 		}
 		return
 	}
@@ -2771,6 +2775,7 @@ func (s *Server) startThreadUserTurnWithAdmission(ctx context.Context, th *threa
 	turnRuntime.Ultra = snapshot.Ultra
 	turnRuntime.AutomationRunID = snapshot.AutomationRunID
 	turnRuntime.ExecutionRunID = snapshot.ExecutionRunID
+	th.currentExecutionRunID = turnRuntime.ExecutionRunID
 	turnRuntime.RequestContext = cloneContextSegments(snapshot.RequestContext)
 	th.mu.Unlock()
 
@@ -3549,6 +3554,7 @@ func (s *Server) startGoalContinuationTurn(ctx context.Context, threadID string)
 	turnRuntime := turnRuntimeSnapshotLocked(th)
 	turnRuntime.HistoryBaselineSeq = th.historyHeadSeq
 	turnRuntime.ExecutionRunID = s.activeExecutionRunID(threadID)
+	th.currentExecutionRunID = turnRuntime.ExecutionRunID
 	th.mu.Unlock()
 	if err := s.attachExecutionTurn(turnRuntime.ExecutionRunID, threadID, turnID, now); err != nil {
 		abortStartedThreadTurn(th, startedThreadTurn{ctx: turnCtx, cancel: cancel, turnID: turnID, turn: turn, runtime: turnRuntime, history: history}, err)

--- a/internal/exec/appserver_controller.go
+++ b/internal/exec/appserver_controller.go
@@ -147,9 +147,9 @@ func (c *localAppServerController) ReadRun(ctx context.Context, runID string) (a
 	return result, err
 }
 
-func (c *localAppServerController) InterruptRun(ctx context.Context, runID string) (appserver.Run, error) {
+func (c *localAppServerController) InterruptRun(ctx context.Context, runID, reason string) (appserver.Run, error) {
 	var result appserver.RunInterruptResult
-	err := c.client.Call(ctx, appserver.MethodRunInterrupt, appserver.RunInterruptParams{RunID: strings.TrimSpace(runID)}, &result)
+	err := c.client.Call(ctx, appserver.MethodRunInterrupt, appserver.RunInterruptParams{RunID: strings.TrimSpace(runID), Reason: strings.TrimSpace(reason)}, &result)
 	return result.Run, err
 }
 

--- a/internal/exec/appserver_controller.go
+++ b/internal/exec/appserver_controller.go
@@ -135,6 +135,24 @@ func (c *localAppServerController) StartTurn(ctx context.Context, threadID strin
 	return result.Turn, err
 }
 
+func (c *localAppServerController) StartRun(ctx context.Context, params appserver.RunStartParams) (appserver.Run, error) {
+	var result appserver.RunStartResult
+	err := c.client.Call(ctx, appserver.MethodRunStart, params, &result)
+	return result.Run, err
+}
+
+func (c *localAppServerController) ReadRun(ctx context.Context, runID string) (appserver.RunView, error) {
+	var result appserver.RunReadResult
+	err := c.client.Call(ctx, appserver.MethodRunRead, appserver.RunReadParams{RunID: strings.TrimSpace(runID)}, &result)
+	return result, err
+}
+
+func (c *localAppServerController) InterruptRun(ctx context.Context, runID string) (appserver.Run, error) {
+	var result appserver.RunInterruptResult
+	err := c.client.Call(ctx, appserver.MethodRunInterrupt, appserver.RunInterruptParams{RunID: strings.TrimSpace(runID)}, &result)
+	return result.Run, err
+}
+
 func (c *localAppServerController) Interrupt(ctx context.Context, threadID string) error {
 	var result appserver.OKResult
 	return c.client.Call(ctx, appserver.MethodTurnInterrupt, appserver.TurnInterruptParams{ThreadID: threadID}, &result)

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -12,11 +12,14 @@ import (
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/appserver"
+	"github.com/blueberrycongee/wuu/internal/execution"
 )
 
 type runState struct {
 	threadID                 string
 	turnID                   string
+	runID                    string
+	useRunControl            bool
 	finalMessage             string
 	tracePath                string
 	status                   string
@@ -126,14 +129,17 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 		emitThreadEvent(opts, "thread_started", thread)
 	}
 
+	_, hasRunController := controller.(RunController)
 	prompt := opts.Prompt
-	if outputSchema != nil {
+	if outputSchema != nil && !hasRunController {
 		prompt = outputSchema.initialPrompt(prompt)
 	}
 	maxRetries := 0
 	if outputSchema != nil {
 		maxRetries = outputSchemaMaxRetries
 	}
+	runController, hasRunController := controller.(RunController)
+	useRunControl := hasRunController
 	for attempt := 0; ; attempt++ {
 		state.finalMessage = ""
 		state.turnID = ""
@@ -145,23 +151,44 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 			input.Images = attachments.Images
 			input.Files = attachments.Files
 		}
-		turn, err := controller.StartTurn(ctx, thread.ID, input)
-		if err != nil {
-			return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, err))
+		var err error
+		if useRunControl {
+			run, startErr := runController.StartRun(ctx, runStartParams(opts, thread.ID, input, outputSchema))
+			if startErr != nil {
+				return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, startErr))
+			}
+			state.runID = run.ID
+			state.useRunControl = true
+			if len(run.Turns) > 0 {
+				state.turnID = run.Turns[len(run.Turns)-1].TurnID
+			}
+			err = waitForRun(ctx, controller, opts, &state)
+		} else {
+			turn, startErr := controller.StartTurn(ctx, thread.ID, input)
+			if startErr != nil {
+				return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, startErr))
+			}
+			state.turnID = turn.ID
+			emitTurnStarted(opts, thread.ID, turn)
+			err = waitForTurn(ctx, controller, opts, &state)
 		}
-		state.turnID = turn.ID
-		emitTurnStarted(opts, thread.ID, turn)
-
-		err = waitForTurn(ctx, controller, opts, &state)
 		if err != nil {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				_ = interruptBestEffort(controller, state.threadID)
+				if state.runID != "" {
+					_ = interruptRunBestEffort(runController, state.runID)
+				} else {
+					_ = interruptBestEffort(controller, state.threadID)
+				}
 				emitTurnInterrupted(opts, state, "timeout")
 				emitResult(opts, state, "timeout", "timeout")
 				return WithExitCode(ExitTimeout, err)
 			}
 			if errors.Is(ctx.Err(), context.Canceled) {
-				_ = interruptBestEffort(controller, state.threadID)
+				if state.runID != "" {
+					_ = interruptRunBestEffort(runController, state.runID)
+				} else {
+					_ = interruptBestEffort(controller, state.threadID)
+				}
 				emitTurnInterrupted(opts, state, "interrupted")
 				emitResult(opts, state, "interrupted", "interrupted")
 				return WithExitCode(ExitInterrupted, err)
@@ -186,6 +213,12 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 			state.structuredResult = structuredResult
 			state.structuredResultSet = true
 			break
+		}
+		if useRunControl {
+			state.status = "failed"
+			emitStructuredOutputValidation(opts, state, err, false)
+			emitResult(opts, state, "failed", err.Error())
+			return WithExitCode(ExitTurnFailed, err)
 		}
 		retrying := attempt < maxRetries
 		emitStructuredOutputValidation(opts, state, err, retrying)
@@ -262,6 +295,47 @@ func startOrResumeThread(ctx context.Context, controller Controller, opts Option
 	return controller.StartThread(ctx, opts.Ephemeral)
 }
 
+func runStartParams(opts Options, threadID string, input TurnInput, outputSchema *outputSchemaValidator) appserver.RunStartParams {
+	request := execution.Request{
+		Mode: execution.ModeStart,
+		Requested: execution.Selection{
+			Provider: strings.TrimSpace(opts.Provider), Model: strings.TrimSpace(opts.Model),
+			Variant: strings.TrimSpace(opts.Variant), Effort: strings.TrimSpace(opts.Effort),
+			PermissionMode: strings.TrimSpace(opts.PermissionMode),
+		},
+		AgentProfile: strings.TrimSpace(opts.AgentProfile), MaxTurns: opts.MaxTurns,
+		TimeoutMS: opts.Timeout.Milliseconds(), Ultra: opts.Ultra, NoTools: opts.NoTools,
+		HasPrompt: input.Prompt != "", ImageCount: len(input.Images), FileCount: len(input.Files),
+		StructuredOutput: outputSchema != nil,
+	}
+	if strings.TrimSpace(opts.ForkID) != "" {
+		request.Mode = execution.ModeFork
+		request.SourceThreadID = strings.TrimSpace(opts.ForkID)
+	} else if opts.ResumeLast || strings.TrimSpace(opts.ResumeID) != "" {
+		request.Mode = execution.ModeResume
+		request.SourceThreadID = threadID
+	}
+	permissionMode := strings.TrimSpace(opts.PermissionMode)
+	var permission *string
+	if permissionMode != "" {
+		permission = &permissionMode
+	}
+	return appserver.RunStartParams{
+		ThreadID: threadID, Prompt: input.Prompt,
+		Images:         append([]appserver.TurnStartImage(nil), input.Images...),
+		Files:          append([]appserver.TurnStartFile(nil), input.Files...),
+		PermissionMode: permission, Request: request,
+		OutputSchema: outputSchemaRaw(outputSchema),
+	}
+}
+
+func outputSchemaRaw(schema *outputSchemaValidator) json.RawMessage {
+	if schema == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), schema.raw...)
+}
+
 func waitForTurn(ctx context.Context, controller Controller, opts Options, state *runState) error {
 	notifications := controller.Notifications()
 	for {
@@ -283,6 +357,27 @@ func waitForTurn(ctx context.Context, controller Controller, opts Options, state
 	}
 }
 
+func waitForRun(ctx context.Context, controller Controller, opts Options, state *runState) error {
+	notifications := controller.Notifications()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case notification, ok := <-notifications:
+			if !ok {
+				return WithExitCode(ExitProtocol, errors.New("app-server notification stream closed before Run completed"))
+			}
+			done, err := handleNotification(opts, notification, state)
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+		}
+	}
+}
+
 func handleNotification(opts Options, notification Notification, state *runState) (bool, error) {
 	switch notification.Method {
 	case appserver.NotificationTurnStarted:
@@ -290,7 +385,7 @@ func handleNotification(opts Options, notification Notification, state *runState
 		if err := decodeNotification(notification, &params); err != nil {
 			return false, err
 		}
-		if state == nil || !state.awaitingAutoContinuation || (state.threadID != "" && params.ThreadID != state.threadID) {
+		if state == nil || (!state.useRunControl && !state.awaitingAutoContinuation) || (state.threadID != "" && params.ThreadID != state.threadID) {
 			return false, nil
 		}
 		state.turnID = params.Turn.ID
@@ -383,6 +478,10 @@ func handleNotification(opts Options, notification Notification, state *runState
 		state.threadID = params.ThreadID
 		state.turnID = params.Turn.ID
 		state.tracePath = params.TracePath
+		if state.useRunControl {
+			state.status = "running"
+			return false, nil
+		}
 		if params.AwaitingAutoContinuation {
 			state.status = "waiting_background"
 			state.awaitingAutoContinuation = true
@@ -391,6 +490,41 @@ func handleNotification(opts Options, notification Notification, state *runState
 		}
 		state.status = "completed"
 		return true, nil
+	case appserver.NotificationRunUpdated:
+		var params appserver.RunUpdatedNotification
+		if err := decodeNotification(notification, &params); err != nil {
+			return false, err
+		}
+		if state == nil || state.runID == "" || params.Run.ID != state.runID {
+			return false, nil
+		}
+		if params.Run.Result != nil {
+			state.tracePath = params.Run.Result.TracePath
+			if state.turnID == "" {
+				state.turnID = params.Run.Result.FinalTurnID
+			}
+		}
+		switch params.Run.Status {
+		case "completed":
+			state.status = "completed"
+			return true, nil
+		case "interrupted", "timed_out", "cancelled":
+			state.status = "interrupted"
+			errText := "execution run interrupted"
+			if params.Run.Error != nil && params.Run.Error.Message != "" {
+				errText = params.Run.Error.Message
+			}
+			emitResult(opts, *state, "interrupted", errText)
+			return false, WithExitCode(ExitInterrupted, errors.New(errText))
+		case "failed":
+			state.status = "failed"
+			errText := "execution run failed"
+			if params.Run.Error != nil && params.Run.Error.Message != "" {
+				errText = params.Run.Error.Message
+			}
+			emitResult(opts, *state, "failed", errText)
+			return false, WithExitCode(ExitTurnFailed, errors.New(errText))
+		}
 	case appserver.NotificationTurnError:
 		var params appserver.TurnErrorNotification
 		if err := decodeNotification(notification, &params); err != nil {
@@ -408,6 +542,9 @@ func handleNotification(opts Options, notification Notification, state *runState
 			state.threadID = params.ThreadID
 			state.turnID = params.TurnID
 			state.status = "interrupted"
+			if state.useRunControl {
+				return false, nil
+			}
 			emitResult(opts, *state, "interrupted", params.Error)
 			return false, WithExitCode(ExitInterrupted, errors.New(params.Error))
 		}
@@ -418,6 +555,13 @@ func handleNotification(opts Options, notification Notification, state *runState
 		state.threadID = params.ThreadID
 		state.turnID = params.TurnID
 		state.status = "failed"
+		if state.useRunControl {
+			if params.Code == "permission_denied" || params.Category == "permission_denied" {
+				state.permissionDenied = true
+				state.permissionError = params.Error
+			}
+			return false, nil
+		}
 		status := "failed"
 		code := exitCodeForTurnError(params, state.permissionDenied)
 		switch code {
@@ -948,6 +1092,7 @@ func emitStructuredOutputValidation(opts Options, state runState, err error, ret
 			"type":      "error",
 			"thread_id": state.threadID,
 			"turn_id":   state.turnID,
+			"run_id":    state.runID,
 			"error":     err.Error(),
 			"retrying":  retrying,
 		})
@@ -969,6 +1114,7 @@ func emitResult(opts Options, state runState, status, errorText string) {
 		"status":        status,
 		"thread_id":     state.threadID,
 		"turn_id":       state.turnID,
+		"run_id":        state.runID,
 		"final_message": state.finalMessage,
 		"trace_path":    state.tracePath,
 	}
@@ -1054,6 +1200,16 @@ func interruptBestEffort(controller Controller, threadID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	return controller.Interrupt(ctx, threadID)
+}
+
+func interruptRunBestEffort(controller RunController, runID string) error {
+	if controller == nil || strings.TrimSpace(runID) == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := controller.InterruptRun(ctx, runID)
+	return err
 }
 
 func writeLastMessage(path string, message string) error {

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -175,7 +175,7 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 		if err != nil {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if state.runID != "" {
-					_ = interruptRunBestEffort(runController, state.runID)
+					_ = interruptRunBestEffort(runController, state.runID, "timeout")
 				} else {
 					_ = interruptBestEffort(controller, state.threadID)
 				}
@@ -185,7 +185,7 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 			}
 			if errors.Is(ctx.Err(), context.Canceled) {
 				if state.runID != "" {
-					_ = interruptRunBestEffort(runController, state.runID)
+					_ = interruptRunBestEffort(runController, state.runID, "interrupted")
 				} else {
 					_ = interruptBestEffort(controller, state.threadID)
 				}
@@ -508,7 +508,15 @@ func handleNotification(opts Options, notification Notification, state *runState
 		case "completed":
 			state.status = "completed"
 			return true, nil
-		case "interrupted", "timed_out", "cancelled":
+		case "timed_out":
+			state.status = "timeout"
+			errText := "execution run timed out"
+			if params.Run.Error != nil && params.Run.Error.Message != "" {
+				errText = params.Run.Error.Message
+			}
+			emitResult(opts, *state, "timeout", errText)
+			return false, WithExitCode(ExitTimeout, errors.New(errText))
+		case "interrupted", "cancelled":
 			state.status = "interrupted"
 			errText := "execution run interrupted"
 			if params.Run.Error != nil && params.Run.Error.Message != "" {
@@ -518,8 +526,8 @@ func handleNotification(opts Options, notification Notification, state *runState
 			return false, WithExitCode(ExitInterrupted, errors.New(errText))
 		case "failed":
 			status := "failed"
-			exitCode := ExitTurnFailed
-			if state.permissionDenied {
+			exitCode := exitCodeForRunError(params.Run.Error, state.permissionDenied)
+			if exitCode == ExitPermissionDenied {
 				status = "permission_denied"
 				exitCode = ExitPermissionDenied
 			}
@@ -978,6 +986,21 @@ func exitCodeForTurnError(params appserver.TurnErrorNotification, permissionDeni
 	return ExitTurnFailed
 }
 
+func exitCodeForRunError(runErr *execution.Error, permissionDenied bool) int {
+	if runErr == nil {
+		if permissionDenied {
+			return ExitPermissionDenied
+		}
+		return ExitTurnFailed
+	}
+	if strings.EqualFold(strings.TrimSpace(runErr.Code), "permission_denied") || strings.EqualFold(strings.TrimSpace(runErr.Category), "permission_denied") {
+		permissionDenied = true
+	}
+	return exitCodeForTurnError(appserver.TurnErrorNotification{
+		Error: runErr.Message, Code: runErr.Code, Category: runErr.Category,
+	}, permissionDenied)
+}
+
 func isProviderModelFailure(text string) bool {
 	text = strings.ToLower(text)
 	for _, marker := range []string{
@@ -1208,13 +1231,13 @@ func interruptBestEffort(controller Controller, threadID string) error {
 	return controller.Interrupt(ctx, threadID)
 }
 
-func interruptRunBestEffort(controller RunController, runID string) error {
+func interruptRunBestEffort(controller RunController, runID, reason string) error {
 	if controller == nil || strings.TrimSpace(runID) == "" {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := controller.InterruptRun(ctx, runID)
+	_, err := controller.InterruptRun(ctx, runID, reason)
 	return err
 }
 

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -517,13 +517,19 @@ func handleNotification(opts Options, notification Notification, state *runState
 			emitResult(opts, *state, "interrupted", errText)
 			return false, WithExitCode(ExitInterrupted, errors.New(errText))
 		case "failed":
-			state.status = "failed"
+			status := "failed"
+			exitCode := ExitTurnFailed
+			if state.permissionDenied {
+				status = "permission_denied"
+				exitCode = ExitPermissionDenied
+			}
+			state.status = status
 			errText := "execution run failed"
 			if params.Run.Error != nil && params.Run.Error.Message != "" {
 				errText = params.Run.Error.Message
 			}
-			emitResult(opts, *state, "failed", errText)
-			return false, WithExitCode(ExitTurnFailed, errors.New(errText))
+			emitResult(opts, *state, status, errText)
+			return false, WithExitCode(exitCode, errors.New(errText))
 		}
 	case appserver.NotificationTurnError:
 		var params appserver.TurnErrorNotification

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -46,12 +46,17 @@ type initializeErrorController struct {
 
 type fakeRunController struct {
 	*fakeController
-	startedParams appserver.RunStartParams
-	run           appserver.Run
+	startedParams   appserver.RunStartParams
+	run             appserver.Run
+	block           bool
+	interruptReason string
 }
 
 func (c *fakeRunController) StartRun(_ context.Context, params appserver.RunStartParams) (appserver.Run, error) {
 	c.startedParams = params
+	if c.block {
+		return c.run, nil
+	}
 	c.fakeController.events = []Notification{
 		notification(appserver.NotificationAgentMessageDelta, appserver.AgentMessageDeltaNotification{ThreadID: "thread-1", TurnID: "turn-1", Delta: "run answer"}),
 		notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "run answer", TracePath: "/run-trace"}),
@@ -64,7 +69,8 @@ func (c *fakeRunController) ReadRun(context.Context, string) (appserver.RunView,
 	return appserver.RunView{Run: c.run, Attached: true}, nil
 }
 
-func (c *fakeRunController) InterruptRun(context.Context, string) (appserver.Run, error) {
+func (c *fakeRunController) InterruptRun(_ context.Context, _ string, reason string) (appserver.Run, error) {
+	c.interruptReason = reason
 	c.run.Status = execution.StatusInterrupted
 	return c.run, nil
 }
@@ -697,6 +703,40 @@ func TestRunTurnErrorPrefersStructuredCategoryOverMessage(t *testing.T) {
 				t.Fatalf("ExitCode = %d, want %d: %v", ExitCode(err), tc.want, err)
 			}
 		})
+	}
+}
+
+func TestRunErrorPreservesStableExitClassification(t *testing.T) {
+	tests := []struct {
+		category string
+		want     int
+	}{
+		{category: "provider", want: ExitProviderModelError},
+		{category: "local", want: ExitToolFailed},
+		{category: "permission_denied", want: ExitPermissionDenied},
+	}
+	for _, tc := range tests {
+		if got := exitCodeForRunError(&execution.Error{Category: tc.category, Message: "failed"}, false); got != tc.want {
+			t.Fatalf("category %q exit code = %d, want %d", tc.category, got, tc.want)
+		}
+	}
+}
+
+func TestRunControllerTimeoutSendsTimeoutReason(t *testing.T) {
+	controller := &fakeRunController{
+		fakeController: newFakeController(),
+		run:            appserver.Run{ID: "run-timeout", Status: execution.StatusRunning, ThreadID: "thread-1"},
+		block:          true,
+	}
+	err := Run(context.Background(), Options{
+		Prompt: "do work", JSON: true, Timeout: 20 * time.Millisecond,
+		Stdout: &bytes.Buffer{}, Controller: controller,
+	})
+	if ExitCode(err) != ExitTimeout {
+		t.Fatalf("ExitCode = %d, err=%v", ExitCode(err), err)
+	}
+	if controller.interruptReason != "timeout" {
+		t.Fatalf("interrupt reason = %q", controller.interruptReason)
 	}
 }
 

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/appserver"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
@@ -41,6 +42,31 @@ type fakeController struct {
 type initializeErrorController struct {
 	*fakeController
 	err error
+}
+
+type fakeRunController struct {
+	*fakeController
+	startedParams appserver.RunStartParams
+	run           appserver.Run
+}
+
+func (c *fakeRunController) StartRun(_ context.Context, params appserver.RunStartParams) (appserver.Run, error) {
+	c.startedParams = params
+	c.fakeController.events = []Notification{
+		notification(appserver.NotificationAgentMessageDelta, appserver.AgentMessageDeltaNotification{ThreadID: "thread-1", TurnID: "turn-1", Delta: "run answer"}),
+		notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "run answer", TracePath: "/run-trace"}),
+		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{ID: "run-1", Status: execution.StatusCompleted, ThreadID: "thread-1", Result: &execution.Result{FinalTurnID: "turn-1", TracePath: "/run-trace"}}}),
+	}
+	return c.run, nil
+}
+
+func (c *fakeRunController) ReadRun(context.Context, string) (appserver.RunView, error) {
+	return appserver.RunView{Run: c.run, Attached: true}, nil
+}
+
+func (c *fakeRunController) InterruptRun(context.Context, string) (appserver.Run, error) {
+	c.run.Status = execution.StatusInterrupted
+	return c.run, nil
 }
 
 func (c *initializeErrorController) Initialize(context.Context) (appserver.InitializeResult, error) {
@@ -134,6 +160,28 @@ func (f *fakeController) Notifications() <-chan Notification {
 		ch <- ev
 	}
 	return ch
+}
+
+func TestRunUsesRunControllerForPlainExec(t *testing.T) {
+	base := newFakeController()
+	controller := &fakeRunController{
+		fakeController: base,
+		run:            appserver.Run{ID: "run-1", Status: execution.StatusRunning, ThreadID: "thread-1", Turns: []execution.TurnRef{{TurnID: "turn-1", ThreadID: "thread-1"}}},
+	}
+	var stdout, stderr bytes.Buffer
+	err := Run(context.Background(), Options{Prompt: "reply", JSON: true, Stdout: &stdout, Stderr: &stderr, Controller: controller})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if base.startCount != 0 {
+		t.Fatalf("legacy StartTurn count = %d", base.startCount)
+	}
+	if controller.startedParams.Request.Mode != execution.ModeStart || controller.startedParams.Prompt != "reply" {
+		t.Fatalf("Run start params = %+v", controller.startedParams)
+	}
+	if !strings.Contains(stdout.String(), `"status":"completed"`) || !strings.Contains(stdout.String(), `"final_message":"run answer"`) {
+		t.Fatalf("Run JSON output = %s", stdout.String())
+	}
 }
 
 func TestRunDefaultStdoutOnlyFinalMessage(t *testing.T) {

--- a/internal/exec/types.go
+++ b/internal/exec/types.go
@@ -115,7 +115,7 @@ type Controller interface {
 type RunController interface {
 	StartRun(context.Context, appserver.RunStartParams) (appserver.Run, error)
 	ReadRun(context.Context, string) (appserver.RunView, error)
-	InterruptRun(context.Context, string) (appserver.Run, error)
+	InterruptRun(context.Context, string, string) (appserver.Run, error)
 }
 
 type Attachments struct {

--- a/internal/exec/types.go
+++ b/internal/exec/types.go
@@ -109,6 +109,15 @@ type Controller interface {
 	Notifications() <-chan Notification
 }
 
+// RunController is the app-server control surface used by the normal exec
+// path. Controller remains compatible with the legacy Turn methods so focused
+// tests and older embedders can migrate independently.
+type RunController interface {
+	StartRun(context.Context, appserver.RunStartParams) (appserver.Run, error)
+	ReadRun(context.Context, string) (appserver.RunView, error)
+	InterruptRun(context.Context, string) (appserver.Run, error)
+}
+
 type Attachments struct {
 	Images []appserver.TurnStartImage
 	Files  []appserver.TurnStartFile

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -1,0 +1,752 @@
+package execution
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/session"
+	"github.com/blueberrycongee/wuu/internal/stringutil"
+)
+
+var (
+	ErrNotFound = errors.New("execution run not found")
+	ErrConflict = errors.New("execution run state conflict")
+)
+
+type Store struct {
+	sessDir string
+	mu      sync.Mutex
+	memory  map[string]Run
+}
+
+func NewStore(sessDir string) (*Store, error) {
+	sessDir = strings.TrimSpace(sessDir)
+	if sessDir == "" {
+		return nil, errors.New("execution store session directory is required")
+	}
+	db, err := session.OpenStore(sessDir)
+	if err != nil {
+		return nil, fmt.Errorf("open execution store: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		return nil, fmt.Errorf("close execution store: %w", err)
+	}
+	return &Store{sessDir: sessDir, memory: make(map[string]Run)}, nil
+}
+
+func (s *Store) Create(ctx context.Context, params CreateParams) (Run, error) {
+	if s == nil {
+		return Run{}, errors.New("execution store is required")
+	}
+	params.RuntimeID = strings.TrimSpace(params.RuntimeID)
+	params.ThreadID = strings.TrimSpace(params.ThreadID)
+	params.Request = normalizeRequest(params.Request)
+	params.Runtime = normalizeRuntime(params.Runtime)
+	params.Workspace = normalizeWorkspace(params.Workspace)
+	if err := validateManifest(params); err != nil {
+		return Run{}, err
+	}
+	now := time.Now().UTC()
+	run := Run{
+		ID:        "run-" + session.NewID(),
+		RuntimeID: params.RuntimeID,
+		Status:    StatusAccepted,
+		Request:   params.Request,
+		Runtime:   params.Runtime,
+		Workspace: params.Workspace,
+		ThreadID:  params.ThreadID,
+		Turns:     []TurnRef{},
+		Ephemeral: params.Ephemeral,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if params.Ephemeral {
+		for _, existing := range s.memory {
+			if existing.ThreadID == run.ThreadID && !existing.Status.Terminal() {
+				return Run{}, fmt.Errorf("%w: thread %q already has active run %q", ErrConflict, run.ThreadID, existing.ID)
+			}
+		}
+		s.memory[run.ID] = cloneRun(run)
+		return run, nil
+	}
+	db, err := session.OpenStore(s.sessDir)
+	if err != nil {
+		return Run{}, err
+	}
+	defer db.Close()
+	requestJSON, err := json.Marshal(run.Request)
+	if err != nil {
+		return Run{}, fmt.Errorf("encode execution request: %w", err)
+	}
+	runtimeJSON, err := json.Marshal(run.Runtime)
+	if err != nil {
+		return Run{}, fmt.Errorf("encode execution runtime: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `
+INSERT INTO execution_runs (
+    id, runtime_id, status, request_json, runtime_json, thread_id, workspace_id, workspace_root,
+    created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.ID, run.RuntimeID, run.Status, string(requestJSON), string(runtimeJSON), run.ThreadID,
+		run.Workspace.ID, run.Workspace.Root,
+		toMillis(run.CreatedAt), toMillis(run.UpdatedAt),
+	)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unique constraint") {
+			return Run{}, fmt.Errorf("%w: thread %q already has an active run", ErrConflict, run.ThreadID)
+		}
+		return Run{}, fmt.Errorf("create execution run: %w", err)
+	}
+	return run, nil
+}
+
+func (s *Store) Get(ctx context.Context, id string) (Run, error) {
+	if s == nil {
+		return Run{}, errors.New("execution store is required")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Run{}, errors.New("execution run id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if run, ok := s.memory[id]; ok {
+		return cloneRun(run), nil
+	}
+	db, err := session.OpenStore(s.sessDir)
+	if err != nil {
+		return Run{}, err
+	}
+	defer db.Close()
+	return loadRun(ctx, db, id)
+}
+
+func (s *Store) List(ctx context.Context, opts ListOptions) ([]Run, error) {
+	if s == nil {
+		return nil, errors.New("execution store is required")
+	}
+	opts.WorkspaceID = strings.TrimSpace(opts.WorkspaceID)
+	opts.WorkspaceRoot = strings.TrimSpace(opts.WorkspaceRoot)
+	opts.ThreadID = strings.TrimSpace(opts.ThreadID)
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 500 {
+		opts.Limit = 500
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db, err := session.OpenStore(s.sessDir)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	durable, err := listDurableRuns(ctx, db, opts)
+	if err != nil {
+		return nil, err
+	}
+	all := append([]Run(nil), durable...)
+	for _, run := range s.memory {
+		if matchesList(run, opts) {
+			all = append(all, cloneRun(run))
+		}
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].UpdatedAt.Equal(all[j].UpdatedAt) {
+			return all[i].ID > all[j].ID
+		}
+		return all[i].UpdatedAt.After(all[j].UpdatedAt)
+	})
+	if len(all) > opts.Limit {
+		all = all[:opts.Limit]
+	}
+	return all, nil
+}
+
+func (s *Store) AttachTurn(ctx context.Context, runID, threadID, turnID string, at time.Time) (Run, error) {
+	runID = strings.TrimSpace(runID)
+	threadID = strings.TrimSpace(threadID)
+	turnID = strings.TrimSpace(turnID)
+	if runID == "" || threadID == "" || turnID == "" {
+		return Run{}, errors.New("execution run, thread, and turn ids are required")
+	}
+	at = normalizedTime(at)
+	return s.update(ctx, runID, func(run *Run) error {
+		if run.Status.Terminal() {
+			return stateConflict(run.ID, run.Status, "attach turn")
+		}
+		if run.ThreadID == "" {
+			run.ThreadID = threadID
+		} else if run.ThreadID != threadID {
+			return fmt.Errorf("%w: run %q belongs to thread %q", ErrConflict, run.ID, run.ThreadID)
+		}
+		for _, ref := range run.Turns {
+			if ref.TurnID == turnID {
+				return nil
+			}
+		}
+		run.Turns = append(run.Turns, TurnRef{
+			TurnID:     turnID,
+			ThreadID:   threadID,
+			Ordinal:    len(run.Turns) + 1,
+			AttachedAt: at,
+		})
+		run.Status = StatusRunning
+		if run.StartedAt == nil {
+			run.StartedAt = timePtr(at)
+		}
+		run.UpdatedAt = at
+		return nil
+	})
+}
+
+func (s *Store) FinishTurn(ctx context.Context, runID, turnID string, terminal TurnTerminal) (Run, error) {
+	runID = strings.TrimSpace(runID)
+	turnID = strings.TrimSpace(turnID)
+	if runID == "" || turnID == "" {
+		return Run{}, errors.New("execution run and turn ids are required")
+	}
+	terminal.TracePath = strings.TrimSpace(terminal.TracePath)
+	terminal.At = normalizedTime(terminal.At)
+	return s.update(ctx, runID, func(run *Run) error {
+		for i := range run.Turns {
+			if run.Turns[i].TurnID != turnID {
+				continue
+			}
+			if run.Status.Terminal() {
+				if run.Turns[i].TracePath == terminal.TracePath {
+					return nil
+				}
+				return stateConflict(run.ID, run.Status, "change turn trace")
+			}
+			run.Turns[i].TracePath = terminal.TracePath
+			run.UpdatedAt = terminal.At
+			return nil
+		}
+		return fmt.Errorf("%w: turn %q is not attached to run %q", ErrConflict, turnID, run.ID)
+	})
+}
+
+func (s *Store) Complete(ctx context.Context, runID string, result Result, at time.Time) (Run, error) {
+	return s.finish(ctx, runID, StatusCompleted, result, nil, at)
+}
+
+func (s *Store) Fail(ctx context.Context, runID string, status Status, result Result, runErr Error, at time.Time) (Run, error) {
+	if status == StatusCompleted || !status.Terminal() {
+		return Run{}, fmt.Errorf("invalid failure status %q", status)
+	}
+	runErr = sanitizeError(runErr)
+	if runErr.Message == "" {
+		return Run{}, errors.New("execution failure message is required")
+	}
+	return s.finish(ctx, runID, status, result, &runErr, at)
+}
+
+// ReconcileOrphans marks durable work from dead app-server processes as
+// interrupted. Detached reattachment is intentionally outside the first Run
+// contract, so leaving orphaned rows active would claim work is still live.
+func (s *Store) ReconcileOrphans(ctx context.Context, currentRuntimeID string, at time.Time) ([]Run, error) {
+	if s == nil {
+		return nil, errors.New("execution store is required")
+	}
+	currentRuntimeID = strings.TrimSpace(currentRuntimeID)
+	if currentRuntimeID == "" {
+		return nil, errors.New("current execution runtime id is required")
+	}
+	at = normalizedTime(at)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db, err := session.OpenStore(s.sessDir)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	cutoff := at.Add(-session.InferenceJournalRecoveryInterval()).UnixMilli()
+	rows, err := db.QueryContext(ctx, `
+SELECT r.id, rt.pid, rt.closed_at
+FROM execution_runs r
+JOIN inference_journal_runtimes rt ON rt.id = r.runtime_id
+WHERE r.runtime_id <> ? AND r.status IN (?, ?)
+  AND (rt.closed_at <> 0 OR rt.heartbeat_at < ?)
+ORDER BY r.created_at, r.id`, currentRuntimeID, StatusAccepted, StatusRunning, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list orphaned execution runs: %w", err)
+	}
+	type candidate struct {
+		id       string
+		pid      int
+		closedAt int64
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var item candidate
+		if err := rows.Scan(&item.id, &item.pid, &item.closedAt); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan orphaned execution run: %w", err)
+		}
+		candidates = append(candidates, item)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close orphaned execution rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate orphaned execution runs: %w", err)
+	}
+	runErr := Error{Code: "process_restarted", Category: "cancelled", Message: "app-server stopped before the run reached a terminal state"}
+	errorJSON, _ := json.Marshal(runErr)
+	var recovered []Run
+	for _, item := range candidates {
+		if item.closedAt == 0 && session.InferenceRuntimeProcessAlive(item.pid) {
+			continue
+		}
+		result, err := db.ExecContext(ctx, `
+UPDATE execution_runs
+SET status = ?, error_json = ?, updated_at = ?, completed_at = ?
+WHERE id = ? AND status IN (?, ?)`,
+			StatusInterrupted, string(errorJSON), toMillis(at), toMillis(at), item.id, StatusAccepted, StatusRunning,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("reconcile execution run %q: %w", item.id, err)
+		}
+		if changed, _ := result.RowsAffected(); changed == 0 {
+			continue
+		}
+		run, err := loadRun(ctx, db, item.id)
+		if err != nil {
+			return nil, err
+		}
+		recovered = append(recovered, run)
+	}
+	return recovered, nil
+}
+
+func (s *Store) finish(ctx context.Context, runID string, status Status, result Result, runErr *Error, at time.Time) (Run, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return Run{}, errors.New("execution run id is required")
+	}
+	at = normalizedTime(at)
+	return s.update(ctx, runID, func(run *Run) error {
+		if run.Status.Terminal() {
+			resultCopy := cloneResult(result)
+			if run.Status == status && reflect.DeepEqual(run.Result, &resultCopy) && reflect.DeepEqual(run.Error, runErr) {
+				return nil
+			}
+			return stateConflict(run.ID, run.Status, "finish")
+		}
+		run.Status = status
+		resultCopy := cloneResult(result)
+		run.Result = &resultCopy
+		if runErr != nil {
+			errorCopy := *runErr
+			run.Error = &errorCopy
+		}
+		run.UpdatedAt = at
+		run.CompletedAt = timePtr(at)
+		return nil
+	})
+}
+
+func (s *Store) update(ctx context.Context, runID string, mutate func(*Run) error) (Run, error) {
+	if s == nil {
+		return Run{}, errors.New("execution store is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if run, ok := s.memory[runID]; ok {
+		copy := cloneRun(run)
+		if err := mutate(&copy); err != nil {
+			return Run{}, err
+		}
+		s.memory[runID] = cloneRun(copy)
+		return copy, nil
+	}
+	db, err := session.OpenStore(s.sessDir)
+	if err != nil {
+		return Run{}, err
+	}
+	defer db.Close()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return Run{}, fmt.Errorf("begin execution update: %w", err)
+	}
+	defer tx.Rollback()
+	run, err := loadRun(ctx, tx, runID)
+	if err != nil {
+		return Run{}, err
+	}
+	beforeTurns := append([]TurnRef(nil), run.Turns...)
+	if err := mutate(&run); err != nil {
+		return Run{}, err
+	}
+	if err := persistRun(ctx, tx, run); err != nil {
+		return Run{}, err
+	}
+	if err := persistTurnChanges(ctx, tx, run.ID, beforeTurns, run.Turns); err != nil {
+		return Run{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Run{}, fmt.Errorf("commit execution update: %w", err)
+	}
+	return run, nil
+}
+
+type queryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func loadRun(ctx context.Context, q queryer, id string) (Run, error) {
+	var run Run
+	var requestJSON, runtimeJSON, resultJSON, errorJSON string
+	var createdMS, startedMS, updatedMS, completedMS int64
+	err := q.QueryRowContext(ctx, `
+SELECT id, runtime_id, status, request_json, runtime_json,
+       thread_id, workspace_id, workspace_root, result_json, error_json,
+       created_at, started_at, updated_at, completed_at
+FROM execution_runs WHERE id = ?`, id).Scan(
+		&run.ID, &run.RuntimeID, &run.Status, &requestJSON, &runtimeJSON,
+		&run.ThreadID, &run.Workspace.ID, &run.Workspace.Root, &resultJSON, &errorJSON,
+		&createdMS, &startedMS, &updatedMS, &completedMS,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Run{}, fmt.Errorf("%w: %q", ErrNotFound, id)
+	}
+	if err != nil {
+		return Run{}, fmt.Errorf("load execution run: %w", err)
+	}
+	if err := json.Unmarshal([]byte(requestJSON), &run.Request); err != nil {
+		return Run{}, fmt.Errorf("decode execution request for %q: %w", id, err)
+	}
+	if err := json.Unmarshal([]byte(runtimeJSON), &run.Runtime); err != nil {
+		return Run{}, fmt.Errorf("decode execution runtime for %q: %w", id, err)
+	}
+	if resultJSON != "" {
+		var result Result
+		if err := json.Unmarshal([]byte(resultJSON), &result); err != nil {
+			return Run{}, fmt.Errorf("decode execution result for %q: %w", id, err)
+		}
+		run.Result = &result
+	}
+	if errorJSON != "" {
+		var runErr Error
+		if err := json.Unmarshal([]byte(errorJSON), &runErr); err != nil {
+			return Run{}, fmt.Errorf("decode execution error for %q: %w", id, err)
+		}
+		run.Error = &runErr
+	}
+	run.CreatedAt = fromMillis(createdMS)
+	run.StartedAt = optionalTime(startedMS)
+	run.UpdatedAt = fromMillis(updatedMS)
+	run.CompletedAt = optionalTime(completedMS)
+	turns, err := loadTurns(ctx, q, id)
+	if err != nil {
+		return Run{}, err
+	}
+	run.Turns = turns
+	return run, nil
+}
+
+func loadTurns(ctx context.Context, q queryer, runID string) ([]TurnRef, error) {
+	rows, err := q.QueryContext(ctx, `
+SELECT thread_id, turn_id, ordinal, trace_path, attached_at
+FROM execution_run_turns WHERE run_id = ? ORDER BY ordinal`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("load execution turn refs: %w", err)
+	}
+	defer rows.Close()
+	turns := make([]TurnRef, 0)
+	for rows.Next() {
+		var ref TurnRef
+		var attachedMS int64
+		if err := rows.Scan(&ref.ThreadID, &ref.TurnID, &ref.Ordinal, &ref.TracePath, &attachedMS); err != nil {
+			return nil, fmt.Errorf("scan execution turn ref: %w", err)
+		}
+		ref.AttachedAt = fromMillis(attachedMS)
+		turns = append(turns, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate execution turn refs: %w", err)
+	}
+	return turns, nil
+}
+
+func listDurableRuns(ctx context.Context, db *sql.DB, opts ListOptions) ([]Run, error) {
+	clauses := []string{"1 = 1"}
+	args := make([]any, 0, 5)
+	if opts.WorkspaceID != "" {
+		clauses = append(clauses, "workspace_id = ?")
+		args = append(args, opts.WorkspaceID)
+	}
+	if opts.WorkspaceRoot != "" {
+		clauses = append(clauses, "workspace_root = ?")
+		args = append(args, opts.WorkspaceRoot)
+	}
+	if opts.ThreadID != "" {
+		clauses = append(clauses, "thread_id = ?")
+		args = append(args, opts.ThreadID)
+	}
+	if opts.Status != "" {
+		clauses = append(clauses, "status = ?")
+		args = append(args, opts.Status)
+	}
+	args = append(args, opts.Limit)
+	rows, err := db.QueryContext(ctx, `
+SELECT id FROM execution_runs
+WHERE `+strings.Join(clauses, " AND ")+`
+ORDER BY updated_at DESC, id DESC LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list execution runs: %w", err)
+	}
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan execution run id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close execution run rows: %w", err)
+	}
+	runs := make([]Run, 0, len(ids))
+	for _, id := range ids {
+		run, err := loadRun(ctx, db, id)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+func persistRun(ctx context.Context, tx *sql.Tx, run Run) error {
+	requestJSON, err := json.Marshal(run.Request)
+	if err != nil {
+		return fmt.Errorf("encode execution request: %w", err)
+	}
+	runtimeJSON, err := json.Marshal(run.Runtime)
+	if err != nil {
+		return fmt.Errorf("encode execution runtime: %w", err)
+	}
+	resultJSON := ""
+	if run.Result != nil {
+		data, marshalErr := json.Marshal(run.Result)
+		if marshalErr != nil {
+			return fmt.Errorf("encode execution result: %w", marshalErr)
+		}
+		resultJSON = string(data)
+	}
+	errorJSON := ""
+	if run.Error != nil {
+		data, marshalErr := json.Marshal(run.Error)
+		if marshalErr != nil {
+			return fmt.Errorf("encode execution error: %w", marshalErr)
+		}
+		errorJSON = string(data)
+	}
+	result, err := tx.ExecContext(ctx, `
+UPDATE execution_runs
+SET status = ?, request_json = ?, runtime_json = ?, thread_id = ?, workspace_id = ?, workspace_root = ?,
+    result_json = ?, error_json = ?, started_at = ?, updated_at = ?, completed_at = ?
+WHERE id = ?`,
+		run.Status, string(requestJSON), string(runtimeJSON), run.ThreadID, run.Workspace.ID, run.Workspace.Root,
+		resultJSON, errorJSON, timeMillis(run.StartedAt), toMillis(run.UpdatedAt), timeMillis(run.CompletedAt), run.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update execution run: %w", err)
+	}
+	if changed, _ := result.RowsAffected(); changed != 1 {
+		return fmt.Errorf("%w: %q", ErrNotFound, run.ID)
+	}
+	return nil
+}
+
+func persistTurnChanges(ctx context.Context, tx *sql.Tx, runID string, before, after []TurnRef) error {
+	if len(after) < len(before) {
+		return errors.New("execution turn refs cannot be removed")
+	}
+	for _, ref := range after {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO execution_run_turns (
+    run_id, thread_id, turn_id, ordinal, trace_path, attached_at
+) VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(run_id, turn_id) DO UPDATE SET
+    trace_path = excluded.trace_path`,
+			runID, ref.ThreadID, ref.TurnID, ref.Ordinal, ref.TracePath, toMillis(ref.AttachedAt),
+		)
+		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "unique constraint") {
+				return fmt.Errorf("%w: turn %q is already attached to another run", ErrConflict, ref.TurnID)
+			}
+			return fmt.Errorf("persist execution turn ref: %w", err)
+		}
+	}
+	return nil
+}
+
+func normalizeRequest(request Request) Request {
+	request.Mode = Mode(strings.TrimSpace(string(request.Mode)))
+	request.SourceThreadID = strings.TrimSpace(request.SourceThreadID)
+	request.Requested = normalizeSelection(request.Requested)
+	request.AgentProfile = strings.TrimSpace(request.AgentProfile)
+	return request
+}
+
+func normalizeRuntime(runtime RuntimeManifest) RuntimeManifest {
+	runtime.Resolved = normalizeSelection(runtime.Resolved)
+	runtime.ProtocolVersion = strings.TrimSpace(runtime.ProtocolVersion)
+	runtime.CoreVersion = strings.TrimSpace(runtime.CoreVersion)
+	runtime.CoreCommit = strings.TrimSpace(runtime.CoreCommit)
+	return runtime
+}
+
+func normalizeSelection(selection Selection) Selection {
+	selection.Provider = strings.TrimSpace(selection.Provider)
+	selection.Model = strings.TrimSpace(selection.Model)
+	selection.Variant = strings.TrimSpace(selection.Variant)
+	selection.Effort = strings.TrimSpace(selection.Effort)
+	selection.PermissionMode = strings.TrimSpace(selection.PermissionMode)
+	return selection
+}
+
+func normalizeWorkspace(workspace WorkspaceRef) WorkspaceRef {
+	workspace.ID = strings.TrimSpace(workspace.ID)
+	workspace.Root = strings.TrimSpace(workspace.Root)
+	return workspace
+}
+
+func validateManifest(params CreateParams) error {
+	if params.RuntimeID == "" {
+		return errors.New("execution runtime id is required")
+	}
+	if params.ThreadID == "" {
+		return errors.New("execution thread id is required")
+	}
+	switch params.Request.Mode {
+	case ModeStart, ModeReview:
+		if params.Request.SourceThreadID != "" {
+			return fmt.Errorf("%s execution request cannot have a source thread", params.Request.Mode)
+		}
+	case ModeResume, ModeFork:
+		if params.Request.SourceThreadID == "" {
+			return fmt.Errorf("%s execution request requires a source thread", params.Request.Mode)
+		}
+	default:
+		return fmt.Errorf("invalid execution mode %q", params.Request.Mode)
+	}
+	if params.Workspace.Root == "" {
+		return errors.New("execution workspace root is required")
+	}
+	if params.Runtime.Resolved.Provider == "" || params.Runtime.Resolved.Model == "" {
+		return errors.New("resolved execution provider and model are required")
+	}
+	if params.Runtime.ProtocolVersion == "" {
+		return errors.New("execution protocol version is required")
+	}
+	if params.Request.MaxTurns < 0 {
+		return errors.New("execution max turns cannot be negative")
+	}
+	if params.Request.TimeoutMS < 0 {
+		return errors.New("execution timeout cannot be negative")
+	}
+	if params.Request.ImageCount < 0 || params.Request.FileCount < 0 {
+		return errors.New("execution attachment counts cannot be negative")
+	}
+	return nil
+}
+
+func matchesList(run Run, opts ListOptions) bool {
+	return (opts.WorkspaceID == "" || run.Workspace.ID == opts.WorkspaceID) &&
+		(opts.WorkspaceRoot == "" || run.Workspace.Root == opts.WorkspaceRoot) &&
+		(opts.ThreadID == "" || run.ThreadID == opts.ThreadID) &&
+		(opts.Status == "" || run.Status == opts.Status)
+}
+
+func stateConflict(id string, status Status, operation string) error {
+	return fmt.Errorf("%w: cannot %s run %q in status %q", ErrConflict, operation, id, status)
+}
+
+func sanitizeError(runErr Error) Error {
+	runErr.Code = strings.TrimSpace(runErr.Code)
+	runErr.Category = strings.TrimSpace(runErr.Category)
+	runErr.Provider = strings.TrimSpace(runErr.Provider)
+	runErr.Message = strings.Join(strings.Fields(runErr.Message), " ")
+	const maxErrorBytes = 2000
+	runErr.Message = stringutil.Truncate(runErr.Message, maxErrorBytes, "")
+	return runErr
+}
+
+func normalizedTime(value time.Time) time.Time {
+	if value.IsZero() {
+		return time.Now().UTC()
+	}
+	return value.UTC()
+}
+
+func toMillis(value time.Time) int64 {
+	return value.UTC().UnixMilli()
+}
+
+func timeMillis(value *time.Time) int64 {
+	if value == nil || value.IsZero() {
+		return 0
+	}
+	return toMillis(*value)
+}
+
+func fromMillis(value int64) time.Time {
+	return time.UnixMilli(value).UTC()
+}
+
+func optionalTime(value int64) *time.Time {
+	if value == 0 {
+		return nil
+	}
+	return timePtr(fromMillis(value))
+}
+
+func timePtr(value time.Time) *time.Time {
+	copy := value.UTC()
+	return &copy
+}
+
+func cloneResult(result Result) Result {
+	return result
+}
+
+func cloneRun(run Run) Run {
+	copy := run
+	copy.Request = normalizeRequest(run.Request)
+	copy.Runtime = normalizeRuntime(run.Runtime)
+	copy.Workspace = normalizeWorkspace(run.Workspace)
+	copy.Turns = append([]TurnRef(nil), run.Turns...)
+	if run.Result != nil {
+		result := cloneResult(*run.Result)
+		copy.Result = &result
+	}
+	if run.Error != nil {
+		runErr := *run.Error
+		copy.Error = &runErr
+	}
+	if run.StartedAt != nil {
+		copy.StartedAt = timePtr(*run.StartedAt)
+	}
+	if run.CompletedAt != nil {
+		copy.CompletedAt = timePtr(*run.CompletedAt)
+	}
+	return copy
+}

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -129,7 +129,13 @@ func (s *Store) Get(ctx context.Context, id string) (Run, error) {
 		return Run{}, err
 	}
 	defer db.Close()
-	return loadRun(ctx, db, id)
+	var run Run
+	err = withReadSnapshot(ctx, db, func(q queryer) error {
+		var loadErr error
+		run, loadErr = loadRun(ctx, q, id)
+		return loadErr
+	})
+	return run, err
 }
 
 func (s *Store) List(ctx context.Context, opts ListOptions) ([]Run, error) {
@@ -153,7 +159,12 @@ func (s *Store) List(ctx context.Context, opts ListOptions) ([]Run, error) {
 		return nil, err
 	}
 	defer db.Close()
-	durable, err := listDurableRuns(ctx, db, opts)
+	var durable []Run
+	err = withReadSnapshot(ctx, db, func(q queryer) error {
+		var listErr error
+		durable, listErr = listDurableRuns(ctx, q, opts)
+		return listErr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -431,6 +442,21 @@ type queryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
 
+func withReadSnapshot(ctx context.Context, db *sql.DB, read func(queryer) error) error {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("begin execution read snapshot: %w", err)
+	}
+	defer tx.Rollback()
+	if err := read(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit execution read snapshot: %w", err)
+	}
+	return nil
+}
+
 func loadRun(ctx context.Context, q queryer, id string) (Run, error) {
 	var run Run
 	var requestJSON, runtimeJSON, resultJSON, errorJSON string
@@ -506,7 +532,7 @@ FROM execution_run_turns WHERE run_id = ? ORDER BY ordinal`, runID)
 	return turns, nil
 }
 
-func listDurableRuns(ctx context.Context, db *sql.DB, opts ListOptions) ([]Run, error) {
+func listDurableRuns(ctx context.Context, q queryer, opts ListOptions) ([]Run, error) {
 	clauses := []string{"1 = 1"}
 	args := make([]any, 0, 5)
 	if opts.WorkspaceID != "" {
@@ -526,7 +552,7 @@ func listDurableRuns(ctx context.Context, db *sql.DB, opts ListOptions) ([]Run, 
 		args = append(args, opts.Status)
 	}
 	args = append(args, opts.Limit)
-	rows, err := db.QueryContext(ctx, `
+	rows, err := q.QueryContext(ctx, `
 SELECT id FROM execution_runs
 WHERE `+strings.Join(clauses, " AND ")+`
 ORDER BY updated_at DESC, id DESC LIMIT ?`, args...)
@@ -547,7 +573,7 @@ ORDER BY updated_at DESC, id DESC LIMIT ?`, args...)
 	}
 	runs := make([]Run, 0, len(ids))
 	for _, id := range ids {
-		run, err := loadRun(ctx, db, id)
+		run, err := loadRun(ctx, q, id)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/execution/store.go
+++ b/internal/execution/store.go
@@ -212,6 +212,29 @@ func (s *Store) AttachTurn(ctx context.Context, runID, threadID, turnID string, 
 	})
 }
 
+// Resolve records the effective runtime and workspace selected under Turn
+// admission. It is allowed only before the first canonical Turn is attached.
+func (s *Store) Resolve(ctx context.Context, runID string, runtime RuntimeManifest, workspace WorkspaceRef, at time.Time) (Run, error) {
+	runtime = normalizeRuntime(runtime)
+	workspace = normalizeWorkspace(workspace)
+	if runtime.Resolved.Provider == "" || runtime.Resolved.Model == "" || runtime.ProtocolVersion == "" {
+		return Run{}, errors.New("resolved execution runtime is incomplete")
+	}
+	if workspace.Root == "" {
+		return Run{}, errors.New("resolved execution workspace root is required")
+	}
+	at = normalizedTime(at)
+	return s.update(ctx, runID, func(run *Run) error {
+		if run.Status != StatusAccepted || len(run.Turns) != 0 {
+			return stateConflict(run.ID, run.Status, "resolve runtime")
+		}
+		run.Runtime = runtime
+		run.Workspace = workspace
+		run.UpdatedAt = at
+		return nil
+	})
+}
+
 func (s *Store) FinishTurn(ctx context.Context, runID, turnID string, terminal TurnTerminal) (Run, error) {
 	runID = strings.TrimSpace(runID)
 	turnID = strings.TrimSpace(turnID)

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -1,0 +1,266 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blueberrycongee/wuu/internal/session"
+)
+
+func TestStoreDurableRunLifecycleAndReload(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	created, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if created.Status != StatusAccepted || created.Ephemeral || len(created.Turns) != 0 {
+		t.Fatalf("created run = %+v", created)
+	}
+
+	startedAt := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	running, err := store.AttachTurn(ctx, created.ID, "thread-1", "turn-1", startedAt)
+	if err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	if running.Status != StatusRunning || running.StartedAt == nil || len(running.Turns) != 1 {
+		t.Fatalf("running run = %+v", running)
+	}
+	secondAt := startedAt.Add(time.Minute)
+	if _, err := store.AttachTurn(ctx, created.ID, "thread-1", "turn-2", secondAt); err != nil {
+		t.Fatalf("AttachTurn second: %v", err)
+	}
+	finishedAt := secondAt.Add(time.Minute)
+	if _, err := store.FinishTurn(ctx, created.ID, "turn-1", TurnTerminal{TracePath: "/trace/one.jsonl", At: finishedAt}); err != nil {
+		t.Fatalf("FinishTurn: %v", err)
+	}
+	completed, err := store.Complete(ctx, created.ID, Result{FinalTurnID: "turn-2", TracePath: "/trace/two.jsonl"}, finishedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if completed.Status != StatusCompleted || completed.CompletedAt == nil || completed.Result == nil || completed.Result.FinalTurnID != "turn-2" {
+		t.Fatalf("completed run = %+v", completed)
+	}
+
+	reopened, err := NewStore(store.sessDir)
+	if err != nil {
+		t.Fatalf("NewStore reopen: %v", err)
+	}
+	got, err := reopened.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != StatusCompleted || len(got.Turns) != 2 || got.Turns[0].TracePath != "/trace/one.jsonl" {
+		t.Fatalf("reloaded run = %+v", got)
+	}
+}
+
+func TestStoreEphemeralRunStaysInProcess(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	params := testCreateParams(ModeStart, "", "ephemeral-thread")
+	params.Ephemeral = true
+	run, err := store.Create(ctx, params)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, run.ID, "ephemeral-thread", "turn-1", time.Now()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	if got, err := store.Get(ctx, run.ID); err != nil || !got.Ephemeral {
+		t.Fatalf("Get ephemeral = %+v, %v", got, err)
+	}
+
+	reopened, err := NewStore(store.sessDir)
+	if err != nil {
+		t.Fatalf("NewStore reopen: %v", err)
+	}
+	if _, err := reopened.Get(ctx, run.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get reopened error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreRejectsInvalidTransitionsAndThreadMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	run, err := store.Create(ctx, testCreateParams(ModeResume, "source-thread", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, run.ID, "thread-2", "turn-1", time.Now()); !errors.Is(err, ErrConflict) {
+		t.Fatalf("thread mismatch error = %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, run.ID, "thread-1", "turn-1", time.Now()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	if _, err := store.Fail(ctx, run.ID, StatusFailed, Result{FinalTurnID: "turn-1"}, Error{Message: "provider failed"}, time.Now()); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, run.ID, "thread-1", "turn-2", time.Now()); !errors.Is(err, ErrConflict) {
+		t.Fatalf("terminal attach error = %v", err)
+	}
+	if _, err := store.Complete(ctx, run.ID, Result{}, time.Now()); !errors.Is(err, ErrConflict) {
+		t.Fatalf("terminal status change error = %v", err)
+	}
+}
+
+func TestStoreEnforcesOneActiveRunAndOneRunPerTurn(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	first, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	if _, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-1")); !errors.Is(err, ErrConflict) {
+		t.Fatalf("second active run error = %v, want ErrConflict", err)
+	}
+	if _, err := store.AttachTurn(ctx, first.ID, "thread-1", "turn-shared", time.Now()); err != nil {
+		t.Fatalf("AttachTurn first: %v", err)
+	}
+	if _, err := store.Complete(ctx, first.ID, Result{FinalTurnID: "turn-shared"}, time.Now()); err != nil {
+		t.Fatalf("Complete first: %v", err)
+	}
+	second, err := store.Create(ctx, testCreateParams(ModeResume, "thread-1", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, second.ID, "thread-1", "turn-shared", time.Now()); !errors.Is(err, ErrConflict) {
+		t.Fatalf("shared turn error = %v, want ErrConflict", err)
+	}
+}
+
+func TestStoreTerminalReplayMustMatchAndErrorIsSingleLine(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	run, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	result := Result{FinalTurnID: "turn-1", ExitCode: 7}
+	terminal, err := store.Fail(ctx, run.ID, StatusFailed, result, Error{Code: "provider", Message: "provider\nfailed"}, time.Now())
+	if err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if terminal.Error == nil || terminal.Error.Message != "provider failed" {
+		t.Fatalf("terminal error = %+v", terminal.Error)
+	}
+	if _, err := store.Fail(ctx, run.ID, StatusFailed, result, Error{Code: "provider", Message: "provider failed"}, time.Now()); err != nil {
+		t.Fatalf("idempotent Fail: %v", err)
+	}
+	if _, err := store.Fail(ctx, run.ID, StatusFailed, Result{FinalTurnID: "other", ExitCode: 7}, Error{Code: "provider", Message: "provider failed"}, time.Now()); !errors.Is(err, ErrConflict) {
+		t.Fatalf("conflicting replay error = %v", err)
+	}
+}
+
+func TestStoreListFiltersAndReconcileActive(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	first, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-1"))
+	if err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	secondParams := testCreateParams(ModeFork, "source-thread", "thread-2")
+	secondParams.Workspace = WorkspaceRef{ID: "other", Root: "/other"}
+	second, err := store.Create(ctx, secondParams)
+	if err != nil {
+		t.Fatalf("Create second: %v", err)
+	}
+	if _, err := store.AttachTurn(ctx, first.ID, "thread-1", "turn-1", time.Now()); err != nil {
+		t.Fatalf("AttachTurn: %v", err)
+	}
+	runs, err := store.List(ctx, ListOptions{WorkspaceID: "workspace-1"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != first.ID {
+		t.Fatalf("filtered runs = %+v", runs)
+	}
+
+	db, err := session.OpenStore(store.sessDir)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	nowMS := time.Now().UTC().UnixMilli()
+	if _, err := db.Exec(`UPDATE inference_journal_runtimes SET closed_at = ? WHERE id = ?`, nowMS, "runtime-1"); err != nil {
+		db.Close()
+		t.Fatalf("close prior runtime: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO inference_journal_runtimes (id, workspace_scope, pid, started_at, heartbeat_at, closed_at)
+VALUES (?, ?, ?, ?, ?, 0)`, "runtime-2", "test-workspace", os.Getpid(), nowMS, nowMS); err != nil {
+		db.Close()
+		t.Fatalf("insert current runtime: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	recovered, err := store.ReconcileOrphans(ctx, "runtime-2", time.Now())
+	if err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+	if len(recovered) != 2 {
+		t.Fatalf("reconciled = %d, want 2", len(recovered))
+	}
+	for _, id := range []string{first.ID, second.ID} {
+		got, err := store.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get %s: %v", id, err)
+		}
+		if got.Status != StatusInterrupted || got.Error == nil || got.Error.Code != "process_restarted" {
+			t.Fatalf("reconciled run = %+v", got)
+		}
+	}
+}
+
+func TestStoreValidatesCanonicalRequest(t *testing.T) {
+	store := newTestStore(t)
+	params := testCreateParams(ModeResume, "", "thread-1")
+	if _, err := store.Create(context.Background(), params); err == nil {
+		t.Fatal("expected missing source thread error")
+	}
+	params = testCreateParams(ModeStart, "", "thread-1")
+	params.Request.TimeoutMS = -1
+	if _, err := store.Create(context.Background(), params); err == nil {
+		t.Fatal("expected invalid timeout error")
+	}
+}
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := NewStore(filepath.Join(t.TempDir(), "sessions"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	db, err := session.OpenStore(store.sessDir)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	now := time.Now().UTC().UnixMilli()
+	if _, err := db.Exec(`
+INSERT INTO inference_journal_runtimes (id, workspace_scope, pid, started_at, heartbeat_at, closed_at)
+VALUES (?, ?, ?, ?, ?, 0)`, "runtime-1", "test-workspace", os.Getpid(), now, now); err != nil {
+		db.Close()
+		t.Fatalf("insert test runtime: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	return store
+}
+
+func testCreateParams(mode Mode, source, threadID string) CreateParams {
+	return CreateParams{
+		RuntimeID: "runtime-1",
+		Request:   Request{Mode: mode, SourceThreadID: source, HasPrompt: true},
+		Runtime: RuntimeManifest{
+			Resolved:        Selection{Provider: "test-provider", Model: "test-model", PermissionMode: "read-only"},
+			ProtocolVersion: "wuu-app-server/v0.1",
+		},
+		Workspace: WorkspaceRef{ID: "workspace-1", Root: "/workspace"},
+		ThreadID:  threadID,
+	}
+}

--- a/internal/execution/store_test.go
+++ b/internal/execution/store_test.go
@@ -229,6 +229,62 @@ func TestStoreValidatesCanonicalRequest(t *testing.T) {
 	}
 }
 
+func TestStoreReadSnapshotDoesNotMixRunAndTurnVersions(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	run, err := store.Create(ctx, testCreateParams(ModeStart, "", "thread-snapshot"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	db, err := session.OpenStore(store.sessDir)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer db.Close()
+
+	err = withReadSnapshot(ctx, db, func(q queryer) error {
+		var status Status
+		if err := q.QueryRowContext(ctx, `SELECT status FROM execution_runs WHERE id = ?`, run.ID).Scan(&status); err != nil {
+			return err
+		}
+		if status != StatusAccepted {
+			t.Fatalf("initial snapshot status = %q", status)
+		}
+		writer, err := NewStore(store.sessDir)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.AttachTurn(ctx, run.ID, run.ThreadID, "turn-snapshot", time.Now().UTC()); err != nil {
+			return err
+		}
+		snapshot, err := loadRun(ctx, q, run.ID)
+		if err != nil {
+			return err
+		}
+		if snapshot.Status != StatusAccepted || len(snapshot.Turns) != 0 {
+			t.Fatalf("mixed read snapshot = %+v", snapshot)
+		}
+		listed, err := listDurableRuns(ctx, q, ListOptions{Status: StatusAccepted, Limit: 10})
+		if err != nil {
+			return err
+		}
+		if len(listed) != 1 || listed[0].ID != run.ID || listed[0].Status != StatusAccepted || len(listed[0].Turns) != 0 {
+			t.Fatalf("mixed list snapshot = %+v", listed)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withReadSnapshot: %v", err)
+	}
+	latest, err := store.Get(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("Get latest: %v", err)
+	}
+	if latest.Status != StatusRunning || len(latest.Turns) != 1 {
+		t.Fatalf("latest run = %+v", latest)
+	}
+}
+
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	store, err := NewStore(filepath.Join(t.TempDir(), "sessions"))

--- a/internal/execution/types.go
+++ b/internal/execution/types.go
@@ -1,0 +1,136 @@
+package execution
+
+import "time"
+
+type Status string
+
+const (
+	StatusAccepted    Status = "accepted"
+	StatusRunning     Status = "running"
+	StatusCompleted   Status = "completed"
+	StatusFailed      Status = "failed"
+	StatusInterrupted Status = "interrupted"
+	StatusTimedOut    Status = "timed_out"
+	StatusCancelled   Status = "cancelled"
+)
+
+func (s Status) Terminal() bool {
+	switch s {
+	case StatusCompleted, StatusFailed, StatusInterrupted, StatusTimedOut, StatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+type Mode string
+
+const (
+	ModeStart  Mode = "start"
+	ModeResume Mode = "resume"
+	ModeFork   Mode = "fork"
+	ModeReview Mode = "review"
+)
+
+type WorkspaceRef struct {
+	ID   string `json:"id,omitempty"`
+	Root string `json:"root"`
+}
+
+type Selection struct {
+	Provider       string `json:"provider,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Variant        string `json:"variant,omitempty"`
+	Effort         string `json:"effort,omitempty"`
+	PermissionMode string `json:"permission_mode,omitempty"`
+}
+
+// Request is the canonical Wuu-owned invocation manifest. User content and
+// attachments live on the referenced Turn; environment and Git state remain
+// external execution inputs and are intentionally not copied here.
+type Request struct {
+	Mode             Mode      `json:"mode"`
+	SourceThreadID   string    `json:"source_thread_id,omitempty"`
+	Requested        Selection `json:"requested,omitempty"`
+	AgentProfile     string    `json:"agent_profile,omitempty"`
+	MaxTurns         int       `json:"max_turns,omitempty"`
+	TimeoutMS        int64     `json:"timeout_ms,omitempty"`
+	Ultra            bool      `json:"ultra,omitempty"`
+	NoTools          bool      `json:"no_tools,omitempty"`
+	HasPrompt        bool      `json:"has_prompt"`
+	ImageCount       int       `json:"image_count,omitempty"`
+	FileCount        int       `json:"file_count,omitempty"`
+	StructuredOutput bool      `json:"structured_output,omitempty"`
+}
+
+type RuntimeManifest struct {
+	Resolved        Selection `json:"resolved"`
+	ProtocolVersion string    `json:"protocol_version"`
+	CoreVersion     string    `json:"core_version,omitempty"`
+	CoreCommit      string    `json:"core_commit,omitempty"`
+	Ultra           bool      `json:"ultra"`
+	MaxParallel     int       `json:"max_parallel"`
+}
+
+type Error struct {
+	Code       string `json:"code,omitempty"`
+	Category   string `json:"category,omitempty"`
+	Message    string `json:"message"`
+	Provider   string `json:"provider,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+}
+
+type Result struct {
+	FinalTurnID string `json:"final_turn_id,omitempty"`
+	FinalItemID string `json:"final_item_id,omitempty"`
+	TracePath   string `json:"trace_path,omitempty"`
+	ExitCode    int    `json:"exit_code,omitempty"`
+}
+
+type TurnRef struct {
+	TurnID     string    `json:"turn_id"`
+	ThreadID   string    `json:"thread_id"`
+	Ordinal    int       `json:"ordinal"`
+	TracePath  string    `json:"trace_path,omitempty"`
+	AttachedAt time.Time `json:"attached_at"`
+}
+
+type Run struct {
+	ID          string          `json:"id"`
+	RuntimeID   string          `json:"runtime_id,omitempty"`
+	Status      Status          `json:"status"`
+	Request     Request         `json:"request"`
+	Runtime     RuntimeManifest `json:"runtime"`
+	Workspace   WorkspaceRef    `json:"workspace"`
+	ThreadID    string          `json:"thread_id"`
+	Turns       []TurnRef       `json:"turns"`
+	Result      *Result         `json:"result,omitempty"`
+	Error       *Error          `json:"error,omitempty"`
+	Ephemeral   bool            `json:"ephemeral,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+}
+
+type CreateParams struct {
+	RuntimeID string
+	Request   Request
+	Runtime   RuntimeManifest
+	Workspace WorkspaceRef
+	ThreadID  string
+	Ephemeral bool
+}
+
+type TurnTerminal struct {
+	TracePath string
+	At        time.Time
+}
+
+type ListOptions struct {
+	WorkspaceID   string
+	WorkspaceRoot string
+	ThreadID      string
+	Status        Status
+	Limit         int
+}

--- a/internal/session/inference_journal.go
+++ b/internal/session/inference_journal.go
@@ -31,6 +31,12 @@ func InferenceJournalRecoveryInterval() time.Duration {
 	return inferenceJournalStaleAfter
 }
 
+// InferenceRuntimeProcessAlive exposes the process-liveness half of the
+// inference runtime lease to sibling metadata stores that share its owner ID.
+func InferenceRuntimeProcessAlive(pid int) bool {
+	return inferenceRuntimeProcessAlive(pid)
+}
+
 // InferenceJournalRuntime binds all journals created by one runtime process to
 // a workspace scope. A fresh runtime id lets startup recovery distinguish
 // records left by the previous process from work created during this boot.

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1174,6 +1174,47 @@ func migrateSchema(db *sql.DB) error {
 		 ON tool_invocations(batch_id, prepared_at, id)`,
 		`CREATE INDEX IF NOT EXISTS idx_tool_invocations_projection
 		 ON tool_invocations(state, projected_at, settled_at)`,
+		`CREATE TABLE IF NOT EXISTS execution_runs (
+				id              TEXT PRIMARY KEY,
+				runtime_id      TEXT NOT NULL DEFAULT '',
+				status          TEXT NOT NULL,
+				request_json    TEXT NOT NULL,
+				runtime_json    TEXT NOT NULL,
+				thread_id       TEXT NOT NULL DEFAULT '',
+				workspace_id    TEXT NOT NULL DEFAULT '',
+				workspace_root  TEXT NOT NULL DEFAULT '',
+				result_json     TEXT NOT NULL DEFAULT '',
+				error_json      TEXT NOT NULL DEFAULT '',
+				created_at      INTEGER NOT NULL,
+				started_at      INTEGER NOT NULL DEFAULT 0,
+				updated_at      INTEGER NOT NULL,
+				completed_at    INTEGER NOT NULL DEFAULT 0,
+				FOREIGN KEY(runtime_id) REFERENCES inference_journal_runtimes(id)
+			)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_runs_updated
+		 ON execution_runs(updated_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_runs_workspace
+		 ON execution_runs(workspace_id, workspace_root, updated_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_runs_thread
+		 ON execution_runs(thread_id, updated_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_runs_active_thread
+		 ON execution_runs(thread_id) WHERE status IN ('accepted', 'running')`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_runs_runtime
+		 ON execution_runs(runtime_id, status, updated_at)`,
+		`CREATE TABLE IF NOT EXISTS execution_run_turns (
+				run_id          TEXT NOT NULL,
+				thread_id       TEXT NOT NULL,
+				turn_id         TEXT NOT NULL,
+				ordinal         INTEGER NOT NULL,
+				trace_path      TEXT NOT NULL DEFAULT '',
+				attached_at     INTEGER NOT NULL,
+				PRIMARY KEY(run_id, turn_id),
+				UNIQUE(run_id, ordinal),
+				UNIQUE(thread_id, turn_id),
+				FOREIGN KEY(run_id) REFERENCES execution_runs(id) ON DELETE CASCADE
+			)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_run_turns_turn
+		 ON execution_run_turns(turn_id, run_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/internal/structuredoutput/validator.go
+++ b/internal/structuredoutput/validator.go
@@ -1,0 +1,96 @@
+package structuredoutput
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const MaxRetries = 2
+
+type Validator struct {
+	raw json.RawMessage
+	sch *jsonschema.Schema
+}
+
+func New(raw json.RawMessage) (*Validator, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("parse output schema: %w", err)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("decode output schema: %w", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource("schema.json", doc); err != nil {
+		return nil, fmt.Errorf("load output schema: %w", err)
+	}
+	sch, err := compiler.Compile("schema.json")
+	if err != nil {
+		return nil, fmt.Errorf("compile output schema: %w", err)
+	}
+	compact, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("normalize output schema: %w", err)
+	}
+	return &Validator{raw: compact, sch: sch}, nil
+}
+
+func (v *Validator) InitialPrompt(prompt string) string {
+	if v == nil {
+		return prompt
+	}
+	return v.prompt("You must complete the task and make your final answer a single JSON value that validates against this JSON Schema.", prompt)
+}
+
+func (v *Validator) RetryPrompt(previous string, validationErr error) string {
+	if v == nil {
+		return ""
+	}
+	message := "Your previous final answer did not validate against the required JSON Schema."
+	if validationErr != nil {
+		message += "\nValidation error: " + validationErr.Error()
+	}
+	return v.prompt(message, "Previous final answer:\n"+previous)
+}
+
+func (v *Validator) Validate(text string) error {
+	if v == nil {
+		return nil
+	}
+	dec := json.NewDecoder(strings.NewReader(strings.TrimSpace(text)))
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return fmt.Errorf("final answer is not valid JSON: %w", err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		return errors.New("final answer contains more than one JSON value")
+	}
+	if err := v.sch.Validate(value); err != nil {
+		return fmt.Errorf("final answer does not match output schema: %w", err)
+	}
+	return nil
+}
+
+func (v *Validator) prompt(instruction, content string) string {
+	var b strings.Builder
+	b.WriteString(instruction)
+	b.WriteString("\nReturn only JSON. Do not wrap it in Markdown. Do not include explanatory text outside the JSON value.\n\nJSON Schema:\n")
+	b.Write(v.raw)
+	if strings.TrimSpace(content) != "" {
+		b.WriteString("\n\nTask:\n")
+		b.WriteString(content)
+	}
+	return b.String()
+}

--- a/internal/structuredoutput/validator_test.go
+++ b/internal/structuredoutput/validator_test.go
@@ -1,0 +1,35 @@
+package structuredoutput
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidatorAcceptsSingleSchemaValue(t *testing.T) {
+	validator, err := New(json.RawMessage(`{"type":"object","required":["ok"],"properties":{"ok":{"type":"boolean"}},"additionalProperties":false}`))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := validator.Validate(`{"ok":true}`); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if err := validator.Validate(`{"ok":"yes"}`); err == nil {
+		t.Fatal("Validate accepted a value that violates the schema")
+	}
+	if err := validator.Validate(`{"ok":true}{"ok":false}`); err == nil {
+		t.Fatal("Validate accepted multiple JSON values")
+	}
+}
+
+func TestValidatorRetryPromptIncludesFailureAndPreviousValue(t *testing.T) {
+	validator, err := New(json.RawMessage(`{"type":"string","minLength":3}`))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	prompt := validator.RetryPrompt(`"no"`, errors.New("too short"))
+	if !strings.Contains(prompt, "Previous final answer") || !strings.Contains(prompt, `"no"`) {
+		t.Fatalf("retry prompt = %q", prompt)
+	}
+}


### PR DESCRIPTION
## Summary
- add durable and ephemeral execution Run manifests without duplicating Thread/Turn/Item facts
- expose `run/start`, `run/read`, `run/list`, `run/interrupt`, and typed Run notifications through app-server
- migrate `wuu exec` and structured-output retries to one app-server Run, preserving JSONL/plain output and exit-code behavior
- add `wuu runs` and `wuu runs read` inspection commands and automation documentation

## Verification
- `go test ./internal/execution ./internal/structuredoutput ./internal/appserver ./internal/exec ./cmd/wuu -count=1 -timeout=4m`
- real `wuu exec --json --ephemeral` smoke completed with a Run ID
- durable `wuu runs` / `wuu runs read` smoke completed; both flag orders verified
- `git diff --check`

## Known validation limits
- `go test ./... -count=1 -timeout=10m` reached the timeout in the existing `internal/tools` Git fixture (`git commit -qm initial`), not in the changed packages.
- `go test -race` passes for `internal/execution` and `internal/exec`; the existing app-server lease test remains timing-sensitive under race and fails with `queued turn was dropped while another app-server owned the thread`.
