### PR TITLE
refactor(exec): converge on the Run control path

### DIFF
--- a/cmd/wuu/main_test.go
+++ b/cmd/wuu/main_test.go
@@ -21,6 +21,7 @@ import (
 	wuucontext "github.com/blueberrycongee/wuu/internal/context"
 	"github.com/blueberrycongee/wuu/internal/evalharness"
 	wuuexec "github.com/blueberrycongee/wuu/internal/exec"
+	"github.com/blueberrycongee/wuu/internal/execution"
 	"github.com/blueberrycongee/wuu/internal/modelprofile"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/runtime"
@@ -1524,7 +1525,7 @@ func withStdin[T any](t *testing.T, text string, fn func() T) T {
 type cliExecFakeController struct {
 	initResult appserver.InitializeResult
 	thread     appserver.Thread
-	turn       appserver.Turn
+	run        appserver.Run
 	events     []wuuexec.Notification
 
 	startedThread  bool
@@ -1548,7 +1549,10 @@ func newCLIExecFakeController(events ...wuuexec.Notification) *cliExecFakeContro
 			},
 		},
 		thread: appserver.Thread{ID: "thread-1", ModelProvider: "test-provider", Model: "test-model", CWD: "/repo"},
-		turn:   appserver.Turn{ID: "turn-1"},
+		run: appserver.Run{
+			ID: "run-1", Status: execution.StatusRunning, ThreadID: "thread-1",
+			Turns: []execution.TurnRef{{TurnID: "turn-1", ThreadID: "thread-1"}},
+		},
 		events: events,
 	}
 }
@@ -1576,24 +1580,56 @@ func (f *cliExecFakeController) ForkThread(_ context.Context, id string) (appser
 	return f.thread, nil
 }
 
-func (f *cliExecFakeController) StartTurn(_ context.Context, _ string, input wuuexec.TurnInput) (appserver.Turn, error) {
-	f.startedPrompt = input.Prompt
-	f.startedImages = append([]appserver.TurnStartImage(nil), input.Images...)
-	f.startedFiles = append([]appserver.TurnStartFile(nil), input.Files...)
-	return f.turn, nil
+func (f *cliExecFakeController) StartRun(_ context.Context, params appserver.RunStartParams) (appserver.Run, error) {
+	f.startedPrompt = params.Prompt
+	f.startedImages = append([]appserver.TurnStartImage(nil), params.Images...)
+	f.startedFiles = append([]appserver.TurnStartFile(nil), params.Files...)
+	return f.run, nil
 }
 
-func (f *cliExecFakeController) Interrupt(context.Context, string) error {
-	return nil
+func (f *cliExecFakeController) InterruptRun(_ context.Context, _ string, _ string) (appserver.Run, error) {
+	return f.run, nil
 }
 
 func (f *cliExecFakeController) Shutdown(context.Context) error {
 	return nil
 }
 
+// Notifications mirrors the in-process app-server: turn/started, the
+// scripted events, then a synthesized completed run/updated unless the
+// script already settles the Run.
 func (f *cliExecFakeController) Notifications() <-chan wuuexec.Notification {
-	ch := make(chan wuuexec.Notification, len(f.events))
-	for _, event := range f.events {
+	hasTurnStarted := false
+	hasRunUpdated := false
+	lastTurnID := "turn-1"
+	lastTrace := ""
+	for _, ev := range f.events {
+		switch ev.Method {
+		case appserver.NotificationTurnStarted:
+			hasTurnStarted = true
+		case appserver.NotificationRunUpdated:
+			hasRunUpdated = true
+		case appserver.NotificationTurnCompleted:
+			var params appserver.TurnCompletedNotification
+			if err := json.Unmarshal(ev.Params, &params); err == nil {
+				lastTurnID = params.Turn.ID
+				lastTrace = params.TracePath
+			}
+		}
+	}
+	events := make([]wuuexec.Notification, 0, len(f.events)+2)
+	if !hasTurnStarted {
+		events = append(events, cliExecNotification(appserver.NotificationTurnStarted, appserver.TurnStartedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}}))
+	}
+	events = append(events, f.events...)
+	if !hasRunUpdated {
+		events = append(events, cliExecNotification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusCompleted,
+			Result: &execution.Result{FinalTurnID: lastTurnID, TracePath: lastTrace},
+		}}))
+	}
+	ch := make(chan wuuexec.Notification, len(events))
+	for _, event := range events {
 		ch <- event
 	}
 	return ch

--- a/docs/en/automation/exec.md
+++ b/docs/en/automation/exec.md
@@ -165,6 +165,7 @@ See [JSONL events](jsonl-events.md) for the event contract.
 - `6`: app-server protocol error.
 - `7`: provider or model error.
 - `8`: tool execution failed and the agent did not recover.
