### PR TITLE
feat(tools): bounded waiting economy for background processes

### DIFF
--- a/internal/appserver/process_notifications.go
+++ b/internal/appserver/process_notifications.go
@@ -44,6 +44,7 @@ func (s *Server) forwardProcessNotifications(threadID string, control *agentcont
 				// obligation so a terminal event dropped behind a full channel is
 				// recovered when any retained event is consumed.
 				s.replayPendingProcessCompletions(threadID, control, manager)
+				s.replayPendingProcessRechecks(threadID, control, manager)
 				continue
 			}
 			if event.Cause != process.EventCauseNaturalExit || !processEventBelongsToThread(threadID, control, event) {
@@ -100,6 +101,72 @@ func processCompletionChatMessage(manager *process.Manager, event process.Event)
 	}
 }
 
+type processRecheckPayload struct {
+	ProcessID         string         `json:"process_id"`
+	Status            process.Status `json:"status"`
+	Command           string         `json:"command,omitempty"`
+	RecheckMinutes    int            `json:"recheck_minutes,omitempty"`
+	OutputLogPath     string         `json:"output_log_path,omitempty"`
+	OutputTail        string         `json:"output_tail,omitempty"`
+	OutputTruncated   bool           `json:"output_truncated,omitempty"`
+	OutputStartOffset int64          `json:"output_start_offset,omitempty"`
+	OutputEndOffset   int64          `json:"output_end_offset,omitempty"`
+	OutputTotalBytes  int64          `json:"output_total_bytes,omitempty"`
+	Instruction       string         `json:"instruction"`
+}
+
+func processRecheckChatMessage(manager *process.Manager, p process.Process) providers.ChatMessage {
+	payload := processRecheckPayload{
+		ProcessID:      p.ID,
+		Status:         p.Status,
+		Command:        tools.RedactToolOutput(p.Command),
+		RecheckMinutes: p.RecheckMinutes,
+		OutputLogPath:  tools.RedactToolOutput(p.LogPath),
+		Instruction:    "This is a scheduled progress recheck for a still-running background process. Review the output tail and decide: intervene with bash action=write_background/stop_background, adjust the schedule with bash action=update_background (recheck_minutes=0 cancels), or do nothing — the next recheck or the completion notification will start another turn. Do not chain read_background waits to keep this turn open.",
+	}
+	if manager != nil {
+		snapshot, err := manager.ReadOutputSnapshot(context.Background(), p.ID, process.OutputReadOptions{MaxBytes: processCompletionOutputBytes})
+		if err == nil {
+			payload.OutputTail = tools.RedactToolOutput(snapshot.Output)
+			payload.OutputTruncated = snapshot.Truncated
+			payload.OutputStartOffset = snapshot.StartOffset
+			payload.OutputEndOffset = snapshot.EndOffset
+			payload.OutputTotalBytes = snapshot.TotalBytes
+		}
+	}
+	encoded, _ := json.Marshal(payload)
+	return providers.ChatMessage{
+		Role:     "user",
+		Name:     wuucontext.ProcessNotificationMessageName,
+		ClientID: processRecheckClientID(p.ID),
+		Content:  "<process_recheck>" + string(encoded) + "</process_recheck>",
+	}
+}
+
+func (s *Server) replayPendingProcessRechecks(threadID string, control *agentcontrol.AgentControl, manager *process.Manager) {
+	if s == nil || manager == nil {
+		return
+	}
+	pending, err := manager.PendingRechecks()
+	if err != nil {
+		providers.DebugLogf("restore pending process rechecks for thread %q: %v", threadID, err)
+		return
+	}
+	for _, p := range pending {
+		event := process.Event{Process: p}
+		if !processEventBelongsToThread(threadID, control, event) {
+			continue
+		}
+		// Rechecks are periodic hints, not one-shot obligations: mark the
+		// delivery once queued; a lost turn is covered by the next interval.
+		if _, markErr := manager.MarkRecheckDelivered(p.ID); markErr != nil {
+			providers.DebugLogf("mark process recheck %q delivered for thread %q: %v", p.ID, threadID, markErr)
+			continue
+		}
+		s.enqueueProcessRecheckTurn(threadID, p.ID, processRecheckChatMessage(manager, p))
+	}
+}
+
 func (s *Server) replayPendingProcessCompletions(threadID string, control *agentcontrol.AgentControl, manager *process.Manager) {
 	if s == nil || manager == nil {
 		return
@@ -130,11 +197,14 @@ func threadHasOutstandingProcessCompletion(threadID string, control *agentcontro
 		return false
 	}
 	for _, p := range processes {
-		if p.CompletionMode == process.CompletionModeDetached {
-			continue
-		}
 		event := process.Event{Process: p}
 		if !processEventBelongsToThread(threadID, control, event) {
+			continue
+		}
+		if !p.PendingRecheckAt.IsZero() {
+			return true
+		}
+		if p.CompletionMode == process.CompletionModeDetached {
 			continue
 		}
 		switch p.Status {
@@ -170,6 +240,19 @@ func (s *Server) restorePendingProcessCompletionsOnThreadResume(threadID string)
 		}
 	}
 	if !needsRuntime {
+		pendingRechecks, recheckErr := s.rt.ProcessManager.PendingRechecks()
+		if recheckErr != nil {
+			providers.DebugLogf("inspect pending process rechecks while resuming thread %q: %v", threadID, recheckErr)
+			return
+		}
+		for _, p := range pendingRechecks {
+			if (p.OwnerKind == process.OwnerMainAgent && strings.TrimSpace(p.OwnerID) == threadID) || p.OwnerKind == process.OwnerSubagent {
+				needsRuntime = true
+				break
+			}
+		}
+	}
+	if !needsRuntime {
 		return
 	}
 	th := s.thread(threadID)
@@ -184,7 +267,16 @@ func (s *Server) restorePendingProcessCompletionsOnThreadResume(threadID string)
 const (
 	processCompletionClientIDPrefix       = "wuu-process-completion:"
 	processCompletionAnswerClientIDPrefix = "wuu-process-completion-answer:"
+	processRecheckClientIDPrefix          = "wuu-process-recheck:"
 )
+
+func processRecheckClientID(processID string) string {
+	processID = strings.TrimSpace(processID)
+	if processID == "" {
+		return ""
+	}
+	return processRecheckClientIDPrefix + processID
+}
 
 func processCompletionClientID(processIDs []string) string {
 	ids := uniqueSortedCompletionIDs(processIDs)
@@ -303,7 +395,51 @@ func (s *Server) enqueueProcessCompletionTurn(threadID, processID string, msg pr
 		s.agentCompletionMu.Unlock()
 		return
 	}
+	pending := s.pendingAgentCompletionTurns[threadID]
+	kept := pending[:0]
+	for _, existing := range pending {
+		// A completion supersedes a queued recheck for the same process: the
+		// completion message carries the final state and the output tail.
+		if existing.kind == agentCompletionTurnKindRecheck && existing.processID == processID {
+			continue
+		}
+		if existing.processID == processID {
+			s.agentCompletionMu.Unlock()
+			return
+		}
+		kept = append(kept, existing)
+	}
+	s.pendingAgentCompletionTurns[threadID] = append(kept, agentCompletionTurn{
+		processID: processID,
+		msg:       msg,
+	})
+	s.agentCompletionMu.Unlock()
+
+	s.kickAgentCompletionDrain(threadID)
+}
+
+func (s *Server) enqueueProcessRecheckTurn(threadID, processID string, msg providers.ChatMessage) {
+	if s == nil || s.closed.Load() {
+		return
+	}
+	threadID = strings.TrimSpace(threadID)
+	processID = strings.TrimSpace(processID)
+	if threadID == "" || processID == "" || !chatMessageHasUserPayload(msg) {
+		return
+	}
+	th := s.thread(threadID)
+	if th == nil || !canResumeAgentCompletionThread(th) {
+		return
+	}
+
+	s.agentCompletionMu.Lock()
+	if s.closed.Load() {
+		s.agentCompletionMu.Unlock()
+		return
+	}
 	for _, pending := range s.pendingAgentCompletionTurns[threadID] {
+		// Any queued turn for the same process — completion or recheck —
+		// already carries fresher state than this recheck.
 		if pending.processID == processID {
 			s.agentCompletionMu.Unlock()
 			return
@@ -311,6 +447,7 @@ func (s *Server) enqueueProcessCompletionTurn(threadID, processID string, msg pr
 	}
 	s.pendingAgentCompletionTurns[threadID] = append(s.pendingAgentCompletionTurns[threadID], agentCompletionTurn{
 		processID: processID,
+		kind:      agentCompletionTurnKindRecheck,
 		msg:       msg,
 	})
 	s.agentCompletionMu.Unlock()

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -40,10 +40,18 @@ type queuedTurn struct {
 	origin   string
 }
 
+type agentCompletionTurnKind string
+
+const (
+	agentCompletionTurnKindCompletion agentCompletionTurnKind = "completion"
+	agentCompletionTurnKindRecheck    agentCompletionTurnKind = "recheck"
+)
+
 type agentCompletionTurn struct {
 	agentID   string
 	resultID  string
 	processID string
+	kind      agentCompletionTurnKind
 	msg       providers.ChatMessage
 	snapshot  *subagent.SubAgentSnapshot
 }

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -37,6 +37,10 @@ const (
 	EventFailed    EventType = "failed"
 	EventStopped   EventType = "stopped"
 	EventCleanedUp EventType = "cleaned_up"
+	// EventRecheckDue marks a scheduled progress recheck firing for a live
+	// process. It is a low-latency hint only; consumers pull the persisted
+	// obligation through PendingRechecks.
+	EventRecheckDue EventType = "recheck_due"
 
 	EventCauseNaturalExit   EventCause = "natural_exit"
 	EventCauseRequestedStop EventCause = "requested_stop"
@@ -80,6 +84,15 @@ type Process struct {
 	TerminalCause         EventCause     `json:"terminal_cause,omitempty"`
 	CompletionDeliveredAt time.Time      `json:"completion_delivered_at,omitempty"`
 	CompletionConsumedBy  string         `json:"completion_consumed_by,omitempty"`
+	// RecheckMinutes is the model-declared progress recheck interval. Zero
+	// disables scheduled rechecks. NextRecheckAt is the persisted deadline of
+	// the next scheduled wake; PendingRecheckAt marks a fired recheck that has
+	// not been delivered to the owning thread yet. Unlike the one-shot
+	// completion obligation, a lost recheck is self-healing: the next interval
+	// fires again while the process stays live.
+	RecheckMinutes   int       `json:"recheck_minutes,omitempty"`
+	NextRecheckAt    time.Time `json:"next_recheck_at,omitempty"`
+	PendingRecheckAt time.Time `json:"pending_recheck_at,omitempty"`
 }
 
 type StartOptions struct {
@@ -92,6 +105,7 @@ type StartOptions struct {
 	CompletionMode        CompletionMode
 	TTY                   bool
 	AllowOutsideWorkspace bool
+	RecheckMinutes        int
 }
 
 type Event struct {
@@ -108,6 +122,12 @@ type OutputReadOptions struct {
 	MaxBytes    int
 	OffsetBytes *int64
 	Wait        time.Duration
+	// MinDwell paces output-driven early returns: new output releases the
+	// wait only once the call has dwelt at least this long, so a
+	// continuously producing process cannot bounce the caller into a tight
+	// return loop. Process exit and the Wait deadline still return
+	// immediately. Zero preserves the original first-output behavior.
+	MinDwell time.Duration
 }
 
 type OutputSnapshot struct {
@@ -129,6 +149,7 @@ type Manager struct {
 	subMu       sync.Mutex
 	handles     map[string]*processHandle
 	subscribers []chan<- Event
+	recheckWake chan struct{}
 }
 
 type processHandle struct {
@@ -170,6 +191,7 @@ func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
 		registryDir: filepath.Join(runtimeDir, "processes"),
 		logDir:      filepath.Join(runtimeDir, "logs"),
 		handles:     make(map[string]*processHandle),
+		recheckWake: make(chan struct{}, 1),
 	}
 	if err := os.MkdirAll(m.registryDir, 0o755); err != nil {
 		return nil, err
@@ -180,6 +202,7 @@ func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
 	if err := m.resumePersistedManagedProcesses(); err != nil {
 		return nil, err
 	}
+	go m.recheckScheduler()
 	return m, nil
 }
 
@@ -220,6 +243,9 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 	if opt.CompletionMode != CompletionModeResume && opt.CompletionMode != CompletionModeDetached {
 		return nil, errors.New("completion_mode must be resume or detached")
 	}
+	if opt.RecheckMinutes < 0 || opt.RecheckMinutes > MaxRecheckMinutes {
+		return nil, fmt.Errorf("recheck_minutes must be between 0 and %d", MaxRecheckMinutes)
+	}
 	m.mu.Lock()
 	rootDir := m.rootDir
 	m.mu.Unlock()
@@ -235,7 +261,10 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 		opt.TTY = false
 	}
 	id := "proc-" + randomHex(4)
-	p := &Process{ID: id, OwnerKind: opt.OwnerKind, OwnerID: opt.OwnerID, Lifecycle: opt.Lifecycle, CompletionMode: opt.CompletionMode, Status: StatusStarting, Command: opt.Command, CWD: cwd, TTY: opt.TTY, LogPath: filepath.Join(m.logDir, id+".log"), StartedAt: time.Now(), UpdatedAt: time.Now(), ExitCode: -1}
+	p := &Process{ID: id, OwnerKind: opt.OwnerKind, OwnerID: opt.OwnerID, Lifecycle: opt.Lifecycle, CompletionMode: opt.CompletionMode, Status: StatusStarting, Command: opt.Command, CWD: cwd, TTY: opt.TTY, LogPath: filepath.Join(m.logDir, id+".log"), StartedAt: time.Now(), UpdatedAt: time.Now(), ExitCode: -1, RecheckMinutes: opt.RecheckMinutes}
+	if opt.RecheckMinutes > 0 {
+		p.NextRecheckAt = p.StartedAt.Add(time.Duration(opt.RecheckMinutes) * time.Minute)
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if err := m.save(p); err != nil {
@@ -342,6 +371,9 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 			defer close(handle.done)
 			m.wait(id, cmd, logf)
 		}()
+	}
+	if p.RecheckMinutes > 0 {
+		m.signalRecheckScheduler()
 	}
 	return p, nil
 }
@@ -531,6 +563,10 @@ func (m *Manager) ReadOutputSnapshot(ctx context.Context, id string, opt OutputR
 	timedOut := false
 	if opt.Wait > 0 && opt.OffsetBytes != nil {
 		deadline := time.Now().Add(opt.Wait)
+		if opt.MinDwell < 0 {
+			opt.MinDwell = 0
+		}
+		minDwellAt := started.Add(opt.MinDwell)
 		for {
 			size, sizeErr := fileSize(p.LogPath)
 			if sizeErr != nil {
@@ -540,7 +576,13 @@ func (m *Manager) ReadOutputSnapshot(ctx context.Context, id string, opt OutputR
 			if offset < 0 {
 				offset = 0
 			}
-			if size > offset || !isLiveStatus(p.Status) {
+			// Process exit always releases immediately; new output releases
+			// only after the minimum dwell so a continuously producing
+			// process cannot bounce the caller faster than that pace.
+			if !isLiveStatus(p.Status) {
+				break
+			}
+			if size > offset && !time.Now().Before(minDwellAt) {
 				break
 			}
 			if !time.Now().Before(deadline) {
@@ -1052,6 +1094,309 @@ func (m *Manager) MarkCompletionDelivered(id, consumer string) (*Process, error)
 		if err := m.save(p); err != nil {
 			return p, err
 		}
+	}
+	return p, nil
+}
+
+// MaxRecheckMinutes bounds the model-declared recheck interval (24h).
+const MaxRecheckMinutes = 24 * 60
+
+const recheckSchedulerIdleInterval = time.Hour
+
+// recheckScheduler is the single timer loop for persisted recheck deadlines.
+// It sleeps until the earliest NextRecheckAt (or an idle interval when
+// nothing is armed) and recomputes whenever signalRecheckScheduler fires.
+// Deadlines live on the process record, so a manager restart rebuilds the
+// schedule simply by scanning the registry on its first pass.
+func (m *Manager) recheckScheduler() {
+	for {
+		next, due := m.scanRechecks()
+		for _, id := range due {
+			m.fireRecheck(id)
+		}
+		delay := recheckSchedulerIdleInterval
+		if !next.IsZero() {
+			delay = time.Until(next)
+			if delay < time.Second {
+				delay = time.Second
+			}
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-m.recheckWake:
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+}
+
+// scanRechecks returns the earliest future recheck deadline and the ids whose
+// deadline has passed. Terminal records carrying stale recheck state are
+// cleaned up lazily here, which is what auto-cancels schedules on completion
+// without touching every terminal transition.
+func (m *Manager) scanRechecks() (time.Time, []string) {
+	processes, err := m.List()
+	if err != nil {
+		return time.Time{}, nil
+	}
+	now := time.Now()
+	var next time.Time
+	var due []string
+	for _, p := range processes {
+		armed := p.RecheckMinutes > 0 || !p.NextRecheckAt.IsZero() || !p.PendingRecheckAt.IsZero()
+		if !armed {
+			continue
+		}
+		if !isLiveStatus(p.Status) {
+			_ = m.clearRecheckState(p.ID)
+			continue
+		}
+		if p.RecheckMinutes <= 0 || p.NextRecheckAt.IsZero() {
+			continue
+		}
+		if !p.NextRecheckAt.After(now) {
+			due = append(due, p.ID)
+			continue
+		}
+		if next.IsZero() || p.NextRecheckAt.Before(next) {
+			next = p.NextRecheckAt
+		}
+	}
+	return next, due
+}
+
+// fireRecheck stamps a due recheck as pending delivery and arms the next
+// interval. The persisted PendingRecheckAt is the delivery obligation; the
+// published event is only a low-latency hint for subscribers.
+func (m *Manager) fireRecheck(id string) {
+	m.mu.Lock()
+	p, err := m.load(id)
+	if err != nil {
+		m.mu.Unlock()
+		return
+	}
+	if !isLiveStatus(p.Status) || p.RecheckMinutes <= 0 {
+		m.mu.Unlock()
+		return
+	}
+	now := time.Now()
+	p.PendingRecheckAt = now
+	p.NextRecheckAt = now.Add(time.Duration(p.RecheckMinutes) * time.Minute)
+	p.UpdatedAt = now
+	if err := m.save(p); err != nil {
+		m.mu.Unlock()
+		return
+	}
+	proc := *p
+	m.mu.Unlock()
+	m.publish(Event{Type: EventRecheckDue, Process: proc})
+	m.signalRecheckScheduler()
+}
+
+func (m *Manager) clearRecheckState(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, err := m.load(id)
+	if err != nil {
+		return err
+	}
+	if p.RecheckMinutes == 0 && p.NextRecheckAt.IsZero() && p.PendingRecheckAt.IsZero() {
+		return nil
+	}
+	p.RecheckMinutes = 0
+	p.NextRecheckAt = time.Time{}
+	p.PendingRecheckAt = time.Time{}
+	p.UpdatedAt = time.Now()
+	return m.save(p)
+}
+
+func (m *Manager) signalRecheckScheduler() {
+	select {
+	case m.recheckWake <- struct{}{}:
+	default:
+	}
+}
+
+// SetRecheck updates a live process's recheck schedule. Zero minutes cancels
+// the schedule and drops any fired-but-undelivered recheck.
+func (m *Manager) SetRecheck(id string, minutes int) (*Process, error) {
+	if minutes < 0 || minutes > MaxRecheckMinutes {
+		return nil, fmt.Errorf("recheck_minutes must be between 0 and %d", MaxRecheckMinutes)
+	}
+	m.mu.Lock()
+	p, err := m.load(id)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	if !isLiveStatus(p.Status) {
+		m.mu.Unlock()
+		return p, fmt.Errorf("process %q is not running", id)
+	}
+	p.RecheckMinutes = minutes
+	if minutes <= 0 {
+		p.NextRecheckAt = time.Time{}
+		p.PendingRecheckAt = time.Time{}
+	} else {
+		p.NextRecheckAt = time.Now().Add(time.Duration(minutes) * time.Minute)
+	}
+	p.UpdatedAt = time.Now()
+	if err := m.save(p); err != nil {
+		m.mu.Unlock()
+		return p, err
+	}
+	m.mu.Unlock()
+	m.signalRecheckScheduler()
+	return p, nil
+}
+
+// PendingRechecks returns live processes with a fired-but-undelivered
+// recheck. Terminal processes never appear here: their completion obligation
+// supersedes any stale recheck.
+func (m *Manager) PendingRechecks() ([]Process, error) {
+	processes, err := m.List()
+	if err != nil {
+		return nil, err
+	}
+	pending := make([]Process, 0)
+	for _, p := range processes {
+		if isLiveStatus(p.Status) && !p.PendingRecheckAt.IsZero() {
+			pending = append(pending, p)
+		}
+	}
+	return pending, nil
+}
+
+// MarkRecheckDelivered clears the pending obligation once the recheck has
+// been queued for the owning thread. Rechecks are periodic, so a delivery
+// lost after this point self-heals at the next interval.
+func (m *Manager) MarkRecheckDelivered(id string) (*Process, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, err := m.load(id)
+	if err != nil {
+		return nil, err
+	}
+	if !p.PendingRecheckAt.IsZero() {
+		p.PendingRecheckAt = time.Time{}
+		p.UpdatedAt = time.Now()
+		if err := m.save(p); err != nil {
+			return p, err
+		}
+	}
+	return p, nil
+}
+
+// ReserveProcessLog allocates a fresh process id and matching log path under
+// the manager's log dir without registering a record. Callers that may later
+// hand a running command to Adopt tee the command's output into this file
+// from the start, so a promotion keeps both past and future output.
+func (m *Manager) ReserveProcessLog() (id, logPath string) {
+	id = "proc-" + randomHex(4)
+	return id, filepath.Join(m.logDir, id+".log")
+}
+
+// AdoptOptions describes an already-running command being promoted to a
+// managed background process.
+type AdoptOptions struct {
+	Command        string
+	CWD            string
+	OwnerKind      OwnerKind
+	OwnerID        string
+	Lifecycle      Lifecycle
+	CompletionMode CompletionMode
+	StartedAt      time.Time
+	// RecheckMinutes arms a progress recheck schedule on the adopted
+	// process. Promoted commands are by definition underestimates — the
+	// caller asked for a bounded run and the bound was wrong — so a default
+	// reminder schedule replaces the kill safety net the timeout used to be.
+	RecheckMinutes int
+}
+
+// Adopt registers a command started through StartCommand — whose output is
+// already teeing into the reserved logf — as a managed background process.
+// The caller keeps no ownership after a successful Adopt: terminal handling,
+// completion delivery, and Stop all go through the manager from here. On
+// error the caller retains the command and should stop it itself.
+func (m *Manager) Adopt(id string, cmd *exec.Cmd, handle *CommandHandle, logf *os.File, opt AdoptOptions) (*Process, error) {
+	if cmd == nil || cmd.Process == nil {
+		return nil, errors.New("running command is required")
+	}
+	if handle == nil {
+		return nil, errors.New("command handle is required")
+	}
+	if logf == nil {
+		return nil, errors.New("log file is required")
+	}
+	if _, err := processRecordPath(m.registryDir, id); err != nil {
+		return nil, err
+	}
+	if opt.OwnerKind != OwnerMainAgent && opt.OwnerKind != OwnerSubagent {
+		return nil, errors.New("owner_kind must be main_agent or subagent")
+	}
+	if opt.Lifecycle == "" {
+		opt.Lifecycle = LifecycleSession
+	}
+	if opt.Lifecycle != LifecycleSession && opt.Lifecycle != LifecycleManaged {
+		return nil, errors.New("lifecycle must be session or managed")
+	}
+	if opt.CompletionMode == "" {
+		opt.CompletionMode = CompletionModeResume
+	}
+	if opt.CompletionMode != CompletionModeResume && opt.CompletionMode != CompletionModeDetached {
+		return nil, errors.New("completion_mode must be resume or detached")
+	}
+	if opt.RecheckMinutes < 0 || opt.RecheckMinutes > MaxRecheckMinutes {
+		return nil, fmt.Errorf("recheck_minutes must be between 0 and %d", MaxRecheckMinutes)
+	}
+	now := time.Now()
+	startedAt := opt.StartedAt
+	if startedAt.IsZero() {
+		startedAt = now
+	}
+	p := &Process{
+		ID:             id,
+		OwnerKind:      opt.OwnerKind,
+		OwnerID:        opt.OwnerID,
+		Lifecycle:      opt.Lifecycle,
+		CompletionMode: opt.CompletionMode,
+		Status:         StatusRunning,
+		Command:        opt.Command,
+		CWD:            opt.CWD,
+		LogPath:        filepath.Join(m.logDir, id+".log"),
+		StartedAt:      startedAt,
+		UpdatedAt:      now,
+		ExitCode:       -1,
+	}
+	if opt.RecheckMinutes > 0 {
+		p.RecheckMinutes = opt.RecheckMinutes
+		p.NextRecheckAt = now.Add(time.Duration(opt.RecheckMinutes) * time.Minute)
+	}
+	p.PID = cmd.Process.Pid
+	p.PGID = ProcessTreeForPID(p.PID).ID()
+	var err error
+	p.ProcessStartTime, _, _, err = readProcessIdentity(p.PID)
+	if err != nil {
+		return nil, fmt.Errorf("record process identity: %w", err)
+	}
+	m.mu.Lock()
+	if err := m.save(p); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	adopted := &processHandle{done: make(chan struct{})}
+	m.handles[id] = adopted
+	m.mu.Unlock()
+	m.publish(Event{Type: EventStarted, Process: *p})
+	go func() {
+		defer close(adopted.done)
+		<-handle.Done()
+		waitErr := handle.Wait()
+		_ = logf.Close()
+		m.finishWait(id, cmd, waitErr)
+	}()
+	if p.RecheckMinutes > 0 {
+		m.signalRecheckScheduler()
 	}
 	return p, nil
 }

--- a/internal/process/manager_recheck_test.go
+++ b/internal/process/manager_recheck_test.go
@@ -1,0 +1,319 @@
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func waitForProcessStatus(t *testing.T, m *Manager, id string, want Status, timeout time.Duration) Process {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		p, err := m.Get(id)
+		if err == nil && p.Status == want {
+			return *p
+		}
+		if time.Now().After(deadline) {
+			current, _ := m.Get(id)
+			t.Fatalf("process %q did not reach status %q within %s (current: %+v)", id, want, timeout, current)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestReadOutputSnapshotMinDwellPacesOutputReturn(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Start(context.Background(), StartOptions{Command: "printf 'tick\\n'; sleep 30", OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = m.Stop(p.ID) }()
+
+	zero := int64(0)
+	paced, err := m.ReadOutputSnapshot(context.Background(), p.ID, OutputReadOptions{
+		MaxBytes:    4096,
+		OffsetBytes: &zero,
+		Wait:        3 * time.Second,
+		MinDwell:    time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(paced.Output, "tick") {
+		t.Fatalf("paced wait should return the new output: %+v", paced)
+	}
+	if paced.Duration < 900*time.Millisecond {
+		t.Fatalf("min dwell should pace the output-driven return, returned after %s", paced.Duration)
+	}
+	if paced.TimedOut {
+		t.Fatal("output arrived before the deadline; the wait should not time out")
+	}
+
+	// Without a minimum dwell the same read releases as soon as output is
+	// visible.
+	unpaced, err := m.ReadOutputSnapshot(context.Background(), p.ID, OutputReadOptions{
+		MaxBytes:    4096,
+		OffsetBytes: &zero,
+		Wait:        3 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unpaced.Duration > 900*time.Millisecond {
+		t.Fatalf("zero min dwell should return on first output, took %s", unpaced.Duration)
+	}
+}
+
+func TestReadOutputSnapshotExitReleasesImmediatelyWithMinDwell(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Start(context.Background(), StartOptions{Command: "exit 0", OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForProcessStatus(t, m, p.ID, StatusStopped, 5*time.Second)
+
+	zero := int64(0)
+	snapshot, err := m.ReadOutputSnapshot(context.Background(), p.ID, OutputReadOptions{
+		MaxBytes:    4096,
+		OffsetBytes: &zero,
+		Wait:        5 * time.Second,
+		MinDwell:    30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Duration > time.Second {
+		t.Fatalf("process exit must release the wait immediately regardless of min dwell, took %s", snapshot.Duration)
+	}
+}
+
+func TestSetRecheckValidation(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Start(context.Background(), StartOptions{Command: "sleep 30", OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = m.Stop(p.ID) }()
+
+	if _, err := m.SetRecheck(p.ID, -1); err == nil {
+		t.Fatal("negative recheck_minutes should fail")
+	}
+	if _, err := m.SetRecheck(p.ID, MaxRecheckMinutes+1); err == nil {
+		t.Fatal("recheck_minutes above the cap should fail")
+	}
+	updated, err := m.SetRecheck(p.ID, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RecheckMinutes != 5 || updated.NextRecheckAt.IsZero() {
+		t.Fatalf("recheck schedule not applied: %+v", updated)
+	}
+	cancelled, err := m.SetRecheck(p.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelled.RecheckMinutes != 0 || !cancelled.NextRecheckAt.IsZero() {
+		t.Fatalf("recheck cancellation not applied: %+v", cancelled)
+	}
+
+	stopped, err := m.Start(context.Background(), StartOptions{Command: "exit 0", OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForProcessStatus(t, m, stopped.ID, StatusStopped, 5*time.Second)
+	if _, err := m.SetRecheck(stopped.ID, 5); err == nil {
+		t.Fatal("setting a recheck on a terminal process should fail")
+	}
+}
+
+func TestRecheckSchedulerFiresAdvancesAndDelivers(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Start(context.Background(), StartOptions{Command: "sleep 60", OwnerKind: OwnerMainAgent, OwnerID: "main", Lifecycle: LifecycleManaged, RecheckMinutes: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = m.Stop(p.ID) }()
+
+	// Pull the deadline into the past so the next scheduler pass fires.
+	m.mu.Lock()
+	rec, err := m.load(p.ID)
+	if err != nil {
+		m.mu.Unlock()
+		t.Fatal(err)
+	}
+	rec.NextRecheckAt = time.Now().Add(-time.Minute)
+	if err := m.save(rec); err != nil {
+		m.mu.Unlock()
+		t.Fatal(err)
+	}
+	m.mu.Unlock()
+	m.signalRecheckScheduler()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var pending []Process
+	for {
+		pending, err = m.PendingRechecks()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pending) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("scheduler did not fire the due recheck within 5s (pending: %+v)", pending)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	fired := pending[0]
+	if fired.ID != p.ID || fired.PendingRecheckAt.IsZero() {
+		t.Fatalf("unexpected pending recheck: %+v", fired)
+	}
+	if !fired.NextRecheckAt.After(time.Now()) {
+		t.Fatalf("firing should arm the next interval in the future: %+v", fired)
+	}
+
+	if _, err := m.MarkRecheckDelivered(p.ID); err != nil {
+		t.Fatal(err)
+	}
+	pending, err = m.PendingRechecks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("delivery should clear the pending obligation: %+v", pending)
+	}
+}
+
+func TestScanRechecksClearsTerminalSchedule(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Start(context.Background(), StartOptions{Command: "sleep 60", OwnerKind: OwnerMainAgent, OwnerID: "main", RecheckMinutes: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Stop(p.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, due := m.scanRechecks(); len(due) != 0 {
+		t.Fatalf("terminal process should never be due: %+v", due)
+	}
+	current, err := m.Get(p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.RecheckMinutes != 0 || !current.NextRecheckAt.IsZero() || !current.PendingRecheckAt.IsZero() {
+		t.Fatalf("terminal process should lose its recheck schedule: %+v", current)
+	}
+}
+
+func TestAdoptTracksNaturalExitAndCompletion(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, logPath := m.ReserveProcessLog()
+	logf, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, err := managedCommand("printf 'adopted-output\\n'; exit 0", root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	handle, err := StartCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Adopt(id, cmd, handle, logf, AdoptOptions{Command: "printf ...; exit 0", CWD: root, OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Status != StatusRunning || p.PGID <= 1 || p.ProcessStartTime == "" {
+		t.Fatalf("adopted process missing identity: %+v", p)
+	}
+
+	terminal := waitForProcessStatus(t, m, p.ID, StatusStopped, 5*time.Second)
+	if terminal.ExitCode != 0 || terminal.TerminalCause != EventCauseNaturalExit {
+		t.Fatalf("unexpected terminal state: %+v", terminal)
+	}
+	pending, err := m.PendingCompletions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, candidate := range pending {
+		if candidate.ID == p.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("adopted process should carry a completion obligation: %+v", pending)
+	}
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "adopted-output") {
+		t.Fatalf("adopted log should keep the process output: %q", content)
+	}
+}
+
+func TestAdoptStopTerminatesProcess(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, logPath := m.ReserveProcessLog()
+	logf, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd, err := managedCommand("sleep 60", root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stdout = logf
+	cmd.Stderr = logf
+	handle, err := StartCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := m.Adopt(id, cmd, handle, logf, AdoptOptions{Command: "sleep 60", CWD: root, OwnerKind: OwnerMainAgent, OwnerID: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped, err := m.Stop(p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stopped.Status != StatusStopped {
+		t.Fatalf("stop should terminate the adopted process: %+v", stopped)
+	}
+}

--- a/internal/tools/tool_bash.go
+++ b/internal/tools/tool_bash.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,12 +14,21 @@ import (
 )
 
 const (
-	bashActionRun             = "run"
-	bashActionStartBackground = "start_background"
-	bashActionListBackground  = "list_background"
-	bashActionReadBackground  = "read_background"
-	bashActionWriteBackground = "write_background"
-	bashActionStopBackground  = "stop_background"
+	bashActionRun              = "run"
+	bashActionStartBackground  = "start_background"
+	bashActionListBackground   = "list_background"
+	bashActionReadBackground   = "read_background"
+	bashActionWriteBackground  = "write_background"
+	bashActionStopBackground   = "stop_background"
+	bashActionUpdateBackground = "update_background"
+)
+
+const (
+	// readBackgroundMaxWaitMS caps one bounded event-driven wait at 5 minutes.
+	readBackgroundMaxWaitMS = 300_000
+	// backgroundWaitMinDwell paces output-driven early returns so a
+	// continuously producing process releases a wait at most this often.
+	backgroundWaitMinDwell = 5 * time.Second
 )
 
 // BashTool is the bash-first command tool exposed to the model on
@@ -70,7 +80,7 @@ func (t *BashTool) Classify(argsJSON string) ToolClassification {
 			Risk:            ToolRiskMedium,
 			Reason:          "managed background process observation",
 		}
-	case bashActionWriteBackground, bashActionStopBackground:
+	case bashActionWriteBackground, bashActionStopBackground, bashActionUpdateBackground:
 		return ToolClassification{
 			ReadOnly:        false,
 			ConcurrencySafe: true,
@@ -94,12 +104,12 @@ func (t *BashTool) ValidateInput(argsJSON string) error {
 		}
 	case bashActionListBackground:
 		return nil
-	case bashActionReadBackground, bashActionWriteBackground, bashActionStopBackground:
+	case bashActionReadBackground, bashActionWriteBackground, bashActionStopBackground, bashActionUpdateBackground:
 		if strings.TrimSpace(args.ProcessID) == "" {
 			return errors.New("bash background action requires process_id")
 		}
 	default:
-		return errors.New("bash action must be one of run, start_background, list_background, read_background, write_background, stop_background")
+		return errors.New("bash action must be one of run, start_background, list_background, read_background, write_background, stop_background, update_background")
 	}
 	return nil
 }
@@ -108,13 +118,14 @@ func (t *BashTool) Definition() providers.ToolDefinition {
 	return providers.ToolDefinition{
 		Name: "bash",
 		Description: "Run bash operations in the workspace. Use for terminal work: tests, lint, builds, git, package managers, scripts, docker, and managed background processes.\n\n" +
-			"Prefer dedicated file/search/edit tools for reading, searching, or changing files. Default action=run is non-interactive and returns exit_code, duration_ms, workspace_revision, output tails, and full_log_ref when available; verification commands add verification metadata. For terminal prompts, confirmations, or REPLs, use action=start_background with tty=true, then action=write_background to send input and action=read_background to read output. Use the background actions for long-lived processes as well. A naturally exiting background command automatically starts a new turn with its status and output tail. If completion is your only remaining dependency, end the current turn; do not keep it open with list_background, read_background, or a wait. Use read_background only for readiness output while the process is still running, or after a completion notification when its output tail was insufficient. cwd defaults to the workspace root. Shell state does not persist between run calls.",
+			"Prefer dedicated file/search/edit tools for reading, searching, or changing files. Default action=run is non-interactive and returns exit_code, duration_ms, workspace_revision, output tails, and full_log_ref when available; verification commands add verification metadata. If a run command hits its timeout it keeps running as a managed background process instead of being killed, with its output so far attached. For terminal prompts, confirmations, or REPLs, use action=start_background with tty=true, then action=write_background to send input and action=read_background to read output. Use the background actions for long-lived processes as well. cwd defaults to the workspace root. Shell state does not persist between run calls.\n\n" +
+			"Wake-ups always come to you — polling is never the only way to learn an outcome: a naturally exiting background process starts a new turn with its status and output tail, and a process started with recheck_minutes additionally wakes you with a progress snapshot on that schedule (the schedule is cancelled automatically on completion). Observation on demand: read_background without wait_ms is a non-blocking snapshot and is always fine; with wait_ms it becomes a bounded event-driven wait that returns early when new output arrives or the process exits (at most one return per call). Rules for waits: do not wait on a process you just launched this turn when its result gates your next step — run that work with action=run instead; if a wait times out with the process still running, do not immediately wait again on the same process — continue other work or end the turn; never chain waits just to keep a turn open. For long silent tasks (downloads, backups), set recheck_minutes on start_background or later via action=update_background so progress finds you on a schedule.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"action": map[string]any{
 					"type":        "string",
-					"enum":        []string{bashActionRun, bashActionStartBackground, bashActionListBackground, bashActionReadBackground, bashActionWriteBackground, bashActionStopBackground},
+					"enum":        []string{bashActionRun, bashActionStartBackground, bashActionListBackground, bashActionReadBackground, bashActionWriteBackground, bashActionStopBackground, bashActionUpdateBackground},
 					"description": "Operation. Defaults to run; background actions manage long-lived processes.",
 				},
 				"command": map[string]any{
@@ -154,7 +165,7 @@ func (t *BashTool) Definition() providers.ToolDefinition {
 				},
 				"wait_ms": map[string]any{
 					"type":        "integer",
-					"description": "For background start/read: wait this many milliseconds for readiness output. Maximum 60000 for start. Do not use it to wait for natural completion; end the current turn and let the completion notification start the next turn.",
+					"description": "For background start/read: wait this many milliseconds for new output before returning. The wait returns early when output arrives (paced to at most one return per ~5s for continuously producing processes) or immediately when the process exits; it never exceeds the deadline. Max 60000 for start, 300000 for read. Do not chain waits to sit on a process — completion notifications and recheck_minutes cover wake-ups.",
 				},
 				"max_bytes": map[string]any{
 					"type":        "integer",
@@ -166,7 +177,11 @@ func (t *BashTool) Definition() providers.ToolDefinition {
 				},
 				"process_id": map[string]any{
 					"type":        "string",
-					"description": "Managed background process id for read_background/write_background/stop_background.",
+					"description": "Managed background process id for read_background/write_background/stop_background/update_background.",
+				},
+				"recheck_minutes": map[string]any{
+					"description": "Optional. For start_background/update_background: minutes between scheduled progress wake-ups for this process (1-1440); 0 cancels the schedule. Each wake-up delivers a status/output snapshot in a new turn, and completing the process cancels the schedule automatically. Pick an interval proportional to the expected duration — around 5 minutes for short tasks, much longer for big downloads.",
+					"type":        "integer",
 				},
 				"input": map[string]any{
 					"type":        "string",
@@ -196,8 +211,10 @@ func (t *BashTool) Execute(ctx context.Context, argsJSON string) (string, error)
 		return t.executeWriteStdin(args)
 	case bashActionStopBackground:
 		return t.executeStopBackground(args)
+	case bashActionUpdateBackground:
+		return t.executeUpdateBackground(args)
 	default:
-		return "", errors.New("bash action must be one of run, start_background, list_background, read_background, write_background, stop_background")
+		return "", errors.New("bash action must be one of run, start_background, list_background, read_background, write_background, stop_background, update_background")
 	}
 }
 
@@ -219,6 +236,7 @@ type bashArgs struct {
 	ProcessID      string `json:"process_id"`
 	Input          string `json:"input"`
 	Background     bool   `json:"background"`
+	RecheckMinutes int    `json:"recheck_minutes"`
 }
 
 func normalizeBashAction(args bashArgs) string {
@@ -398,7 +416,7 @@ func (t *BashTool) executeStartBackground(ctx context.Context, args bashArgs) (s
 	if err != nil {
 		return "", err
 	}
-	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: args.TTY, AllowOutsideWorkspace: t.env.BypassToolHardProtections()})
+	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: args.TTY, AllowOutsideWorkspace: t.env.BypassToolHardProtections(), RecheckMinutes: args.RecheckMinutes})
 	response := startProcessResponse{}
 	if p != nil {
 		response.Process = redactProcess(t.env, *p)
@@ -440,12 +458,12 @@ func (t *BashTool) executeStartBackground(ctx context.Context, args bashArgs) (s
 
 func bashBackgroundNextSuggestions(waitMS int, completionMode string) []string {
 	if strings.TrimSpace(completionMode) == string(proc.CompletionModeDetached) {
-		return []string{"this process is detached and will not start another model turn when it exits", "use bash action=read_background only when you explicitly need readiness or later output"}
+		return []string{"this process is detached and will not start another model turn when it exits", "use bash action=read_background snapshots only when you explicitly need its output"}
 	}
 	if waitMS <= 0 {
-		return []string{"continue independent work; if completion is the only remaining dependency, end this turn now and the natural exit will start a new turn automatically", "do not call list_background, read_background, or wait only to keep this turn open; use read_background only for readiness output while the process is still running"}
+		return []string{"continue independent work; if completion is the only remaining dependency, end this turn now and the natural exit will start a new turn automatically", "read_background without wait_ms gives a non-blocking snapshot whenever you need progress; for a long silent task, schedule wake-ups with bash action=update_background and recheck_minutes"}
 	}
-	return []string{"continue independent work; if completion is the only remaining dependency, end this turn now and the natural exit will start a new turn automatically", "when the still-running process needs more readiness output, pass initial_end_offset as offset_bytes to bash action=read_background"}
+	return []string{"continue independent work; if completion is the only remaining dependency, end this turn now and the natural exit will start a new turn automatically", "when the still-running process needs more output, pass initial_end_offset as offset_bytes to bash action=read_background — a bounded wait_ms is fine, but do not chain waits to keep this turn open"}
 }
 
 func (t *BashTool) executeListBackground() (string, error) {
@@ -472,29 +490,69 @@ func (t *BashTool) executeReadBackground(ctx context.Context, args bashArgs) (st
 	if err != nil {
 		return "", err
 	}
+	waitMS := args.WaitMS
+	if waitMS > readBackgroundMaxWaitMS {
+		waitMS = readBackgroundMaxWaitMS
+	}
+	wait := time.Duration(waitMS) * time.Millisecond
+	minDwell := time.Duration(0)
+	if wait > 0 {
+		minDwell = backgroundWaitMinDwell
+		if minDwell > wait {
+			minDwell = wait
+		}
+	}
 	snapshot, err := m.ReadOutputSnapshot(ctx, args.ProcessID, proc.OutputReadOptions{
 		MaxBytes:    args.MaxBytes,
 		OffsetBytes: args.OffsetBytes,
-		Wait:        time.Duration(args.WaitMS) * time.Millisecond,
+		Wait:        wait,
+		MinDwell:    minDwell,
 	})
 	if err != nil {
 		return "", err
 	}
 	process := markProcessCompletionObserved(m, snapshot.Process)
 	return mustJSON(map[string]any{
-		"action":       bashActionReadBackground,
-		"process_id":   args.ProcessID,
-		"output":       t.env.RedactToolOutput(snapshot.Output),
-		"truncated":    snapshot.Truncated,
-		"start_offset": snapshot.StartOffset,
-		"end_offset":   snapshot.EndOffset,
-		"total_bytes":  snapshot.TotalBytes,
-		"timed_out":    snapshot.TimedOut,
-		"duration_ms":  snapshot.Duration.Milliseconds(),
-		"status":       process.Status,
-		"exit_code":    process.ExitCode,
-		"process":      redactProcess(t.env, process),
+		"action":           bashActionReadBackground,
+		"process_id":       args.ProcessID,
+		"output":           t.env.RedactToolOutput(snapshot.Output),
+		"truncated":        snapshot.Truncated,
+		"start_offset":     snapshot.StartOffset,
+		"end_offset":       snapshot.EndOffset,
+		"total_bytes":      snapshot.TotalBytes,
+		"timed_out":        snapshot.TimedOut,
+		"duration_ms":      snapshot.Duration.Milliseconds(),
+		"status":           process.Status,
+		"exit_code":        process.ExitCode,
+		"process":          redactProcess(t.env, process),
+		"next_suggestions": bashReadBackgroundNextSuggestions(waitMS, minDwell, snapshot, process),
 	})
+}
+
+// bashReadBackgroundNextSuggestions turns the wait outcome into in-context
+// guidance. The chatty hint fires exactly when it matters: a wait released
+// right at the pacing floor with new output, meaning the process produces
+// output continuously and repeated waits would spin.
+func bashReadBackgroundNextSuggestions(waitMS int, minDwell time.Duration, snapshot proc.OutputSnapshot, process proc.Process) []string {
+	live := process.Status == proc.StatusStarting || process.Status == proc.StatusRunning || process.Status == proc.StatusStopping
+	if !live {
+		return []string{"process is terminal; page remaining output with offset_bytes when the tail is insufficient — no further waits are useful"}
+	}
+	if waitMS <= 0 {
+		return nil
+	}
+	if snapshot.TimedOut {
+		return []string{
+			"the wait expired with the process still running; do not immediately wait again on the same process — continue other work or end this turn and let the completion notification start the next turn",
+			"for a long silent task, schedule a wake-up instead: bash action=update_background with process_id and recheck_minutes",
+		}
+	}
+	if snapshot.Duration <= minDwell+time.Second {
+		return []string{
+			"this process is producing output continuously (the wait returned after ~" + snapshot.Duration.Round(time.Second).String() + "); do not chain waits on it — use non-blocking snapshots when you need progress and rely on the completion notification or recheck_minutes for wake-ups",
+		}
+	}
+	return []string{"process is still running; pass end_offset as offset_bytes if you wait for more output again"}
 }
 
 func (t *BashTool) executeWriteStdin(args bashArgs) (string, error) {
@@ -528,4 +586,29 @@ func (t *BashTool) executeStopBackground(args bashArgs) (string, error) {
 		redacted.Action = bashActionStopBackground
 	}
 	return mustJSON(redacted)
+}
+
+func (t *BashTool) executeUpdateBackground(args bashArgs) (string, error) {
+	m, err := t.env.ProcessManager()
+	if err != nil {
+		return "", err
+	}
+	p, err := m.SetRecheck(args.ProcessID, args.RecheckMinutes)
+	if err != nil {
+		return "", err
+	}
+	next := []string{}
+	if p.RecheckMinutes > 0 {
+		next = append(next, "progress wake-ups are scheduled every "+strconv.Itoa(p.RecheckMinutes)+" minute(s) until the process completes; each wake-up starts a new turn with a status/output snapshot")
+	} else {
+		next = append(next, "recheck schedule cancelled; the completion notification still starts a new turn when the process exits")
+	}
+	return mustJSON(map[string]any{
+		"action":           bashActionUpdateBackground,
+		"process_id":       args.ProcessID,
+		"recheck_minutes":  p.RecheckMinutes,
+		"next_recheck_at":  p.NextRecheckAt,
+		"process":          redactProcessPtr(t.env, p),
+		"next_suggestions": next,
+	})
 }

--- a/internal/tools/tool_bash_background_test.go
+++ b/internal/tools/tool_bash_background_test.go
@@ -1,0 +1,193 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	proc "github.com/blueberrycongee/wuu/internal/process"
+	"github.com/blueberrycongee/wuu/internal/providers"
+)
+
+func TestBashReadBackgroundNextSuggestions(t *testing.T) {
+	liveProcess := proc.Process{Status: proc.StatusRunning}
+	deadProcess := proc.Process{Status: proc.StatusStopped}
+
+	if got := bashReadBackgroundNextSuggestions(0, 0, proc.OutputSnapshot{}, liveProcess); got != nil {
+		t.Fatalf("plain snapshots need no guidance: %v", got)
+	}
+
+	terminal := bashReadBackgroundNextSuggestions(5000, backgroundWaitMinDwell, proc.OutputSnapshot{}, deadProcess)
+	if len(terminal) == 0 || !strings.Contains(terminal[0], "terminal") {
+		t.Fatalf("terminal processes should close the wait path: %v", terminal)
+	}
+
+	timedOut := bashReadBackgroundNextSuggestions(5000, backgroundWaitMinDwell, proc.OutputSnapshot{TimedOut: true}, liveProcess)
+	if len(timedOut) < 2 || !strings.Contains(timedOut[0], "do not immediately wait again") || !strings.Contains(timedOut[1], "update_background") {
+		t.Fatalf("an expired wait should steer away from re-waiting and toward rechecks: %v", timedOut)
+	}
+
+	chatty := bashReadBackgroundNextSuggestions(120000, backgroundWaitMinDwell, proc.OutputSnapshot{Duration: backgroundWaitMinDwell}, liveProcess)
+	if len(chatty) == 0 || !strings.Contains(chatty[0], "continuously") {
+		t.Fatalf("a wait released at the pacing floor should name the chatty pattern: %v", chatty)
+	}
+
+	quiet := bashReadBackgroundNextSuggestions(120000, backgroundWaitMinDwell, proc.OutputSnapshot{Duration: 90 * time.Second}, liveProcess)
+	if len(quiet) == 0 || !strings.Contains(quiet[0], "end_offset") {
+		t.Fatalf("a normal early return should just teach incremental offsets: %v", quiet)
+	}
+}
+
+func TestBashUpdateBackgroundRequiresProcessID(t *testing.T) {
+	kit, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"update_background","recheck_minutes":10}`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "process_id") {
+		t.Fatalf("update_background without process_id should fail: %v", err)
+	}
+}
+
+func TestBashUpdateBackgroundScheduleLifecycle(t *testing.T) {
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	manager, err := proc.NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = manager.CleanupSession() }()
+	kit.SetProcessManager(manager)
+
+	startResp, err := kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"start_background","command":"sleep 60"}`,
+	})
+	if err != nil {
+		t.Fatalf("start background: %v", err)
+	}
+	var started struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(startResp), &started); err != nil || started.ID == "" {
+		t.Fatalf("parse start response: %v\n%s", err, startResp)
+	}
+
+	updateResp, err := kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"update_background","process_id":"` + started.ID + `","recheck_minutes":10}`,
+	})
+	if err != nil {
+		t.Fatalf("update background: %v", err)
+	}
+	var updated struct {
+		RecheckMinutes int `json:"recheck_minutes"`
+	}
+	if err := json.Unmarshal([]byte(updateResp), &updated); err != nil {
+		t.Fatalf("parse update response: %v\n%s", err, updateResp)
+	}
+	if updated.RecheckMinutes != 10 {
+		t.Fatalf("recheck_minutes = %d, want 10", updated.RecheckMinutes)
+	}
+	record, err := manager.Get(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.RecheckMinutes != 10 || record.NextRecheckAt.IsZero() {
+		t.Fatalf("schedule not persisted: %+v", record)
+	}
+
+	cancelResp, err := kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"update_background","process_id":"` + started.ID + `","recheck_minutes":0}`,
+	})
+	if err != nil {
+		t.Fatalf("cancel recheck: %v", err)
+	}
+	if !strings.Contains(cancelResp, `"recheck_minutes":0`) {
+		t.Fatalf("cancellation should report recheck_minutes 0: %s", cancelResp)
+	}
+}
+
+func TestBashStartBackgroundRejectsInvalidRecheck(t *testing.T) {
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	manager, err := proc.NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = manager.CleanupSession() }()
+	kit.SetProcessManager(manager)
+
+	_, err = kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"start_background","command":"sleep 5","recheck_minutes":-3}`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "recheck_minutes") {
+		t.Fatalf("negative recheck_minutes should fail: %v", err)
+	}
+}
+
+func TestBashRunTimeoutPromotesToBackground(t *testing.T) {
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	manager, err := proc.NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = manager.CleanupSession() }()
+	kit.SetProcessManager(manager)
+
+	resp, err := kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"run","command":"printf 'partial\\n'; sleep 30","timeout_seconds":1}`,
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var result shellExecutionResult
+	if err := json.Unmarshal([]byte(resp), &result); err != nil {
+		t.Fatalf("parse run result: %v\n%s", err, resp)
+	}
+	if !result.TimedOut {
+		t.Fatalf("run should report the timeout: %+v", result)
+	}
+	if result.PromotedProcessID == "" {
+		t.Fatalf("run should promote the timed-out command instead of killing it: %+v", result)
+	}
+	if !strings.Contains(result.Output, "partial") {
+		t.Fatalf("promotion should attach the output captured so far: %+v", result)
+	}
+	record, err := manager.Get(result.PromotedProcessID)
+	if err != nil {
+		t.Fatalf("promoted process should be managed: %v", err)
+	}
+	if record.Status != proc.StatusRunning {
+		t.Fatalf("promoted process should keep running: %+v", record)
+	}
+	if record.RecheckMinutes != defaultPromotedRecheckMinutes || record.NextRecheckAt.IsZero() {
+		t.Fatalf("promoted process should carry the safety-net recheck: %+v", record)
+	}
+	stopped, err := manager.Stop(result.PromotedProcessID)
+	if err != nil {
+		t.Fatalf("stop promoted process: %v", err)
+	}
+	if stopped.Status != proc.StatusStopped {
+		t.Fatalf("promoted process should stop cleanly: %+v", stopped)
+	}
+}

--- a/internal/tools/tool_bash_test.go
+++ b/internal/tools/tool_bash_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestBashDefinitionExplainsInteractiveBackgroundFlow(t *testing.T) {
 	def := NewBashTool(&Env{}).Definition()
-	for _, want := range []string{"action=start_background", "tty=true", "action=write_background", "action=read_background", "automatically starts a new turn", "end the current turn", "do not keep it open"} {
+	for _, want := range []string{"action=start_background", "tty=true", "action=write_background", "action=read_background", "starts a new turn", "end the turn", "recheck_minutes", "update_background", "timeout it keeps running"} {
 		if !strings.Contains(def.Description, want) {
 			t.Fatalf("bash description must teach %q interactive flow: %q", want, def.Description)
 		}
@@ -34,8 +34,12 @@ func TestBashDefinitionExplainsInteractiveBackgroundFlow(t *testing.T) {
 		t.Fatalf("bash command description does not distinguish run from interactive background use: %q", commandDescription)
 	}
 	wait, ok := properties["wait_ms"].(map[string]any)
-	if !ok || !strings.Contains(wait["description"].(string), "Do not use it to wait for natural completion") {
-		t.Fatalf("bash wait_ms description does not explain turn handoff: %+v", wait)
+	if !ok || !strings.Contains(wait["description"].(string), "Do not chain waits") {
+		t.Fatalf("bash wait_ms description does not explain bounded waits: %+v", wait)
+	}
+	recheck, ok := properties["recheck_minutes"].(map[string]any)
+	if !ok || !strings.Contains(recheck["description"].(string), "wake-ups") {
+		t.Fatalf("bash recheck_minutes does not explain scheduled wake-ups: %+v", recheck)
 	}
 	completionMode, ok := properties["completion_mode"].(map[string]any)
 	if !ok || !strings.Contains(completionMode["description"].(string), "long-lived services") {

--- a/internal/tools/tool_shell.go
+++ b/internal/tools/tool_shell.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -19,6 +21,13 @@ import (
 )
 
 const maxShellTailBytes = 8 * 1024
+
+// defaultPromotedRecheckMinutes is the safety-net recheck schedule armed on
+// a run command whose timeout promoted it to a background process. A
+// promoted command is an underestimate by definition, so the schedule
+// replaces the kill safety net the timeout used to be; the model can change
+// or clear it with bash action=update_background.
+const defaultPromotedRecheckMinutes = 30
 
 // The shell classification and execution engine below is shared
 // infrastructure for the unified bash tool (see tool_bash.go). The former
@@ -44,6 +53,7 @@ type shellExecutionResult struct {
 	WorkspaceRevision   string                  `json:"workspace_revision"`
 	StdoutTailTruncated bool                    `json:"stdout_tail_truncated"`
 	StderrTailTruncated bool                    `json:"stderr_tail_truncated"`
+	PromotedProcessID   string                  `json:"promoted_process_id,omitempty"`
 	FullLogRef          string                  `json:"full_log_ref,omitempty"`
 	FullLogBytes        int                     `json:"full_log_bytes,omitempty"`
 	FullLogError        string                  `json:"full_log_error,omitempty"`
@@ -145,24 +155,79 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Tee output into a reserved managed log from the start so a timeout can
+	// promote the run to a background process with both past and future
+	// output available through the background read path.
+	var logf *os.File
+	reservedID := ""
+	mgr, mgrErr := env.ProcessManager()
+	if mgrErr == nil && mgr != nil {
+		if id, logPath := mgr.ReserveProcessLog(); id != "" {
+			if f, openErr := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644); openErr == nil {
+				reservedID, logf = id, f
+			}
+		}
+	}
+	if logf != nil {
+		cmd.Stdout = io.MultiWriter(&stdout, logf)
+		cmd.Stderr = io.MultiWriter(&stderr, logf)
+	} else {
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+	}
+	discardReservedLog := func() {
+		if logf == nil {
+			return
+		}
+		_ = logf.Close()
+		_ = os.Remove(logf.Name())
+	}
 
 	startedAt := time.Now()
 	handle, err := proc.StartCommand(cmd)
 	if err != nil {
+		discardReservedLog()
 		return shellExecutionResult{}, fmt.Errorf("run command: %w", err)
 	}
 	interrupted := false
+	promotedID := ""
 	select {
 	case <-handle.Done():
 		err = handle.Wait()
 	case <-runCtx.Done():
 		interrupted = true
-		if stopErr := handle.Stop(proc.DefaultStopGracePeriod); stopErr != nil {
-			return shellExecutionResult{}, fmt.Errorf("stop command: %w", stopErr)
+		// A genuine timeout (not a caller cancellation) promotes the command
+		// to a managed background process instead of killing it: the result
+		// gates nothing further this turn, and completion arrives as a
+		// notification later. The default recheck replaces the kill safety
+		// net the timeout used to be — a promoted command is an underestimate
+		// by definition, so something should look at it periodically.
+		if logf != nil && errors.Is(runCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			adopted, adoptErr := mgr.Adopt(reservedID, cmd, handle, logf, proc.AdoptOptions{
+				Command:        command,
+				CWD:            workDir,
+				OwnerKind:      proc.OwnerKind(defaultProcessOwnerKind(env, "")),
+				OwnerID:        defaultProcessOwnerID(env),
+				StartedAt:      startedAt,
+				RecheckMinutes: defaultPromotedRecheckMinutes,
+			})
+			if adoptErr == nil {
+				promotedID = adopted.ID
+			}
 		}
-		err = handle.Wait()
+		if promotedID == "" {
+			if stopErr := handle.Stop(proc.DefaultStopGracePeriod); stopErr != nil {
+				discardReservedLog()
+				return shellExecutionResult{}, fmt.Errorf("stop command: %w", stopErr)
+			}
+			err = handle.Wait()
+		}
+	}
+	if promotedID != "" {
+		// The manager owns the log and the wait from here.
+		logf = nil
+	} else {
+		discardReservedLog()
 	}
 	durationMS := time.Since(startedAt).Milliseconds()
 	exitCode := 0
@@ -189,6 +254,14 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 	classification := classifyShellCommand(command)
 	timedOut := interrupted && errors.Is(runCtx.Err(), context.DeadlineExceeded)
 
+	nextSuggestions := shellNextSuggestions(exitCode, timedOut, classification)
+	if promotedID != "" {
+		nextSuggestions = []string{
+			"the command exceeded its timeout and keeps running as background process " + promotedID + " with its output so far attached; do NOT rerun the same command — its completion will start a new turn automatically",
+			"progress wake-ups are scheduled every " + strconv.Itoa(defaultPromotedRecheckMinutes) + " minutes as a safety net; use bash action=read_background with process_id for a snapshot, stop_background to cancel it, or update_background with recheck_minutes to change or clear the schedule",
+		}
+	}
+
 	return shellExecutionResult{
 		Action:              "run",
 		Command:             redactedCommand,
@@ -205,7 +278,8 @@ func executeShellCommandInDir(ctx context.Context, env *Env, command string, tim
 		WorkspaceRevision:   workspaceRevision(ctx, env.RevisionRoot(ctx)),
 		StdoutTailTruncated: stdoutTailTruncated,
 		StderrTailTruncated: stderrTailTruncated,
-		NextSuggestions:     shellNextSuggestions(exitCode, timedOut, classification),
+		PromotedProcessID:   promotedID,
+		NextSuggestions:     nextSuggestions,
 		redactedStdout:      redactedStdout,
 		redactedStderr:      redactedStderr,
 	}, nil

--- a/internal/tools/tool_shell_process_test.go
+++ b/internal/tools/tool_shell_process_test.go
@@ -93,6 +93,19 @@ while :; do sleep 1; done
 	if got.result.ExitCode == 0 {
 		t.Fatal("timed-out command was reported as successful")
 	}
+	// A timeout no longer kills the tree outright: the run is promoted to a
+	// managed background process with its output so far. Stopping that
+	// process must still take the whole tree down.
+	if got.result.PromotedProcessID == "" {
+		t.Fatal("timed-out command should be promoted to a background process")
+	}
+	mgr, err := (&Env{RootDir: root}).ProcessManager()
+	if err != nil {
+		t.Fatalf("process manager: %v", err)
+	}
+	if _, err := mgr.Stop(got.result.PromotedProcessID); err != nil {
+		t.Fatalf("stop promoted process: %v", err)
+	}
 	waitForShellTestProcessExit(t, descendantPID)
 }
 


### PR DESCRIPTION
## 背景

慢任务（无代理下载安装包）在旧设计里是盲区：后台进程只在退出时投递完成通知，期间模型没有合法的"看进度"方式——read_background 被文案限定为 readiness-only，stall / 长跑任务完全没有机制。

## 设计

参照 kimi-code v2 的"有界等待经济"（codex 的纯轮询式不适合桌面常驻 turn 模型——它的进程退出甚至不注入模型上下文）。不变式：**等待必须有界、有通知兜底、走指定原语而非自造循环**。

- **read_background = 有界事件驱动等待 + 快照**：wait_ms 上限放宽到 300s；有新输出或进程退出提前返回；5s min-dwell 限速（持续输出的进程每次返回至少驻留 5s，返回频率被结构性封顶）；话痨 / 超时返回携带 next_suggestions，在教学现场引导到快照或 recheck。
- **recheck_minutes 声明式复查**：start_background / 新增 update_background 参数；持久化在 process record，manager 调度器到点触发，完成自动取消（调度器惰性清理，终态进程不残留日程），重启后经既有 reconcile 路径重建；投递复用 completion 的 synthetic-turn 通道（completion 取代排队中的 recheck；入队即标记送达——周期性提示丢了下个周期自愈，所以不需要 completion 那套应答落定才标记的重型语义）。
- **前台超时自动转后台**：run 超时不再杀进程——输出从一开始就 tee 进 manager 日志，超时时 Manager.Adopt 把在跑命令提升为受管后台进程（返回 promoted_process_id + 已捕获输出）。promoted 进程默认携带 30 分钟 recheck 作为安全网，替代原来的"超时即杀"语义（dev server 走 start_background，不受影响）；stop_background 照常终止整棵进程树。

## 教学（工具描述）

- 别 wait 本 turn 刚启动的任务——结果挡路就该用 action=run 前台跑；
- wait 超时后不要立刻再 wait——干别的或结束 turn；
- 非阻塞快照永远合法；
- 长沉默任务（下载、备份）用 recheck_minutes 让进度按日程找上门。

## 测试

- process 包 +7：min-dwell 限速 / 退出即返、SetRecheck 校验、调度器触发-推进-送达、终态自动清理、Adopt 自然退出携带 completion 义务、Adopt 可 Stop；
- tools 包 +5：suggestions 纯函数分支、update_background 校验 / 生命周期、非法 recheck 拒绝、run 超时提升集成（含安全网 recheck 与 stop 断言）；
- 更新 2 个钉住旧契约的测试（description 文案；超时杀树 → 超时提升 + stop 杀树）；
- go vet / gofmt / go build ./... 全绿；process + tools + appserver 三包回归全绿。

## 已知边界

- promoted 之后 stdout buffer 仍随 MultiWriter 增长——run 路径不走 tty，命令通常安静，风险低；
- appserver 的 recheck 入队去重无独立单测（与 completion 入队同级，后者同样没有）。