+- `9`: the target thread already has a running turn (try again later, or use another thread).
 
 Scripts should use exit codes instead of parsing natural-language error text.
 

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -94,8 +94,6 @@ const (
 	MethodTurnUnsteer      = "turn/unsteer"
 	MethodTurnInterrupt    = "turn/interrupt"
 	MethodRunStart         = "run/start"
-	MethodRunRead          = "run/read"
-	MethodRunList          = "run/list"
 	MethodRunInterrupt     = "run/interrupt"
 	MethodProcessList      = "process/list"
 	MethodProcessRead      = "process/read"
@@ -1403,28 +1401,10 @@ type RunStartResult struct {
 	Run Run `json:"run"`
 }
 
-type RunReadParams struct {
-	RunID string `json:"run_id"`
-}
-
 type RunView struct {
 	Run      Run     `json:"run"`
 	Thread   *Thread `json:"thread,omitempty"`
 	Attached bool    `json:"attached"`
-}
-
-type RunReadResult = RunView
-
-type RunListParams struct {
-	WorkspaceID   string           `json:"workspace_id,omitempty"`
-	WorkspaceRoot string           `json:"workspace_root,omitempty"`
-	ThreadID      string           `json:"thread_id,omitempty"`
-	Status        execution.Status `json:"status,omitempty"`
-	Limit         int              `json:"limit,omitempty"`
-}
-
-type RunListResult struct {
-	Runs []Run `json:"runs"`
 }
 
 type RunInterruptParams struct {

--- a/internal/appserver/run_handlers.go
+++ b/internal/appserver/run_handlers.go
@@ -115,7 +115,8 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 		if admissionErr == nil {
 			admissionErr = fmt.Errorf("thread %q already has a running turn", params.ThreadID)
 		}
-		_, _ = s.runStore.Fail(ctx, run.ID, execution.StatusCancelled, execution.Result{}, execution.Error{Code: "admission_failed", Category: "cancelled", Message: admissionErr.Error()}, time.Now().UTC())
+		runErr := execution.Error{Code: "admission_failed", Category: "cancelled", Message: admissionErr.Error()}
+		_, _ = s.runStore.Fail(ctx, run.ID, execution.StatusCancelled, execution.Result{ExitCode: execution.ExitCodeForSettlement(execution.StatusCancelled, &runErr)}, runErr, time.Now().UTC())
 		return s.writeRunError(req.ID, "thread_busy", admissionErr)
 	}
 
@@ -158,40 +159,6 @@ func (s *Server) handleRunStart(ctx context.Context, req Request) error {
 	}
 	launch.Commit()
 	return nil
-}
-
-func (s *Server) handleRunRead(ctx context.Context, req Request) error {
-	var params RunReadParams
-	if err := decodeParams(req.Params, &params); err != nil {
-		return s.writeRunError(req.ID, "invalid_params", err)
-	}
-	view, err := s.readExecutionRun(ctx, strings.TrimSpace(params.RunID))
-	if err != nil {
-		code := "internal_error"
-		if errors.Is(err, execution.ErrNotFound) {
-			code = "run_not_found"
-		}
-		return s.writeRunError(req.ID, code, err)
-	}
-	return s.writeResponse(req.ID, RunReadResult(view), nil)
-}
-
-func (s *Server) handleRunList(ctx context.Context, req Request) error {
-	var params RunListParams
-	if err := decodeParams(req.Params, &params); err != nil {
-		return s.writeRunError(req.ID, "invalid_params", err)
-	}
-	if s.runStore == nil {
-		return s.writeRunError(req.ID, "internal_error", errors.New("execution run store is unavailable"))
-	}
-	runs, err := s.runStore.List(ctx, execution.ListOptions{
-		WorkspaceID: strings.TrimSpace(params.WorkspaceID), WorkspaceRoot: strings.TrimSpace(params.WorkspaceRoot),
-		ThreadID: strings.TrimSpace(params.ThreadID), Status: params.Status, Limit: params.Limit,
-	})
-	if err != nil {
-		return s.writeRunError(req.ID, "internal_error", err)
-	}
-	return s.writeResponse(req.ID, RunListResult{Runs: runs}, nil)
 }
 
 func (s *Server) handleRunInterrupt(ctx context.Context, req Request) error {
@@ -390,7 +357,6 @@ func (s *Server) settleExecutionRunTurn(runID, turnID, tracePath string, turn Tu
 		if turn.Status == TurnStatusInterrupted || errors.Is(turnErr, context.Canceled) {
 			status = s.executionRunInterruptStatus(runID)
 		}
-		result.ExitCode = executionExitCode(status)
 		runError := execution.Error{Code: "turn_failed", Category: "unknown", Message: turnErr.Error()}
 		if structured != nil {
 			runError = execution.Error{
@@ -398,6 +364,7 @@ func (s *Server) settleExecutionRunTurn(runID, turnID, tracePath string, turn Tu
 				Provider: structured.Provider, StatusCode: structured.StatusCode,
 			}
 		}
+		result.ExitCode = execution.ExitCodeForSettlement(status, &runError)
 		run, err = s.runStore.Fail(context.Background(), runID, status, result, runError, at)
 	} else if !awaitingContinuation {
 		run, err = s.runStore.Complete(context.Background(), runID, result, at)
@@ -491,7 +458,8 @@ func (s *Server) failAndDetachExecutionRun(runID string, status execution.Status
 	if cause != nil {
 		message = cause.Error()
 	}
-	run, err := s.runStore.Fail(context.Background(), runID, status, execution.Result{ExitCode: executionExitCode(status)}, execution.Error{Code: code, Category: category, Message: message}, time.Now().UTC())
+	runError := execution.Error{Code: code, Category: category, Message: message}
+	run, err := s.runStore.Fail(context.Background(), runID, status, execution.Result{ExitCode: execution.ExitCodeForSettlement(status, &runError)}, runError, time.Now().UTC())
 	if err != nil {
 		current, readErr := s.runStore.Get(context.Background(), runID)
 		if readErr != nil || !current.Status.Terminal() {
@@ -502,19 +470,6 @@ func (s *Server) failAndDetachExecutionRun(runID string, status execution.Status
 	s.detachExecutionRun(runID)
 	s.kickQueuedTurnDrain(run.ThreadID)
 	return run, nil
-}
-
-func executionExitCode(status execution.Status) int {
-	switch status {
-	case execution.StatusCompleted:
-		return 0
-	case execution.StatusInterrupted, execution.StatusCancelled:
-		return 5
-	case execution.StatusTimedOut:
-		return 4
-	default:
-		return 1
-	}
 }
 
 func (s *Server) interruptAttachedRunsOnClose() {

--- a/internal/appserver/run_handlers_test.go
+++ b/internal/appserver/run_handlers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/structuredoutput"
 )
 
-func TestRunStartSettlesManifestBeforeRunRead(t *testing.T) {
+func TestRunStartSettlesManifest(t *testing.T) {
 	client := &fakeClient{response: providersResponse("run-protocol-ok")}
 	rt := newTestRuntime(t, client)
 	runtimeJournal, err := session.NewInferenceJournalRuntime(rt.SessionDir, "run-test")
@@ -87,26 +87,11 @@ func TestRunStartSettlesManifestBeforeRunRead(t *testing.T) {
 	if run.Result == nil || run.Result.FinalTurnID != run.Turns[0].TurnID {
 		t.Fatalf("Run result = %+v", run.Result)
 	}
-
-	readRaw := mustJSON(Request{ID: json.RawMessage(`"read"`), Method: MethodRunRead, Params: mustJSON(RunReadParams{RunID: run.ID})})
-	if err := srv.handleLine(context.Background(), readRaw); err != nil {
-		t.Fatalf("run/read: %v", err)
+	if run.Result.ExitCode != execution.ExitOK {
+		t.Fatalf("Run exit code = %d, want %d", run.Result.ExitCode, execution.ExitOK)
 	}
-	readResult := remarshal[RunReadResult](t, responseByID(t, parseOutput(t, out.String()), "read")["result"])
-	if readResult.Run.Status != execution.StatusCompleted || readResult.Thread == nil {
-		t.Fatalf("run/read result = %+v", readResult)
-	}
-	if readResult.Attached {
-		t.Fatalf("terminal Run should not remain attached")
-	}
-
-	listRaw := mustJSON(Request{ID: json.RawMessage(`"list"`), Method: MethodRunList, Params: mustJSON(RunListParams{ThreadID: thread.ID})})
-	if err := srv.handleLine(context.Background(), listRaw); err != nil {
-		t.Fatalf("run/list: %v", err)
-	}
-	listResult := remarshal[RunListResult](t, responseByID(t, parseOutput(t, out.String()), "list")["result"])
-	if len(listResult.Runs) != 1 || listResult.Runs[0].ID != run.ID {
-		t.Fatalf("run/list result = %+v", listResult)
+	if srv.executionRunAttached(run.ID) {
+		t.Fatal("terminal Run should not remain attached")
 	}
 }
 

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -830,10 +830,6 @@ func (s *Server) handleLine(ctx context.Context, raw []byte) error {
 		return s.handleTurnInterrupt(req)
 	case MethodRunStart:
 		return s.handleRunStart(ctx, req)
-	case MethodRunRead:
-		return s.handleRunRead(ctx, req)
-	case MethodRunList:
-		return s.handleRunList(ctx, req)
 	case MethodRunInterrupt:
 		return s.handleRunInterrupt(ctx, req)
 	case MethodProcessList:

--- a/internal/appserver/turn_error.go
+++ b/internal/appserver/turn_error.go
@@ -188,6 +188,10 @@ func categoryFromMessage(message string) string {
 		return "cancelled"
 	case strings.Contains(lower, "invalid_request_error"), strings.Contains(lower, "invalid request error"), strings.Contains(lower, "http 400"):
 		return "invalid_request"
+	// Workspace boundary denials (tools emit error_kind=boundary_denied)
+	// are a permission-mode rejection, not a local or provider fault.
+	case strings.Contains(lower, "boundary_denied"):
+		return "permission_denied"
 	// Local comes BEFORE auth: a "permission denied: file /etc/hosts"
 	// string has both "permission denied" and "file" tokens, and the
 	// local check is the more specific match (auth + file → local).

--- a/internal/exec/appserver_controller.go
+++ b/internal/exec/appserver_controller.go
@@ -123,39 +123,16 @@ func (c *localAppServerController) ForkThread(ctx context.Context, threadID stri
 	return result.Thread, err
 }
 
-func (c *localAppServerController) StartTurn(ctx context.Context, threadID string, input TurnInput) (appserver.Turn, error) {
-	var result appserver.TurnStartResult
-	params := appserver.TurnStartParams{
-		ThreadID: threadID,
-		Prompt:   input.Prompt,
-		Images:   append([]appserver.TurnStartImage(nil), input.Images...),
-		Files:    append([]appserver.TurnStartFile(nil), input.Files...),
-	}
-	err := c.client.Call(ctx, appserver.MethodTurnStart, params, &result)
-	return result.Turn, err
-}
-
 func (c *localAppServerController) StartRun(ctx context.Context, params appserver.RunStartParams) (appserver.Run, error) {
 	var result appserver.RunStartResult
 	err := c.client.Call(ctx, appserver.MethodRunStart, params, &result)
 	return result.Run, err
 }
 
-func (c *localAppServerController) ReadRun(ctx context.Context, runID string) (appserver.RunView, error) {
-	var result appserver.RunReadResult
-	err := c.client.Call(ctx, appserver.MethodRunRead, appserver.RunReadParams{RunID: strings.TrimSpace(runID)}, &result)
-	return result, err
-}
-
 func (c *localAppServerController) InterruptRun(ctx context.Context, runID, reason string) (appserver.Run, error) {
 	var result appserver.RunInterruptResult
 	err := c.client.Call(ctx, appserver.MethodRunInterrupt, appserver.RunInterruptParams{RunID: strings.TrimSpace(runID), Reason: strings.TrimSpace(reason)}, &result)
 	return result.Run, err
-}
-
-func (c *localAppServerController) Interrupt(ctx context.Context, threadID string) error {
-	var result appserver.OKResult
-	return c.client.Call(ctx, appserver.MethodTurnInterrupt, appserver.TurnInterruptParams{ThreadID: threadID}, &result)
 }
 
 // shutdownFallbackTimeout bounds Shutdown when the caller's context carries
@@ -171,6 +148,15 @@ func (c *localAppServerController) Shutdown(ctx context.Context) error {
 		ctx, cancel = context.WithTimeout(ctx, shutdownFallbackTimeout)
 		defer cancel()
 	}
+	// The notification channel is drained until the protocol closes. Without
+	// this a full buffer blocks the read loop, which would then never read
+	// the shutdown response.
+	drainDone := make(chan struct{})
+	go func() {
+		for range c.client.Notifications() {
+		}
+		close(drainDone)
+	}()
 	var result appserver.OKResult
 	err := c.client.Call(ctx, appserver.MethodShutdown, nil, &result)
 	for _, pipe := range c.pipes {
@@ -189,6 +175,9 @@ func (c *localAppServerController) Shutdown(ctx context.Context) error {
 			return errors.Join(err, fmt.Errorf("app server run loop did not exit before shutdown deadline: %w", ctx.Err()))
 		}
 	}
+	// The pipes are closed, so the protocol read loop has closed the
+	// notification channel and the drain goroutine is done or about to be.
+	<-drainDone
 	// RunStdio synchronously drains app-server-owned turns and worker
 	// finalizers. Only then is it safe to close the shared runtime resources
 	// those terminal paths still use.

--- a/internal/exec/runner.go
+++ b/internal/exec/runner.go
@@ -16,21 +16,17 @@ import (
 )
 
 type runState struct {
-	threadID                 string
-	turnID                   string
-	runID                    string
-	useRunControl            bool
-	finalMessage             string
-	tracePath                string
-	status                   string
-	commandItems             map[string]appserver.ThreadItem
-	toolOutputs              map[string]string
-	seenSubagents            map[string]bool
-	permissionDenied         bool
-	permissionError          string
-	structuredResult         any
-	structuredResultSet      bool
-	awaitingAutoContinuation bool
+	threadID            string
+	turnID              string
+	runID               string
+	finalMessage        string
+	tracePath           string
+	status              string
+	commandItems        map[string]appserver.ThreadItem
+	toolOutputs         map[string]string
+	seenSubagents       map[string]bool
+	structuredResult    any
+	structuredResultSet bool
 }
 
 type trackingWriter struct {
@@ -129,105 +125,44 @@ func Run(ctx context.Context, opts Options) (runErr error) {
 		emitThreadEvent(opts, "thread_started", thread)
 	}
 
-	_, hasRunController := controller.(RunController)
-	prompt := opts.Prompt
-	if outputSchema != nil && !hasRunController {
-		prompt = outputSchema.initialPrompt(prompt)
+	input := TurnInput{Prompt: opts.Prompt, Images: attachments.Images, Files: attachments.Files}
+	run, err := controller.StartRun(ctx, runStartParams(opts, thread.ID, input, outputSchema))
+	if err != nil {
+		return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, err))
 	}
-	maxRetries := 0
-	if outputSchema != nil {
-		maxRetries = outputSchemaMaxRetries
+	state.runID = run.ID
+	if len(run.Turns) > 0 {
+		state.turnID = run.Turns[len(run.Turns)-1].TurnID
 	}
-	runController, hasRunController := controller.(RunController)
-	useRunControl := hasRunController
-	for attempt := 0; ; attempt++ {
-		state.finalMessage = ""
-		state.turnID = ""
-		state.status = "running"
-		state.commandItems = nil
-		state.toolOutputs = nil
-		input := TurnInput{Prompt: prompt}
-		if attempt == 0 {
-			input.Images = attachments.Images
-			input.Files = attachments.Files
+	if err := waitForRun(ctx, controller, opts, &state); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			_ = interruptRunBestEffort(controller, state.runID, "timeout")
+			emitTurnInterrupted(opts, state, "timeout")
+			emitResult(opts, state, "timeout", "timeout")
+			return WithExitCode(ExitTimeout, err)
 		}
-		var err error
-		if useRunControl {
-			run, startErr := runController.StartRun(ctx, runStartParams(opts, thread.ID, input, outputSchema))
-			if startErr != nil {
-				return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, startErr))
-			}
-			state.runID = run.ID
-			state.useRunControl = true
-			if len(run.Turns) > 0 {
-				state.turnID = run.Turns[len(run.Turns)-1].TurnID
-			}
-			err = waitForRun(ctx, controller, opts, &state)
-		} else {
-			turn, startErr := controller.StartTurn(ctx, thread.ID, input)
-			if startErr != nil {
-				return finishRunError(opts, &state, classifyProtocolOrContextError(ctx, startErr))
-			}
-			state.turnID = turn.ID
-			emitTurnStarted(opts, thread.ID, turn)
-			err = waitForTurn(ctx, controller, opts, &state)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			_ = interruptRunBestEffort(controller, state.runID, "interrupted")
+			emitTurnInterrupted(opts, state, "interrupted")
+			emitResult(opts, state, "interrupted", "interrupted")
+			return WithExitCode(ExitInterrupted, err)
 		}
-		if err != nil {
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				if state.runID != "" {
-					_ = interruptRunBestEffort(runController, state.runID, "timeout")
-				} else {
-					_ = interruptBestEffort(controller, state.threadID)
-				}
-				emitTurnInterrupted(opts, state, "timeout")
-				emitResult(opts, state, "timeout", "timeout")
-				return WithExitCode(ExitTimeout, err)
-			}
-			if errors.Is(ctx.Err(), context.Canceled) {
-				if state.runID != "" {
-					_ = interruptRunBestEffort(runController, state.runID, "interrupted")
-				} else {
-					_ = interruptBestEffort(controller, state.threadID)
-				}
-				emitTurnInterrupted(opts, state, "interrupted")
-				emitResult(opts, state, "interrupted", "interrupted")
-				return WithExitCode(ExitInterrupted, err)
-			}
-			return finishRunError(opts, &state, err)
-		}
-		if state.permissionDenied {
-			errorText := state.permissionError
-			if errorText == "" {
-				errorText = "permission denied"
-			}
-			state.status = "permission_denied"
-			emitResult(opts, state, "permission_denied", errorText)
-			return WithExitCode(ExitPermissionDenied, errors.New(errorText))
-		}
+		return finishRunError(opts, &state, err)
+	}
 
-		if outputSchema == nil {
-			break
-		}
-		structuredResult, err := outputSchema.validate(state.finalMessage)
-		if err == nil {
-			state.structuredResult = structuredResult
-			state.structuredResultSet = true
-			break
-		}
-		if useRunControl {
+	if outputSchema != nil {
+		// The app-server already validated and retried the final message
+		// inside the Run; this parse only fills the structured_result
+		// payload. A mismatch means settlement and streamed content disagree.
+		structuredResult, validateErr := outputSchema.validate(state.finalMessage)
+		if validateErr != nil {
 			state.status = "failed"
-			emitStructuredOutputValidation(opts, state, err, false)
-			emitResult(opts, state, "failed", err.Error())
-			return WithExitCode(ExitTurnFailed, err)
+			emitStructuredOutputValidation(opts, state, validateErr, false)
+			emitResult(opts, state, "failed", validateErr.Error())
+			return WithExitCode(ExitTurnFailed, validateErr)
 		}
-		retrying := attempt < maxRetries
-		emitStructuredOutputValidation(opts, state, err, retrying)
-		if !retrying {
-			state.status = "failed"
-			emitResult(opts, state, "failed", err.Error())
-			return WithExitCode(ExitTurnFailed, err)
-		}
-		prompt = outputSchema.retryPrompt(state.finalMessage, err)
+		state.structuredResult = structuredResult
+		state.structuredResultSet = true
 	}
 
 	if opts.OutputLastMessage != "" {
@@ -336,27 +271,6 @@ func outputSchemaRaw(schema *outputSchemaValidator) json.RawMessage {
 	return append(json.RawMessage(nil), schema.raw...)
 }
 
-func waitForTurn(ctx context.Context, controller Controller, opts Options, state *runState) error {
-	notifications := controller.Notifications()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case notification, ok := <-notifications:
-			if !ok {
-				return WithExitCode(ExitProtocol, errors.New("app-server notification stream closed before turn completed"))
-			}
-			done, err := handleNotification(opts, notification, state)
-			if err != nil {
-				return err
-			}
-			if done {
-				return nil
-			}
-		}
-	}
-}
-
 func waitForRun(ctx context.Context, controller Controller, opts Options, state *runState) error {
 	notifications := controller.Notifications()
 	for {
@@ -385,7 +299,7 @@ func handleNotification(opts Options, notification Notification, state *runState
 		if err := decodeNotification(notification, &params); err != nil {
 			return false, err
 		}
-		if state == nil || (!state.useRunControl && !state.awaitingAutoContinuation) || (state.threadID != "" && params.ThreadID != state.threadID) {
+		if state == nil || (state.threadID != "" && params.ThreadID != state.threadID) {
 			return false, nil
 		}
 		state.turnID = params.Turn.ID
@@ -393,7 +307,6 @@ func handleNotification(opts Options, notification Notification, state *runState
 		state.status = "running"
 		state.commandItems = nil
 		state.toolOutputs = nil
-		state.awaitingAutoContinuation = false
 		emitTurnStarted(opts, params.ThreadID, params.Turn)
 	case appserver.NotificationAgentMessageDelta:
 		var params appserver.AgentMessageDeltaNotification
@@ -478,18 +391,10 @@ func handleNotification(opts Options, notification Notification, state *runState
 		state.threadID = params.ThreadID
 		state.turnID = params.Turn.ID
 		state.tracePath = params.TracePath
-		if state.useRunControl {
-			state.status = "running"
-			return false, nil
-		}
-		if params.AwaitingAutoContinuation {
-			state.status = "waiting_background"
-			state.awaitingAutoContinuation = true
-			state.turnID = ""
-			return false, nil
-		}
-		state.status = "completed"
-		return true, nil
+		// A Run fans out multiple turns (structured-output retries, automatic
+		// continuations); only the Run's terminal run/updated ends the wait.
+		state.status = "running"
+		return false, nil
 	case appserver.NotificationRunUpdated:
 		var params appserver.RunUpdatedNotification
 		if err := decodeNotification(notification, &params); err != nil {
@@ -526,10 +431,9 @@ func handleNotification(opts Options, notification Notification, state *runState
 			return false, WithExitCode(ExitInterrupted, errors.New(errText))
 		case "failed":
 			status := "failed"
-			exitCode := exitCodeForRunError(params.Run.Error, state.permissionDenied)
+			exitCode := runExitCode(params.Run)
 			if exitCode == ExitPermissionDenied {
 				status = "permission_denied"
-				exitCode = ExitPermissionDenied
 			}
 			state.status = status
 			errText := "execution run failed"
@@ -547,7 +451,8 @@ func handleNotification(opts Options, notification Notification, state *runState
 		// The core reports interrupts through turn/error with an embedded
 		// Turn.Status; surface them as turn_interrupted rather than
 		// turn_failed so `wuu exec --json` distinguishes a cancel from a
-		// genuine failure.
+		// genuine failure. The process exit classification arrives with the
+		// Run's terminal run/updated, so a turn error never ends the wait.
 		if params.Turn.Status == appserver.TurnStatusInterrupted {
 			emitJSON(opts, map[string]any{"type": "turn_interrupted", "thread_id": params.ThreadID, "turn_id": params.TurnID, "reason": "interrupted"})
 			if !isCurrentTurn(state, params.ThreadID, params.TurnID) {
@@ -556,11 +461,7 @@ func handleNotification(opts Options, notification Notification, state *runState
 			state.threadID = params.ThreadID
 			state.turnID = params.TurnID
 			state.status = "interrupted"
-			if state.useRunControl {
-				return false, nil
-			}
-			emitResult(opts, *state, "interrupted", params.Error)
-			return false, WithExitCode(ExitInterrupted, errors.New(params.Error))
+			return false, nil
 		}
 		emitJSON(opts, map[string]any{"type": "turn_failed", "thread_id": params.ThreadID, "turn_id": params.TurnID, "error": params.Error})
 		if !isCurrentTurn(state, params.ThreadID, params.TurnID) {
@@ -569,27 +470,7 @@ func handleNotification(opts Options, notification Notification, state *runState
 		state.threadID = params.ThreadID
 		state.turnID = params.TurnID
 		state.status = "failed"
-		if state.useRunControl {
-			if params.Code == "permission_denied" || params.Category == "permission_denied" {
-				state.permissionDenied = true
-				state.permissionError = params.Error
-			}
-			return false, nil
-		}
-		status := "failed"
-		code := exitCodeForTurnError(params, state.permissionDenied)
-		switch code {
-		case ExitPermissionDenied:
-			status = "permission_denied"
-			state.permissionDenied = true
-			if state.permissionError == "" {
-				state.permissionError = params.Error
-			}
-		case ExitInterrupted:
-			status = "interrupted"
-		}
-		emitResult(opts, *state, status, params.Error)
-		return false, WithExitCode(code, errors.New(params.Error))
+		return false, nil
 	}
 	return false, nil
 }
@@ -949,56 +830,14 @@ func copyStringField(dst map[string]any, src map[string]any, key string) {
 	}
 }
 
-func isPermissionFailure(text string) bool {
-	text = strings.ToLower(text)
-	for _, marker := range []string{
-		"error_kind=boundary_denied",
-	} {
-		if strings.Contains(text, marker) {
-			return true
-		}
+// runExitCode trusts the exit code the app-server settled into the Run
+// manifest, falling back to the shared settlement mapping only when the
+// record predates server-side classification.
+func runExitCode(run appserver.Run) int {
+	if run.Result != nil && run.Result.ExitCode != 0 {
+		return run.Result.ExitCode
 	}
-	return false
-}
-
-func exitCodeForTurnError(params appserver.TurnErrorNotification, permissionDenied bool) int {
-	if permissionDenied || isPermissionFailure(params.Error) {
-		return ExitPermissionDenied
-	}
-	switch strings.ToLower(strings.TrimSpace(params.Category)) {
-	case "provider", "auth", "network", "invalid_request":
-		return ExitProviderModelError
-	case "local":
-		return ExitToolFailed
-	case "cancelled", "canceled":
-		return ExitInterrupted
-	case "":
-		// Older app-server versions did not send structured categories.
-	default:
-		return ExitTurnFailed
-	}
-	if isProviderModelFailure(params.Error) {
-		return ExitProviderModelError
-	}
-	if isToolFailure(params.Error) {
-		return ExitToolFailed
-	}
-	return ExitTurnFailed
-}
-
-func exitCodeForRunError(runErr *execution.Error, permissionDenied bool) int {
-	if runErr == nil {
-		if permissionDenied {
-			return ExitPermissionDenied
-		}
-		return ExitTurnFailed
-	}
-	if strings.EqualFold(strings.TrimSpace(runErr.Code), "permission_denied") || strings.EqualFold(strings.TrimSpace(runErr.Category), "permission_denied") {
-		permissionDenied = true
-	}
-	return exitCodeForTurnError(appserver.TurnErrorNotification{
-		Error: runErr.Message, Code: runErr.Code, Category: runErr.Category,
-	}, permissionDenied)
+	return execution.ExitCodeForSettlement(execution.Status(run.Status), run.Error)
 }
 
 func isProviderModelFailure(text string) bool {
@@ -1013,21 +852,6 @@ func isProviderModelFailure(text string) bool {
 		"auth token",
 		"unsupported wire",
 		"unsupported api",
-	} {
-		if strings.Contains(text, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-func isToolFailure(text string) bool {
-	text = strings.ToLower(text)
-	for _, marker := range []string{
-		"tool execution failed",
-		"tool call failed",
-		"tool failed",
-		"error_kind=tool",
 	} {
 		if strings.Contains(text, marker) {
 			return true
@@ -1219,19 +1043,16 @@ func classifyProtocolOrContextError(ctx context.Context, err error) error {
 	if errors.Is(ctx.Err(), context.Canceled) {
 		return WithExitCode(ExitInterrupted, err)
 	}
+	// A thread that already has a running turn is a conflict the caller can
+	// act on (wait, or target another thread), not a protocol fault.
+	var protocolErr *ProtocolError
+	if errors.As(err, &protocolErr) && strings.EqualFold(strings.TrimSpace(protocolErr.Code), "thread_busy") {
+		return WithExitCode(ExitConflict, err)
+	}
 	return WithExitCode(ExitProtocol, err)
 }
 
-func interruptBestEffort(controller Controller, threadID string) error {
-	if controller == nil || strings.TrimSpace(threadID) == "" {
-		return nil
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	return controller.Interrupt(ctx, threadID)
-}
-
-func interruptRunBestEffort(controller RunController, runID, reason string) error {
+func interruptRunBestEffort(controller Controller, runID, reason string) error {
 	if controller == nil || strings.TrimSpace(runID) == "" {
 		return nil
 	}

--- a/internal/exec/runner_test.go
+++ b/internal/exec/runner_test.go
@@ -21,58 +21,23 @@ import (
 type fakeController struct {
 	initResult appserver.InitializeResult
 	thread     appserver.Thread
-	turn       appserver.Turn
+	run        appserver.Run
 	events     []Notification
-	batches    [][]Notification
+	block      bool
+	startErr   error
 
-	startedThread     bool
-	startEphemeral    bool
-	resumedThread     string
-	forkedThread      string
-	startedPrompt     string
-	startedTurnThread string
-	startedPrompts    []string
-	startedImages     []appserver.TurnStartImage
-	startedFiles      []appserver.TurnStartFile
-	interrupted       string
-	shutdown          bool
-	startCount        int
+	startedThread   bool
+	startEphemeral  bool
+	resumedThread   string
+	forkedThread    string
+	startedParams   appserver.RunStartParams
+	interruptReason string
+	shutdown        bool
 }
 
 type initializeErrorController struct {
 	*fakeController
 	err error
-}
-
-type fakeRunController struct {
-	*fakeController
-	startedParams   appserver.RunStartParams
-	run             appserver.Run
-	block           bool
-	interruptReason string
-}
-
-func (c *fakeRunController) StartRun(_ context.Context, params appserver.RunStartParams) (appserver.Run, error) {
-	c.startedParams = params
-	if c.block {
-		return c.run, nil
-	}
-	c.fakeController.events = []Notification{
-		notification(appserver.NotificationAgentMessageDelta, appserver.AgentMessageDeltaNotification{ThreadID: "thread-1", TurnID: "turn-1", Delta: "run answer"}),
-		notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "run answer", TracePath: "/run-trace"}),
-		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{ID: "run-1", Status: execution.StatusCompleted, ThreadID: "thread-1", Result: &execution.Result{FinalTurnID: "turn-1", TracePath: "/run-trace"}}}),
-	}
-	return c.run, nil
-}
-
-func (c *fakeRunController) ReadRun(context.Context, string) (appserver.RunView, error) {
-	return appserver.RunView{Run: c.run, Attached: true}, nil
-}
-
-func (c *fakeRunController) InterruptRun(_ context.Context, _ string, reason string) (appserver.Run, error) {
-	c.interruptReason = reason
-	c.run.Status = execution.StatusInterrupted
-	return c.run, nil
 }
 
 func (c *initializeErrorController) Initialize(context.Context) (appserver.InitializeResult, error) {
@@ -88,10 +53,6 @@ func (w failingWriter) Write([]byte) (int, error) {
 }
 
 func newFakeController(events ...Notification) *fakeController {
-	return newFakeControllerBatches(events)
-}
-
-func newFakeControllerBatches(batches ...[]Notification) *fakeController {
 	return &fakeController{
 		initResult: appserver.InitializeResult{
 			ProtocolVersion: appserver.ProtocolVersion,
@@ -102,9 +63,12 @@ func newFakeControllerBatches(batches ...[]Notification) *fakeController {
 				Mode: "standard",
 			},
 		},
-		thread:  appserver.Thread{ID: "thread-1", ModelProvider: "test-provider", Model: "test-model", CWD: "/repo"},
-		turn:    appserver.Turn{ID: "turn-1"},
-		batches: batches,
+		thread: appserver.Thread{ID: "thread-1", ModelProvider: "test-provider", Model: "test-model", CWD: "/repo"},
+		run: appserver.Run{
+			ID: "run-1", Status: execution.StatusRunning, ThreadID: "thread-1",
+			Turns: []execution.TurnRef{{TurnID: "turn-1", ThreadID: "thread-1"}},
+		},
+		events: events,
 	}
 }
 
@@ -131,21 +95,17 @@ func (f *fakeController) ForkThread(_ context.Context, id string) (appserver.Thr
 	return f.thread, nil
 }
 
-func (f *fakeController) StartTurn(_ context.Context, threadID string, input TurnInput) (appserver.Turn, error) {
-	f.startCount++
-	f.startedTurnThread = threadID
-	f.startedPrompt = input.Prompt
-	f.startedPrompts = append(f.startedPrompts, input.Prompt)
-	f.startedImages = append([]appserver.TurnStartImage(nil), input.Images...)
-	f.startedFiles = append([]appserver.TurnStartFile(nil), input.Files...)
-	turn := f.turn
-	turn.ID = fmt.Sprintf("turn-%d", f.startCount)
-	return turn, nil
+func (f *fakeController) StartRun(_ context.Context, params appserver.RunStartParams) (appserver.Run, error) {
+	f.startedParams = params
+	if f.startErr != nil {
+		return appserver.Run{}, f.startErr
+	}
+	return f.run, nil
 }
 
-func (f *fakeController) Interrupt(_ context.Context, threadID string) error {
-	f.interrupted = threadID
-	return nil
+func (f *fakeController) InterruptRun(_ context.Context, _ string, reason string) (appserver.Run, error) {
+	f.interruptReason = reason
+	return f.run, nil
 }
 
 func (f *fakeController) Shutdown(context.Context) error {
@@ -153,13 +113,42 @@ func (f *fakeController) Shutdown(context.Context) error {
 	return nil
 }
 
+// Notifications mirrors the in-process app-server: a turn/started for the
+// Run's first turn, then the scripted events, then — unless the script
+// already settles the Run — a synthesized completed run/updated carrying
+// the last scripted turn's id and trace path.
 func (f *fakeController) Notifications() <-chan Notification {
-	idx := f.startCount - 1
-	var events []Notification
-	if idx >= 0 && idx < len(f.batches) {
-		events = f.batches[idx]
-	} else {
-		events = f.events
+	if f.block {
+		return make(chan Notification)
+	}
+	hasTurnStarted := false
+	hasRunUpdated := false
+	lastTurnID := "turn-1"
+	lastTrace := ""
+	for _, ev := range f.events {
+		switch ev.Method {
+		case appserver.NotificationTurnStarted:
+			hasTurnStarted = true
+		case appserver.NotificationRunUpdated:
+			hasRunUpdated = true
+		case appserver.NotificationTurnCompleted:
+			var params appserver.TurnCompletedNotification
+			if err := json.Unmarshal(ev.Params, &params); err == nil {
+				lastTurnID = params.Turn.ID
+				lastTrace = params.TracePath
+			}
+		}
+	}
+	events := make([]Notification, 0, len(f.events)+2)
+	if !hasTurnStarted {
+		events = append(events, notification(appserver.NotificationTurnStarted, appserver.TurnStartedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}}))
+	}
+	events = append(events, f.events...)
+	if !hasRunUpdated {
+		events = append(events, notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusCompleted,
+			Result: &execution.Result{FinalTurnID: lastTurnID, TracePath: lastTrace},
+		}}))
 	}
 	ch := make(chan Notification, len(events))
 	for _, ev := range events {
@@ -168,19 +157,15 @@ func (f *fakeController) Notifications() <-chan Notification {
 	return ch
 }
 
-func TestRunUsesRunControllerForPlainExec(t *testing.T) {
-	base := newFakeController()
-	controller := &fakeRunController{
-		fakeController: base,
-		run:            appserver.Run{ID: "run-1", Status: execution.StatusRunning, ThreadID: "thread-1", Turns: []execution.TurnRef{{TurnID: "turn-1", ThreadID: "thread-1"}}},
-	}
+func TestRunUsesRunControlForPlainExec(t *testing.T) {
+	controller := newFakeController(
+		notification(appserver.NotificationAgentMessageDelta, appserver.AgentMessageDeltaNotification{ThreadID: "thread-1", TurnID: "turn-1", Delta: "run answer"}),
+		notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "run answer", TracePath: "/run-trace"}),
+	)
 	var stdout, stderr bytes.Buffer
 	err := Run(context.Background(), Options{Prompt: "reply", JSON: true, Stdout: &stdout, Stderr: &stderr, Controller: controller})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
-	}
-	if base.startCount != 0 {
-		t.Fatalf("legacy StartTurn count = %d", base.startCount)
 	}
 	if controller.startedParams.Request.Mode != execution.ModeStart || controller.startedParams.Prompt != "reply" {
 		t.Fatalf("Run start params = %+v", controller.startedParams)
@@ -214,7 +199,7 @@ func TestRunDefaultStdoutOnlyFinalMessage(t *testing.T) {
 	if !strings.Contains(stderr.String(), "provider: test-provider") || !strings.Contains(stderr.String(), "trace_path: /trace.jsonl") {
 		t.Fatalf("stderr missing run metadata: %q", stderr.String())
 	}
-	if !controller.startedThread || controller.startedPrompt != "do work" || !controller.shutdown {
+	if !controller.startedThread || controller.startedParams.Prompt != "do work" || !controller.shutdown {
 		t.Fatalf("controller did not run expected app-server path: %+v", controller)
 	}
 }
@@ -560,7 +545,7 @@ func TestRunForkUsesForkPath(t *testing.T) {
 	}
 }
 
-func TestRunPassesAttachmentsToTurnStart(t *testing.T) {
+func TestRunPassesAttachmentsToRunStart(t *testing.T) {
 	controller := newFakeController(
 		notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "done"}),
 	)
@@ -577,17 +562,23 @@ func TestRunPassesAttachmentsToTurnStart(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(controller.startedImages) != 1 || controller.startedImages[0].MediaType != "image/png" || controller.startedImages[0].Data != "image-data" {
-		t.Fatalf("images not passed to StartTurn: %+v", controller.startedImages)
+	images := controller.startedParams.Images
+	if len(images) != 1 || images[0].MediaType != "image/png" || images[0].Data != "image-data" {
+		t.Fatalf("images not passed to run/start: %+v", images)
 	}
-	if len(controller.startedFiles) != 1 || controller.startedFiles[0].MediaType != "application/pdf" || controller.startedFiles[0].Filename != "report.pdf" {
-		t.Fatalf("files not passed to StartTurn: %+v", controller.startedFiles)
+	files := controller.startedParams.Files
+	if len(files) != 1 || files[0].MediaType != "application/pdf" || files[0].Filename != "report.pdf" {
+		t.Fatalf("files not passed to run/start: %+v", files)
 	}
 }
 
 func TestRunTurnErrorReturnsExitCodeOne(t *testing.T) {
 	controller := newFakeController(
 		notification(appserver.NotificationTurnError, appserver.TurnErrorNotification{ThreadID: "thread-1", TurnID: "turn-1", Error: "model failed"}),
+		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusFailed,
+			Error: &execution.Error{Code: "turn_failed", Category: "unknown", Message: "model failed"},
+		}}),
 	)
 	var stdout bytes.Buffer
 
@@ -615,6 +606,10 @@ func TestRunTurnErrorWithInterruptedStatusEmitsTurnInterrupted(t *testing.T) {
 			Error:    "interrupted",
 			Turn:     appserver.Turn{ID: "turn-1", Status: appserver.TurnStatusInterrupted},
 		}),
+		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusInterrupted,
+			Error: &execution.Error{Code: "interrupted", Category: "cancelled", Message: "interrupted"},
+		}}),
 	)
 	var stdout bytes.Buffer
 
@@ -646,9 +641,13 @@ func TestRunTurnErrorWithInterruptedStatusEmitsTurnInterrupted(t *testing.T) {
 	}
 }
 
-func TestRunTurnErrorClassifiesProviderModelError(t *testing.T) {
+func TestRunFailedErrorClassifiesProviderModelError(t *testing.T) {
 	controller := newFakeController(
 		notification(appserver.NotificationTurnError, appserver.TurnErrorNotification{ThreadID: "thread-1", TurnID: "turn-1", Error: "provider returned an error"}),
+		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusFailed,
+			Error: &execution.Error{Code: "stream_error", Category: "provider", Message: "provider returned an error"},
+		}}),
 	)
 	var stdout bytes.Buffer
 
@@ -663,9 +662,13 @@ func TestRunTurnErrorClassifiesProviderModelError(t *testing.T) {
 	}
 }
 
-func TestRunTurnErrorClassifiesToolFailure(t *testing.T) {
+func TestRunFailedErrorClassifiesToolFailure(t *testing.T) {
 	controller := newFakeController(
 		notification(appserver.NotificationTurnError, appserver.TurnErrorNotification{ThreadID: "thread-1", TurnID: "turn-1", Error: "tool execution failed: run_shell failed"}),
+		notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+			ID: "run-1", ThreadID: "thread-1", Status: execution.StatusFailed,
+			Error: &execution.Error{Code: "tool_failed", Category: "local", Message: "tool execution failed: run_shell failed"},
+		}}),
 	)
 	var stdout bytes.Buffer
 
@@ -680,7 +683,7 @@ func TestRunTurnErrorClassifiesToolFailure(t *testing.T) {
 	}
 }
 
-func TestRunTurnErrorPrefersStructuredCategoryOverMessage(t *testing.T) {
+func TestRunFailedErrorPrefersStructuredCategory(t *testing.T) {
 	tests := []struct {
 		name     string
 		category string
@@ -696,6 +699,10 @@ func TestRunTurnErrorPrefersStructuredCategoryOverMessage(t *testing.T) {
 				notification(appserver.NotificationTurnError, appserver.TurnErrorNotification{
 					ThreadID: "thread-1", TurnID: "turn-1", Error: tc.message, Category: tc.category,
 				}),
+				notification(appserver.NotificationRunUpdated, appserver.RunUpdatedNotification{Run: appserver.Run{
+					ID: "run-1", ThreadID: "thread-1", Status: execution.StatusFailed,
+					Error: &execution.Error{Code: "turn_failed", Category: tc.category, Message: tc.message},
+				}}),
 			)
 			var stdout bytes.Buffer
 			err := Run(context.Background(), Options{Prompt: "do work", JSON: true, Stdout: &stdout, Controller: controller})
@@ -706,7 +713,13 @@ func TestRunTurnErrorPrefersStructuredCategoryOverMessage(t *testing.T) {
 	}
 }
 
-func TestRunErrorPreservesStableExitClassification(t *testing.T) {
+func TestRunExitCodePreservesStableExitClassification(t *testing.T) {
+	t.Run("trusts persisted exit code", func(t *testing.T) {
+		run := appserver.Run{Status: execution.StatusFailed, Result: &execution.Result{ExitCode: ExitPermissionDenied}}
+		if got := runExitCode(run); got != ExitPermissionDenied {
+			t.Fatalf("runExitCode = %d, want %d", got, ExitPermissionDenied)
+		}
+	})
 	tests := []struct {
 		category string
 		want     int
@@ -716,18 +729,16 @@ func TestRunErrorPreservesStableExitClassification(t *testing.T) {
 		{category: "permission_denied", want: ExitPermissionDenied},
 	}
 	for _, tc := range tests {
-		if got := exitCodeForRunError(&execution.Error{Category: tc.category, Message: "failed"}, false); got != tc.want {
+		run := appserver.Run{Status: execution.StatusFailed, Error: &execution.Error{Category: tc.category, Message: "failed"}}
+		if got := runExitCode(run); got != tc.want {
 			t.Fatalf("category %q exit code = %d, want %d", tc.category, got, tc.want)
 		}
 	}
 }
 
 func TestRunControllerTimeoutSendsTimeoutReason(t *testing.T) {
-	controller := &fakeRunController{
-		fakeController: newFakeController(),
-		run:            appserver.Run{ID: "run-timeout", Status: execution.StatusRunning, ThreadID: "thread-1"},
-		block:          true,
-	}
+	controller := newFakeController()
+	controller.block = true
 	err := Run(context.Background(), Options{
 		Prompt: "do work", JSON: true, Timeout: 20 * time.Millisecond,
 		Stdout: &bytes.Buffer{}, Controller: controller,
@@ -742,6 +753,7 @@ func TestRunControllerTimeoutSendsTimeoutReason(t *testing.T) {
 
 func TestRunTimeoutInterruptsAndReturnsExitCodeFour(t *testing.T) {
 	controller := newFakeController()
+	controller.block = true
 	var stdout bytes.Buffer
 
 	err := Run(context.Background(), Options{
@@ -754,8 +766,8 @@ func TestRunTimeoutInterruptsAndReturnsExitCodeFour(t *testing.T) {
 	if ExitCode(err) != ExitTimeout {
 		t.Fatalf("ExitCode = %d, err=%v", ExitCode(err), err)
 	}
-	if controller.interrupted != "thread-1" {
-		t.Fatalf("interrupted thread = %q", controller.interrupted)
+	if controller.interruptReason != "timeout" {
+		t.Fatalf("interrupt reason = %q", controller.interruptReason)
 	}
 	if !controller.shutdown {
 		t.Fatal("controller was not shutdown")
@@ -953,62 +965,19 @@ func TestRunOutputSchemaEmitsStructuredResult(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if !strings.Contains(controller.startedPrompt, "Return only JSON") || !strings.Contains(controller.startedPrompt, `"summary"`) {
-		t.Fatalf("prompt missing schema instructions: %q", controller.startedPrompt)
+	// The schema travels to the app-server untouched; prompt injection and
+	// retries happen inside the Run, not in the exec client.
+	if controller.startedParams.Prompt != "summarize" {
+		t.Fatalf("exec should forward the prompt untouched, got %q", controller.startedParams.Prompt)
+	}
+	if !strings.Contains(string(controller.startedParams.OutputSchema), `"summary"`) {
+		t.Fatalf("run/start missing output schema: %q", controller.startedParams.OutputSchema)
 	}
 	events := parseJSONLines(t, stdout.String())
 	result := events[len(events)-1]
 	structured, ok := result["structured_result"].(map[string]any)
 	if !ok || structured["summary"] != "done" {
 		t.Fatalf("structured_result = %+v", result["structured_result"])
-	}
-}
-
-func TestRunOutputSchemaRetriesInvalidFinalMessage(t *testing.T) {
-	schemaPath := writeExecSchema(t, `{
-		"type": "object",
-		"required": ["summary"],
-		"properties": {
-			"summary": {"type": "string"}
-		}
-	}`)
-	controller := newFakeControllerBatches(
-		[]Notification{
-			notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-1"}, Content: "not json"}),
-		},
-		[]Notification{
-			notification(appserver.NotificationTurnCompleted, appserver.TurnCompletedNotification{ThreadID: "thread-1", Turn: appserver.Turn{ID: "turn-2"}, Content: `{"summary":"fixed"}`}),
-		},
-	)
-	var stdout bytes.Buffer
-
-	if err := Run(context.Background(), Options{
-		Prompt:           "summarize",
-		OutputSchemaPath: schemaPath,
-		JSON:             true,
-		Stdout:           &stdout,
-		Controller:       controller,
-	}); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if controller.startCount != 2 {
-		t.Fatalf("startCount = %d, want 2", controller.startCount)
-	}
-	if len(controller.startedPrompts) != 2 || !strings.Contains(controller.startedPrompts[1], "previous final answer did not validate") {
-		t.Fatalf("retry prompt missing validation context: %+v", controller.startedPrompts)
-	}
-	events := parseJSONLines(t, stdout.String())
-	gotTypes := make([]string, 0, len(events))
-	for _, event := range events {
-		gotTypes = append(gotTypes, event["type"].(string))
-	}
-	wantTypes := []string{"session_configured", "thread_started", "turn_started", "turn_completed", "error", "turn_started", "turn_completed", "result"}
-	if !reflect.DeepEqual(gotTypes, wantTypes) {
-		t.Fatalf("event types:\n got: %#v\nwant: %#v\njsonl:\n%s", gotTypes, wantTypes, stdout.String())
-	}
-	result := events[len(events)-1]
-	if result["status"] != "completed" {
-		t.Fatalf("unexpected result: %+v", result)
 	}
 }
 

--- a/internal/exec/structured_output.go
+++ b/internal/exec/structured_output.go
@@ -12,8 +12,6 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-const outputSchemaMaxRetries = 2
-
 type outputSchemaValidator struct {
 	path string
 	raw  json.RawMessage
@@ -60,40 +58,8 @@ func loadOutputSchema(rootDir, inputPath string) (*outputSchemaValidator, error)
 	return &outputSchemaValidator{path: absPath, raw: compact, sch: sch}, nil
 }
 
-func (v *outputSchemaValidator) initialPrompt(prompt string) string {
-	if v == nil {
-		return prompt
-	}
-	var b strings.Builder
-	b.WriteString("You must complete the task and make your final answer a single JSON value that validates against this JSON Schema.\n")
-	b.WriteString("Return only JSON. Do not wrap it in Markdown. Do not include explanatory text outside the JSON value.\n\n")
-	b.WriteString("JSON Schema:\n")
-	b.Write(v.raw)
-	if strings.TrimSpace(prompt) != "" {
-		b.WriteString("\n\nTask:\n")
-		b.WriteString(prompt)
-	}
-	return b.String()
-}
-
-func (v *outputSchemaValidator) retryPrompt(previous string, validationErr error) string {
-	if v == nil {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("Your previous final answer did not validate against the required JSON Schema.\n")
-	b.WriteString("Return only a corrected JSON value. Do not wrap it in Markdown. Do not include explanatory text outside the JSON value.\n\n")
-	b.WriteString("Validation error:\n")
-	b.WriteString(validationErr.Error())
-	b.WriteString("\n\nJSON Schema:\n")
-	b.Write(v.raw)
-	if strings.TrimSpace(previous) != "" {
-		b.WriteString("\n\nPrevious final answer:\n")
-		b.WriteString(previous)
-	}
-	return b.String()
-}
-
+// validate parses the final message for the structured_result payload. The
+// schema-driven prompt and any retries happen inside the app-server Run.
 func (v *outputSchemaValidator) validate(text string) (any, error) {
 	if v == nil {
 		return nil, nil

--- a/internal/exec/types.go
+++ b/internal/exec/types.go
@@ -8,18 +8,22 @@ import (
 	"time"
 
 	"github.com/blueberrycongee/wuu/internal/appserver"
+	"github.com/blueberrycongee/wuu/internal/execution"
 )
 
+// The exit-code contract lives in the execution package so the code persisted
+// in a Run's manifest and the code this process exits with share one source.
 const (
-	ExitOK                 = 0
-	ExitTurnFailed         = 1
-	ExitInvalidInput       = 2
-	ExitPermissionDenied   = 3
-	ExitTimeout            = 4
-	ExitInterrupted        = 5
-	ExitProtocol           = 6
-	ExitProviderModelError = 7
-	ExitToolFailed         = 8
+	ExitOK                 = execution.ExitOK
+	ExitTurnFailed         = execution.ExitTurnFailed
+	ExitInvalidInput       = execution.ExitInvalidInput
+	ExitPermissionDenied   = execution.ExitPermissionDenied
+	ExitTimeout            = execution.ExitTimeout
+	ExitInterrupted        = execution.ExitInterrupted
+	ExitProtocol           = execution.ExitProtocol
+	ExitProviderModelError = execution.ExitProviderModelError
+	ExitToolFailed         = execution.ExitToolFailed
+	ExitConflict           = execution.ExitConflict
 )
 
 type ExitError struct {
@@ -98,24 +102,18 @@ type Options struct {
 	Controller        Controller
 }
 
+// Controller is the app-server control surface for one exec invocation. An
+// invocation is driven as a single Run; the app-server owns turn fan-out
+// (structured-output retries, automatic continuations) inside that Run.
 type Controller interface {
 	Initialize(context.Context) (appserver.InitializeResult, error)
 	StartThread(context.Context, bool) (appserver.Thread, error)
 	ResumeThread(context.Context, string) (appserver.Thread, error)
 	ForkThread(context.Context, string) (appserver.Thread, error)
-	StartTurn(context.Context, string, TurnInput) (appserver.Turn, error)
-	Interrupt(context.Context, string) error
+	StartRun(context.Context, appserver.RunStartParams) (appserver.Run, error)
+	InterruptRun(context.Context, string, string) (appserver.Run, error)
 	Shutdown(context.Context) error
 	Notifications() <-chan Notification
-}
-
-// RunController is the app-server control surface used by the normal exec
-// path. Controller remains compatible with the legacy Turn methods so focused
-// tests and older embedders can migrate independently.
-type RunController interface {
-	StartRun(context.Context, appserver.RunStartParams) (appserver.Run, error)
-	ReadRun(context.Context, string) (appserver.RunView, error)
-	InterruptRun(context.Context, string, string) (appserver.Run, error)
 }
 
 type Attachments struct {

--- a/internal/execution/exitcodes.go
+++ b/internal/execution/exitcodes.go
@@ -1,0 +1,55 @@
+package execution
+
+import "strings"
+
+// Exit codes are the shared contract between a settled Run and CLI-style
+// callers. The app-server records them in Result.ExitCode at settlement
+// time, and `wuu exec` maps its process exit status directly onto them, so
+// the persisted audit record and the CLI behavior can never drift apart.
+const (
+	ExitOK                 = 0
+	ExitTurnFailed         = 1
+	ExitInvalidInput       = 2
+	ExitPermissionDenied   = 3
+	ExitTimeout            = 4
+	ExitInterrupted        = 5
+	ExitProtocol           = 6
+	ExitProviderModelError = 7
+	ExitToolFailed         = 8
+	ExitConflict           = 9
+)
+
+// ExitCodeForSettlement maps a terminal Run status and its structured error
+// to the exit code recorded in Result.ExitCode. Classification trusts the
+// structured code/category produced by the app-server's turn-error builder;
+// unknown categories fall back to ExitTurnFailed rather than guessing from
+// message text.
+func ExitCodeForSettlement(status Status, runErr *Error) int {
+	switch status {
+	case StatusCompleted:
+		return ExitOK
+	case StatusTimedOut:
+		return ExitTimeout
+	case StatusInterrupted, StatusCancelled:
+		return ExitInterrupted
+	}
+	if runErr == nil {
+		return ExitTurnFailed
+	}
+	code := strings.ToLower(strings.TrimSpace(runErr.Code))
+	category := strings.ToLower(strings.TrimSpace(runErr.Category))
+	if code == "permission_denied" || category == "permission_denied" {
+		return ExitPermissionDenied
+	}
+	switch category {
+	case "provider", "auth", "network", "invalid_request":
+		return ExitProviderModelError
+	case "local":
+		return ExitToolFailed
+	case "cancelled", "canceled":
+		return ExitInterrupted
+	case "timeout":
+		return ExitTimeout
+	}
+	return ExitTurnFailed
+}

--- a/internal/execution/exitcodes_test.go
+++ b/internal/execution/exitcodes_test.go
@@ -1,0 +1,39 @@
+package execution
+
+import "testing"
+
+func TestExitCodeForSettlementMapsStatuses(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status Status
+		err    *Error
+		want   int
+	}{
+		{name: "completed", status: StatusCompleted, want: ExitOK},
+		{name: "timed out", status: StatusTimedOut, want: ExitTimeout},
+		{name: "timed out wins over error", status: StatusTimedOut, err: &Error{Code: "x"}, want: ExitTimeout},
+		{name: "interrupted", status: StatusInterrupted, want: ExitInterrupted},
+		{name: "cancelled", status: StatusCancelled, want: ExitInterrupted},
+		{name: "failed without error", status: StatusFailed, want: ExitTurnFailed},
+		{name: "permission by code", status: StatusFailed, err: &Error{Code: "permission_denied"}, want: ExitPermissionDenied},
+		{name: "permission by category", status: StatusFailed, err: &Error{Category: "permission_denied"}, want: ExitPermissionDenied},
+		{name: "provider", status: StatusFailed, err: &Error{Category: "provider"}, want: ExitProviderModelError},
+		{name: "auth", status: StatusFailed, err: &Error{Category: "auth"}, want: ExitProviderModelError},
+		{name: "network", status: StatusFailed, err: &Error{Category: "network"}, want: ExitProviderModelError},
+		{name: "invalid request", status: StatusFailed, err: &Error{Category: "invalid_request"}, want: ExitProviderModelError},
+		{name: "local tool failure", status: StatusFailed, err: &Error{Category: "local"}, want: ExitToolFailed},
+		{name: "cancelled category under failed status", status: StatusFailed, err: &Error{Category: "cancelled"}, want: ExitInterrupted},
+		{name: "timeout category under failed status", status: StatusFailed, err: &Error{Category: "timeout"}, want: ExitTimeout},
+		{name: "unknown category", status: StatusFailed, err: &Error{Code: "turn_failed", Category: "unknown"}, want: ExitTurnFailed},
+		{name: "internal category", status: StatusFailed, err: &Error{Category: "internal"}, want: ExitTurnFailed},
+		{name: "mixed case category normalizes", status: StatusFailed, err: &Error{Category: " Provider "}, want: ExitProviderModelError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExitCodeForSettlement(tc.status, tc.err); got != tc.want {
+				t.Fatalf("ExitCodeForSettlement(%s, %+v) = %d, want %d", tc.status, tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/execution/types.go
+++ b/internal/execution/types.go
@@ -95,6 +95,9 @@ type TurnRef struct {
 	AttachedAt time.Time `json:"attached_at"`
 }
 
+// Run is the execution record of one invocation. Higher-level orchestration
+// (kanban dispatch, automation schedules) keeps its own dispatch record and
+// references the execution Run; it does not redefine execution state here.
 type Run struct {
 	ID          string          `json:"id"`
 	RuntimeID   string          `json:"runtime_id,omitempty"`


### PR DESCRIPTION
## 背景

EXEC 路径（CI 路径）在 #158 落地 Run 控制面后处于双路径过渡态：runner 里 legacy turn 控制与 Run 控制并存，退出码分类在客户端靠错误文本子串猜测，且与落盘到 Run manifest 的 exit_code 不一致。对照 thirdparty（codex exec / opencode 的 in-process server 驱动）评估后，按"保留扎实高频部分、砍掉不付租金的上层建筑"的方向收敛。

## 改动

**删除（无消费方的额外设计）**
- exec runner 的 legacy turn 双路径：`useRunControl` 分支、`waitForTurn`、exec 侧结构化输出重试循环（服务端已在同一 Run 内完成重试）、`RunController` 接口（并入 `Controller`）。
- `run/read`、`run/list` 协议方法：全仓零调用；离线审计由直接读 store 的 `wuu runs` 承担。
- 退出码的文本嗅探（`isPermissionFailure`/`isToolFailure` 等）：分类只信结构化 category。

**下推/修复（扎实的缺口）**
- 退出码契约收敛到 `internal/execution`：服务端 settle 时把细分退出码（3/7/8 等）写入 `Result.ExitCode`，落盘审计记录与进程退出码不再漂移；`BuildTurnError` 新增 `boundary_denied → permission_denied` 分类（此前该分类只存在于客户端文本匹配，服务端从未产出）。
- `thread_busy`（resume 到有活跃 turn 的线程）映射为专属退出码 9，文档已同步。
- Shutdown 期间并发排空通知通道，消除"通知缓冲满 → readLoop 阻塞 → shutdown 响应读不到"的慢退出路径。

## 测试

- 迁移 exec 与 cmd 的 fake controller 到新接口（fake 镜像真实 server：turn/started → 脚本事件 → 终态 run/updated）。
- 删除 `TestRunOutputSchemaRetriesInvalidFinalMessage`（测的是被删除的 exec 侧重试循环；服务端重试由 `TestExecutionRunSchemaOutcomeRetriesWithinOneRun` 等覆盖）。
- 退出码分类测试从 turn-error 迁移到 run 终态（分类来源已转移到服务端）；`TestRunStartSettlesManifestBeforeRunRead` 改为 store 直读并新增落盘 exit_code 断言。
- 新增 `internal/execution` 退出码表测试。
- `gofmt` / `go vet ./...` / `go test ./...` 全部通过。

## 说明

- `wuu runs` CLI、Run 清单落盘、JSONL 契约、resume/fork/timeout 等高频面均不变。
- kanban / automation 的 Run 模型不在本 PR 范围；`internal/execution` 的 Run 类型注释里留了分层定位（上层派单记录引用 execution.Run），防止第三个 Run 概念再长出来。