### PR TITLE
feat(workspace): focus composer on active document

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -30,6 +30,7 @@ import type {
   ActivityListResult,
   ActivityReleaseResult,
   ActivitySession,
+  ActiveDocumentContext,
   CoreBuildInfo,
   DesktopBuildInfo,
   InputFile,
@@ -1675,6 +1676,7 @@ app.whenReady().then(async () => {
       images?: InputImage[],
       files?: InputFile[],
       permissionMode?: string,
+      activeDocument?: ActiveDocumentContext,
     ) =>
       appServerRequest<{ turn: Turn }>(event, "turn/start", {
         thread_id: threadId,
@@ -1682,6 +1684,7 @@ app.whenReady().then(async () => {
         images: images ?? [],
         files: files ?? [],
         ...(permissionMode === undefined ? {} : { permission_mode: permissionMode }),
+        ...(activeDocument === undefined ? {} : { active_document: activeDocument }),
       }),
   );
   ipcMain.handle(
@@ -1694,6 +1697,7 @@ app.whenReady().then(async () => {
       clientId?: string,
       files?: InputFile[],
       permissionMode?: string,
+      activeDocument?: ActiveDocumentContext,
     ) =>
       appServerRequest(event, "turn/queue", {
         thread_id: threadId,
@@ -1702,6 +1706,7 @@ app.whenReady().then(async () => {
         files: files ?? [],
         client_id: clientId,
         ...(permissionMode === undefined ? {} : { permission_mode: permissionMode }),
+        ...(activeDocument === undefined ? {} : { active_document: activeDocument }),
       }),
   );
   ipcMain.handle(
@@ -1740,6 +1745,7 @@ app.whenReady().then(async () => {
       images?: InputImage[],
       clientId?: string,
       files?: InputFile[],
+      activeDocument?: ActiveDocumentContext,
     ) =>
       appServerRequest(event, "turn/steer", {
         thread_id: threadId,
@@ -1748,6 +1754,7 @@ app.whenReady().then(async () => {
         images: images ?? [],
         files: files ?? [],
         client_id: clientId,
+        ...(activeDocument === undefined ? {} : { active_document: activeDocument }),
       }),
   );
   ipcMain.handle("wuu:turn-unsteer", (event, threadId: string, steerId: string) =>

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -359,15 +359,15 @@ const api: WuuDesktopApi = {
     ipcRenderer.invoke("wuu:file-show-in-folder", path),
   openExternal: (url: string) =>
     ipcRenderer.invoke("wuu:open-external", url),
-  startTurn: (threadId: string, prompt: string, images, files, permissionMode) =>
-    ipcRenderer.invoke("wuu:turn-start", threadId, prompt, images, files, permissionMode),
-  queueTurn: (threadId: string, prompt: string, images, clientId, files, permissionMode) =>
-    ipcRenderer.invoke("wuu:turn-queue", threadId, prompt, images, clientId, files, permissionMode),
+  startTurn: (threadId: string, prompt: string, images, files, permissionMode, activeDocument) =>
+    ipcRenderer.invoke("wuu:turn-start", threadId, prompt, images, files, permissionMode, activeDocument),
+  queueTurn: (threadId: string, prompt: string, images, clientId, files, permissionMode, activeDocument) =>
+    ipcRenderer.invoke("wuu:turn-queue", threadId, prompt, images, clientId, files, permissionMode, activeDocument),
   updateQueuedTurn: (threadId: string, queueId: string, prompt: string, images, files) =>
     ipcRenderer.invoke("wuu:turn-update-queued", threadId, queueId, prompt, images, files),
   dequeueTurn: (threadId: string, queueId: string) =>
     ipcRenderer.invoke("wuu:turn-dequeue", threadId, queueId),
-  steerTurn: (threadId: string, expectedTurnId: string, prompt: string, images, clientId, files) =>
+  steerTurn: (threadId: string, expectedTurnId: string, prompt: string, images, clientId, files, activeDocument) =>
     ipcRenderer.invoke(
       "wuu:turn-steer",
       threadId,
@@ -376,6 +376,7 @@ const api: WuuDesktopApi = {
       images,
       clientId,
       files,
+      activeDocument,
     ),
   unsteerTurn: (threadId: string, steerId: string) =>
     ipcRenderer.invoke("wuu:turn-unsteer", threadId, steerId),

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2890,7 +2890,11 @@ export function App(): JSX.Element {
     if (viewSwitchPending) {
       return;
     }
-    const message = createComposerMessage(prompt, composerImages, composerFiles);
+    const draftMessage = createComposerMessage(prompt, composerImages, composerFiles);
+    const message =
+      draftMessage && activeWorkspaceFile
+        ? { ...draftMessage, activeDocument: { path: activeWorkspaceFile } }
+        : draftMessage;
     const currentState = appStateRef.current;
     const targetThread = activeThreadForState(currentState);
     if (targetThread?.read_only) {
@@ -3118,6 +3122,7 @@ export function App(): JSX.Element {
         message.id,
         files,
         targetThread.permission_mode || currentState.initialized.permissions?.mode,
+        message.activeDocument,
       );
       enqueueComposerMessage(targetThread.id, {
         ...message,
@@ -3163,6 +3168,7 @@ export function App(): JSX.Element {
         inputImagesFromComposer(encodedImages),
         message.id,
         files,
+        message.activeDocument,
       );
       updateThreadPendingComposerMessages(targetThread.id, (previous) => ({
         ...previous,
@@ -3310,6 +3316,7 @@ export function App(): JSX.Element {
         images,
         files,
         thread.permission_mode || currentState.initialized.permissions?.mode,
+        message.activeDocument,
       );
       setState((current) =>
         updateThreadByID(
@@ -3504,6 +3511,7 @@ export function App(): JSX.Element {
         images,
         files,
         targetThread.permission_mode || currentState.initialized.permissions?.mode,
+        message.activeDocument,
       );
       setState((current) =>
         updateThreadByID(
@@ -3634,6 +3642,7 @@ export function App(): JSX.Element {
         images,
         files,
         targetThread.permission_mode || currentState.initialized.permissions?.mode,
+        message.activeDocument,
       );
       setState((current) =>
         updateThreadByID(
@@ -4227,7 +4236,9 @@ export function App(): JSX.Element {
                   />
                 }
               >
-                {renderComposer("hero")}
+                {rightPanelGlobalized && activeWorkspaceFileTabID
+                  ? <div />
+                  : renderComposer("hero")}
               </EmptyConversationHome>
             ) : (
               <CachedConversationPanes
@@ -4365,6 +4376,14 @@ export function App(): JSX.Element {
           onBrowserActivityTakeover={() => void takeoverBrowserActivity()}
           onBrowserActivityRelease={() => void releaseBrowserActivity()}
           onBrowserActivityStop={() => void stopBrowserActivity()}
+          focusedComposer={
+            rightPanelGlobalized && activeWorkspaceFileTabID
+              ? renderComposer("dock")
+              : undefined
+          }
+          fileRefreshKey={
+            activeThreadIsRunning ? "running" : activeThread?.updated_at
+          }
         />
       )}
       {environmentDialog === "commit" ? (

--- a/desktop/src/renderer/AppWorkspaceFileTabs.test.tsx
+++ b/desktop/src/renderer/AppWorkspaceFileTabs.test.tsx
@@ -41,6 +41,7 @@ import { RIGHT_PANEL_MOTION_MS } from "./AppLayoutState";
 let container: HTMLDivElement;
 let root: Root | null = null;
 let serverEventHandlers: Array<(event: ServerEvent) => void> = [];
+let startTurnMock: ReturnType<typeof vi.fn>;
 const originalInnerWidth = window.innerWidth;
 
 const workspace = "/tmp/wuu-artifact-tab-test";
@@ -126,6 +127,7 @@ function installWindowStubs(): void {
 
 function installWuuApi(): void {
   const thread = completedThread();
+  startTurnMock = vi.fn().mockResolvedValue({ turn: thread.turns[0] });
   const api = {
     listProjects: vi.fn().mockResolvedValue({
       projects: [],
@@ -139,6 +141,7 @@ function installWuuApi(): void {
     listThreads: vi.fn().mockResolvedValue({ threads: [thread] }),
     listArchivedThreads: vi.fn().mockResolvedValue({ threads: [] }),
     resumeThread: vi.fn().mockResolvedValue({ thread }),
+    startTurn: startTurnMock,
     getActiveGoalSummary: vi.fn().mockResolvedValue(null),
     gitStatus: vi.fn().mockResolvedValue({
       is_repo: false,
@@ -272,11 +275,39 @@ describe("workspace file tabs", () => {
     expect(container.querySelector(".conversation-pane")?.hasAttribute("inert")).toBe(true);
     expect(container.querySelector(".sidebar")?.hasAttribute("inert")).toBe(true);
     expect(container.querySelector(".workspace-right-panel")?.hasAttribute("inert")).toBe(false);
+    expect(container.querySelector('[data-testid="workspace-document-composer"]')).not.toBeNull();
+    expect(container.querySelectorAll("[data-main-conversation-composer]")).toHaveLength(1);
     expect(
       container.querySelector('[data-testid="jump-to-latest-probe"]'),
     ).toBeNull();
     expect(document.activeElement).toBe(
       container.querySelector(".workspace-tool-tab.active .workspace-tool-tab-main"),
+    );
+
+    const focusedTextarea = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="workspace-document-composer"] textarea',
+    );
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    await act(async () => {
+      valueSetter?.call(focusedTextarea, "Rewrite the weak section.");
+      focusedTextarea?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      focusedTextarea?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await flushAsync();
+    expect(startTurnMock).toHaveBeenCalledWith(
+      "thread-artifact-tabs",
+      "Rewrite the weak section.",
+      [],
+      [],
+      "standard",
+      { path: "README.md" },
     );
 
     act(() => {
@@ -290,7 +321,48 @@ describe("workspace file tabs", () => {
     expect(shell?.classList.contains("right-panel-animating")).toBe(true);
     expect(container.querySelector(".conversation-pane")?.hasAttribute("inert")).toBe(false);
     expect(container.querySelector(".sidebar")?.hasAttribute("inert")).toBe(false);
+    expect(container.querySelector('[data-testid="workspace-document-composer"]')).toBeNull();
     expect(document.activeElement).toBe(fileLink);
+  });
+
+  it("mounts only the focused composer for an empty conversation", async () => {
+    installWuuApi();
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+    await flushAsync();
+
+    vi.useFakeTimers();
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(".rich-file-link")?.click();
+    });
+    await flushAsync();
+    act(() => {
+      vi.advanceTimersByTime(RIGHT_PANEL_MOTION_MS);
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="展开为全面板"]')?.click();
+    });
+    await flushAsync();
+
+    const emptyThread = { ...completedThread(), turns: [] };
+    await act(async () => {
+      for (const handler of serverEventHandlers) {
+        handler({
+          kind: "notification",
+          workdir: workspace,
+          message: {
+            method: "thread/updated",
+            params: { thread: emptyThread },
+          },
+        } as ServerEvent);
+      }
+    });
+    await flushAsync();
+
+    expect(container.querySelector('[data-testid="workspace-document-composer"]')).not.toBeNull();
+    expect(container.querySelectorAll("[data-main-conversation-composer]")).toHaveLength(1);
   });
 
   it("focuses the workspace automatically when a compact window cannot keep conversation usable", async () => {

--- a/desktop/src/renderer/ComposerMessages.ts
+++ b/desktop/src/renderer/ComposerMessages.ts
@@ -1,5 +1,5 @@
 import type { ClipboardEvent as ReactClipboardEvent } from "react";
-import type { InputFile, InputImage, Turn } from "../shared/protocol";
+import type { ActiveDocumentContext, InputFile, InputImage, Turn } from "../shared/protocol";
 import { formatCurrentNumber, translateCurrent } from "./i18n";
 
 // Renderer-side image compression runs on the Electron canvas before the
@@ -71,6 +71,7 @@ export type QueuedComposerMessage = {
   text: string;
   images: ComposerImage[];
   files: ComposerFile[];
+  activeDocument?: ActiveDocumentContext;
   held?: boolean;
   heldPosition?: number;
   origin?: "queue" | "steer";
@@ -393,6 +394,7 @@ export function inputFilesFromComposer(files: ComposerFile[]): InputFile[] {
 }
 
 export function mergeGuideMessages(messages: QueuedComposerMessage[]): QueuedComposerMessage {
+  const latestActiveDocument = messages[messages.length - 1]?.activeDocument;
   return {
     id: nextComposerMessageID(),
     text: messages
@@ -400,7 +402,8 @@ export function mergeGuideMessages(messages: QueuedComposerMessage[]): QueuedCom
       .filter(Boolean)
       .join("\n"),
     images: messages.flatMap((message) => message.images.map((image) => ({ ...image }))),
-    files: messages.flatMap((message) => message.files.map((file) => ({ ...file })))
+    files: messages.flatMap((message) => message.files.map((file) => ({ ...file }))),
+    activeDocument: latestActiveDocument ? { ...latestActiveDocument } : undefined,
   };
 }
 

--- a/desktop/src/renderer/ComposerPendingState.test.tsx
+++ b/desktop/src/renderer/ComposerPendingState.test.tsx
@@ -322,6 +322,7 @@ describe("useComposerPendingState", () => {
       [{ media_type: "image/png", data: "aW1hZ2U=" }],
       "queue-1",
       [],
+      undefined,
     );
     expect(
       hook
@@ -351,6 +352,40 @@ describe("useComposerPendingState", () => {
         .get()
         .pendingComposerMessagesByThread["thread-a"]?.queued.map((item) => item.id),
     ).toEqual(["queue-2"]);
+  });
+
+  it("keeps a queued document snapshot when converting it to a steer", async () => {
+    const steerTurn = vi.fn().mockResolvedValue({ turn_id: "turn-running" });
+    installWuuStub({ steerTurn });
+    const runningThread = thread("thread-a", true);
+    const hook = await renderComposerPendingState({
+      appState: {
+        ...initialState,
+        thread: runningThread,
+        threads: [runningThread],
+      },
+    });
+    const queued = {
+      ...message("queue-1", "Revise it"),
+      activeDocument: { path: "docs/plan.md" },
+    };
+
+    act(() => {
+      hook.get().enqueueComposerMessage("thread-a", queued);
+    });
+    await act(async () => {
+      await hook.get().guideQueuedMessage("queue-1");
+    });
+
+    expect(steerTurn).toHaveBeenCalledWith(
+      "thread-a",
+      "turn-running",
+      "Revise it",
+      [],
+      "queue-1",
+      [],
+      { path: "docs/plan.md" },
+    );
   });
 
   it("restores a queued message into the primary composer for editing", async () => {

--- a/desktop/src/renderer/ComposerPendingState.ts
+++ b/desktop/src/renderer/ComposerPendingState.ts
@@ -481,6 +481,7 @@ export function useComposerPendingState({
         inputImagesFromComposer(target.message.images),
         target.message.id,
         files,
+        target.message.activeDocument,
       );
       updateThreadPendingComposerMessages(target.threadID, (previous) => ({
         queued: previous.queued.filter((message) => message.id !== id),

--- a/desktop/src/renderer/WorkspaceFiles.test.tsx
+++ b/desktop/src/renderer/WorkspaceFiles.test.tsx
@@ -403,6 +403,45 @@ describe("WorkspaceFileTree", () => {
     expect(container.textContent).toContain("button code");
   });
 
+  it("refreshes an open file without clearing the current preview", async () => {
+    await render(
+      <WorkspaceFilePreview
+        activeContext={activeContext}
+        selectedFilePath="/repo/src/components/Button.tsx"
+        refreshKey="running"
+        onOpenRightPanel={() => {}}
+      />,
+    );
+    await settleDirectoryLoads();
+
+    let finishRefresh: ((result: WorkspaceFileReadResult) => void) | undefined;
+    readWorkspaceFile.mockImplementationOnce(
+      () => new Promise<WorkspaceFileReadResult>((resolve) => {
+        finishRefresh = resolve;
+      }),
+    );
+    await render(
+      <WorkspaceFilePreview
+        activeContext={activeContext}
+        selectedFilePath="/repo/src/components/Button.tsx"
+        refreshKey="completed"
+        onOpenRightPanel={() => {}}
+      />,
+    );
+
+    expect(container.textContent).toContain("button code");
+
+    await act(async () => {
+      finishRefresh?.(workspaceFile({
+        path: "src/components/Button.tsx",
+        absolute_path: "/repo/src/components/Button.tsx",
+        text: "updated button code",
+      }));
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("updated button code");
+  });
+
   it("opens selected non-Markdown text files in the center Monaco editor surface", async () => {
     readWorkspaceFile.mockResolvedValueOnce({
       root: "/repo",

--- a/desktop/src/renderer/WorkspaceFiles.tsx
+++ b/desktop/src/renderer/WorkspaceFiles.tsx
@@ -532,6 +532,7 @@ export function WorkspaceFilePreview({
   selectedFilePath,
   selection,
   anchor,
+  refreshKey,
   onOpenRightPanel,
   onOpenFile,
   onDirtyChange
@@ -542,6 +543,7 @@ export function WorkspaceFilePreview({
   selectedFilePath?: string;
   selection?: WorkspaceFileSelection;
   anchor?: string;
+  refreshKey?: string;
   onOpenRightPanel: () => void;
   onOpenFile?: (path: string) => void;
   onDirtyChange?: (state: WorkspaceFileDirtyState) => void;
@@ -552,6 +554,7 @@ export function WorkspaceFilePreview({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
   const editorViewStateRef = useRef<WorkspaceMonacoViewState | null>(null);
+  const loadedFileKeyRef = useRef<string | undefined>(undefined);
   const markdownHostRef = useRef<HTMLDivElement>(null);
   const selectedWorkspaceFilePath = useMemo(
     () => normalizeSelectedWorkspaceFilePath(selectedFilePath, activeContext?.cwd),
@@ -568,15 +571,20 @@ export function WorkspaceFilePreview({
     }
 
     let cancelled = false;
-    editorViewStateRef.current = null;
-    setFile(undefined);
-    setDraftText("");
-    setLoading(true);
+    const fileKey = `${activeContext?.cwd ?? ""}\n${selectedWorkspaceFilePath}`;
+    const refreshing = loadedFileKeyRef.current === fileKey;
+    if (!refreshing) {
+      editorViewStateRef.current = null;
+      setFile(undefined);
+      setDraftText("");
+      setLoading(true);
+    }
     setError(undefined);
     void window.wuu
       .readWorkspaceFile(selectedWorkspaceFilePath, activeContext?.cwd)
       .then((result) => {
         if (!cancelled) {
+          loadedFileKeyRef.current = fileKey;
           setFile(result);
           setDraftText(result.text ?? "");
         }
@@ -595,7 +603,7 @@ export function WorkspaceFilePreview({
     return () => {
       cancelled = true;
     };
-  }, [activeContext?.cwd, selectedWorkspaceFilePath, locale]);
+  }, [activeContext?.cwd, selectedWorkspaceFilePath, locale, refreshKey]);
 
   const isMarkdown = Boolean(file && isMarkdownPath(file.path));
   const isMarkdownReadingMode = isMarkdown && !selection;

--- a/desktop/src/renderer/WorkspacePanels.tsx
+++ b/desktop/src/renderer/WorkspacePanels.tsx
@@ -2,6 +2,7 @@ import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useRef,
@@ -137,6 +138,8 @@ export function WorkspaceRightPanel({
   onBrowserActivityTakeover,
   onBrowserActivityRelease,
   onBrowserActivityStop,
+  focusedComposer,
+  fileRefreshKey,
 }: {
   open: boolean;
   present: boolean;
@@ -174,6 +177,8 @@ export function WorkspaceRightPanel({
   onBrowserActivityTakeover?: () => void;
   onBrowserActivityRelease?: () => void;
   onBrowserActivityStop?: () => void;
+  focusedComposer?: ReactNode;
+  fileRefreshKey?: string;
 }): JSX.Element {
   const { t } = useI18n();
   const activeTab = activeTabID ? tabs.find((tab) => tab.id === activeTabID) : undefined;
@@ -382,7 +387,7 @@ export function WorkspaceRightPanel({
 
   return (
     <aside
-      className={`workspace-right-panel${activeTab ? " detail" : " tools"}${activeTab?.kind === "review" ? " review" : ""}${activeTab?.kind === "diff" ? " diff" : ""}${activeTab?.kind === "files" || activeTab?.kind === "file" ? " files" : ""}${activeTab?.kind === "terminal" ? " terminal" : ""}`}
+      className={`workspace-right-panel${activeTab ? " detail" : " tools"}${activeTab?.kind === "review" ? " review" : ""}${activeTab?.kind === "diff" ? " diff" : ""}${activeTab?.kind === "files" || activeTab?.kind === "file" ? " files" : ""}${activeTab?.kind === "terminal" ? " terminal" : ""}${focusedComposer && activeTab?.kind === "file" ? " document-focus" : ""}`}
       data-sheet={
         sheetPhase === "exiting"
           ? "parked"
@@ -548,6 +553,11 @@ export function WorkspaceRightPanel({
                       onDirtyChange={updateFileDirtyState}
                       onOpenFile={onOpenFile}
                       tab={tab}
+                      refreshKey={
+                        open && activeTab?.kind === "file" && tab.id === activeFileTabID
+                          ? fileRefreshKey
+                          : undefined
+                      }
                     />
                   ))}
                   {activeTab?.kind === "files" ? (
@@ -619,6 +629,11 @@ export function WorkspaceRightPanel({
           </div>
         </>
       ) : null}
+      {focusedComposer && activeTab?.kind === "file" ? (
+        <div className="workspace-document-composer" data-testid="workspace-document-composer">
+          {focusedComposer}
+        </div>
+      ) : null}
     </aside>
   );
 }
@@ -628,11 +643,13 @@ function WorkspaceFileResource({
   onDirtyChange,
   onOpenFile,
   tab,
+  refreshKey,
 }: {
   active: boolean;
   onDirtyChange: (tabID: string, dirty: boolean) => void;
   onOpenFile: (path: string) => void;
   tab: WorkspaceFileViewTab;
+  refreshKey?: string;
 }): JSX.Element {
   const handleDirtyChange = useCallback(
     (state: WorkspaceFileDirtyState) => onDirtyChange(tab.id, state.dirty),
@@ -659,6 +676,7 @@ function WorkspaceFileResource({
         anchor={tab.anchor}
         editorResourceID={tab.id}
         selection={tab.selection}
+        refreshKey={refreshKey}
         selectedFilePath={tab.path}
         onOpenRightPanel={() => {}}
         onOpenFile={handleOpenFile}

--- a/desktop/src/renderer/styles/workspace.css
+++ b/desktop/src/renderer/styles/workspace.css
@@ -796,6 +796,45 @@ html.resizing-workspace-file-split * {
   min-height: 0;
 }
 
+.workspace-document-composer {
+  position: absolute;
+  z-index: 8;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 0 clamp(20px, 4vw, 72px) 24px;
+  pointer-events: none;
+}
+
+.workspace-document-composer .dock-composer-wrap {
+  display: block;
+  padding: 0;
+  background: transparent;
+}
+
+.workspace-document-composer .dock-composer-wrap::before {
+  display: none;
+}
+
+.workspace-document-composer .dock-composer-wrap .composer-stack {
+  transform: none;
+}
+
+.workspace-document-composer .composer-frame {
+  box-shadow:
+    0 18px 54px rgba(20, 24, 28, 0.14),
+    0 2px 10px rgba(20, 24, 28, 0.08);
+}
+
+.workspace-right-panel.document-focus .workspace-file-code-scroll,
+.workspace-right-panel.document-focus .workspace-file-editor-scroll.markdown-reading {
+  scroll-padding-bottom: 180px;
+}
+
+.workspace-right-panel.document-focus .workspace-markdown-reading {
+  padding-bottom: 180px;
+}
+
 .workspace-tool-menu {
   display: grid;
   height: 100%;

--- a/internal/appserver/active_document_context_test.go
+++ b/internal/appserver/active_document_context_test.go
@@ -1,0 +1,111 @@
+package appserver
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/blueberrycongee/wuu/internal/agent"
+	wuucontext "github.com/blueberrycongee/wuu/internal/context"
+)
+
+func TestActiveDocumentRequestContext(t *testing.T) {
+	if got := activeDocumentRequestContext(nil); got != nil {
+		t.Fatalf("nil document context = %#v, want nil", got)
+	}
+	if got := activeDocumentRequestContext(&ActiveDocument{Path: "  "}); got != nil {
+		t.Fatalf("blank document context = %#v, want nil", got)
+	}
+
+	segments := activeDocumentRequestContext(&ActiveDocument{Path: " docs/plan.md "})
+	if len(segments) != 1 {
+		t.Fatalf("segments = %d, want 1", len(segments))
+	}
+	segment := segments[0]
+	if segment.Lifecycle != agent.ContextSegmentRequestOnly || segment.Durable || segment.VisibleInUI {
+		t.Fatalf("document context lifecycle = %+v, want hidden request-only", segment)
+	}
+	if len(segment.Blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(segment.Blocks))
+	}
+	block := segment.Blocks[0]
+	if block.Kind != wuucontext.BlockActiveFiles || block.Source != "desktop.document_focus" {
+		t.Fatalf("block identity = %+v", block)
+	}
+	if !strings.Contains(block.Content, `"docs/plan.md"`) {
+		t.Fatalf("block content %q does not identify the active document", block.Content)
+	}
+}
+
+func TestActiveDocumentContextForTurnUsesLatestSteerSnapshot(t *testing.T) {
+	base := append(
+		agent.RequestOnlyContextBlocks([]wuucontext.Block{{
+			Kind: wuucontext.BlockTaskState, Source: "test.task_state", Content: "keep me",
+		}}),
+		activeDocumentRequestContext(&ActiveDocument{Path: "docs/original.md"})...,
+	)
+	overridden := activeDocumentContextForTurn(base, true, &ActiveDocument{Path: "docs/latest.md"})
+	if len(overridden) != 2 || !strings.Contains(overridden[1].Blocks[0].Content, `"docs/latest.md"`) {
+		t.Fatalf("overridden context = %#v, want latest steer document", overridden)
+	}
+	if overridden[0].Blocks[0].Source != "test.task_state" {
+		t.Fatalf("overridden context dropped non-document segment: %#v", overridden)
+	}
+	if strings.Contains(overridden[1].Blocks[0].Content, "original.md") {
+		t.Fatalf("overridden context retained original document: %#v", overridden)
+	}
+	if cleared := activeDocumentContextForTurn(base, true, nil); len(cleared) != 1 || cleared[0].Blocks[0].Source != "test.task_state" {
+		t.Fatalf("cleared context = %#v, want only non-document context", cleared)
+	}
+	retained := activeDocumentContextForTurn(base, false, nil)
+	if len(retained) != 2 || !strings.Contains(retained[1].Blocks[0].Content, `"docs/original.md"`) {
+		t.Fatalf("retained context = %#v, want original turn context", retained)
+	}
+}
+
+func TestReleaseTurnExecutionClearsSteerDocumentSnapshot(t *testing.T) {
+	th := &threadState{
+		currentTurn:           "turn-1",
+		activeSteerDocument:   &ActiveDocument{Path: "docs/latest.md"},
+		activeSteerContextSet: true,
+	}
+
+	th.releaseTurnExecutionLocked("turn-1")
+
+	if th.activeSteerDocument != nil || th.activeSteerContextSet {
+		t.Fatalf(
+			"steer document state survived turn release: document=%#v set=%t",
+			th.activeSteerDocument,
+			th.activeSteerContextSet,
+		)
+	}
+}
+
+func TestRemovingSteerDocumentOverrideRestoresPreviousSnapshot(t *testing.T) {
+	th := &threadState{steerDocumentOverrides: []activeDocumentOverride{
+		{steerID: "steer-1", document: &ActiveDocument{Path: "docs/first.md"}},
+		{steerID: "steer-2", document: &ActiveDocument{Path: "docs/latest.md"}},
+	}}
+	th.applyLatestSteerDocumentOverrideLocked()
+
+	th.removeSteerDocumentOverrideLocked("steer-2")
+
+	if !th.activeSteerContextSet || th.activeSteerDocument == nil || th.activeSteerDocument.Path != "docs/first.md" {
+		t.Fatalf("active steer document = %#v, want previous snapshot", th.activeSteerDocument)
+	}
+	th.removeSteerDocumentOverrideLocked("steer-1")
+	if th.activeSteerContextSet || th.activeSteerDocument != nil {
+		t.Fatalf("active steer document survived final unsteer: %#v", th.activeSteerDocument)
+	}
+}
+
+func TestQueuedDocumentSnapshotDoesNotPersistRequestContextBlock(t *testing.T) {
+	snapshot := turnRuntimeSnapshot{ActiveDocument: &ActiveDocument{Path: "docs/queued.md"}}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "desktop.document_focus") || strings.Contains(string(encoded), "ACTIVE_FILES") {
+		t.Fatalf("queued snapshot persisted request-only context block: %s", encoded)
+	}
+}

--- a/internal/appserver/model.go
+++ b/internal/appserver/model.go
@@ -356,6 +356,9 @@ func (th *threadState) releaseTurnExecutionLocked(turnID string) {
 	th.runningProviderName = ""
 	th.runningModel = ""
 	th.cancel = nil
+	th.activeSteerDocument = nil
+	th.activeSteerContextSet = false
+	th.steerDocumentOverrides = nil
 }
 
 func applyTokenUsageToTurn(turn *Turn, usage providers.TokenUsage, contextTokens int, model string) {

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -1362,6 +1362,11 @@ type TurnStartParams struct {
 	Images         []TurnStartImage `json:"images,omitempty"`
 	Files          []TurnStartFile  `json:"files,omitempty"`
 	PermissionMode *string          `json:"permission_mode,omitempty"`
+	ActiveDocument *ActiveDocument  `json:"active_document,omitempty"`
+}
+
+type ActiveDocument struct {
+	Path string `json:"path"`
 }
 
 type TurnStartImage struct {
@@ -1439,6 +1444,7 @@ type TurnQueueParams struct {
 	Files          []TurnStartFile  `json:"files,omitempty"`
 	ClientID       string           `json:"client_id,omitempty"`
 	PermissionMode *string          `json:"permission_mode,omitempty"`
+	ActiveDocument *ActiveDocument  `json:"active_document,omitempty"`
 }
 
 type QueuedTurn struct {
@@ -1478,6 +1484,7 @@ type TurnSteerParams struct {
 	Files          []TurnStartFile  `json:"files,omitempty"`
 	ExpectedTurnID string           `json:"expected_turn_id"`
 	ClientID       string           `json:"client_id,omitempty"`
+	ActiveDocument *ActiveDocument  `json:"active_document,omitempty"`
 }
 
 type TurnSteerResult struct {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -75,19 +75,22 @@ type threadState struct {
 	runtimeSelectionMutation bool
 	runtimeSubscription      *threadRuntimeSubscription
 
-	mu                    sync.Mutex
-	running               bool
-	currentTurn           string
-	currentTurnKind       TurnKind
-	currentExecutionRunID string
-	currentTurnResumed    bool
-	runningProviderName   string
-	runningModel          string
-	cancel                context.CancelFunc
-	executionLease        *session.ThreadExecutionLease
-	admissionReserved     bool
-	pendingSteers         []providers.ChatMessage
-	interrupting          bool
+	mu                     sync.Mutex
+	running                bool
+	currentTurn            string
+	currentTurnKind        TurnKind
+	currentExecutionRunID  string
+	currentTurnResumed     bool
+	runningProviderName    string
+	runningModel           string
+	cancel                 context.CancelFunc
+	executionLease         *session.ThreadExecutionLease
+	admissionReserved      bool
+	pendingSteers          []providers.ChatMessage
+	activeSteerDocument    *ActiveDocument
+	activeSteerContextSet  bool
+	steerDocumentOverrides []activeDocumentOverride
+	interrupting           bool
 	// Worker-tree freeze (turn/interrupt): while set, agent-completion drains
 	// hold their pending synthetic turns. The next user-initiated turn folds
 	// the whole-tree snapshot into its request (frozenTreeContext) and marks

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -117,6 +117,12 @@ type turnRuntimeSnapshot struct {
 	AutomationRunID string
 	ExecutionRunID  string
 	RequestContext  []agent.ContextSegment
+	ActiveDocument  *ActiveDocument
+}
+
+type activeDocumentOverride struct {
+	steerID  string
+	document *ActiveDocument
 }
 
 func (s *Server) handleTurnStart(ctx context.Context, req Request) error {
@@ -164,6 +170,7 @@ func (s *Server) handleTurnStart(ctx context.Context, req Request) error {
 	// The user turn snapshots the session-level Ultra setting once, at
 	// admission. Mid-turn changes affect only the next user turn.
 	snapshot.Ultra = s.rt.UltraMode()
+	snapshot.RequestContext = activeDocumentRequestContext(params.ActiveDocument)
 	var threadRuntime *runtime.ThreadRuntime
 	started, ok, err := s.startThreadUserTurnWithAdmission(
 		ctx,
@@ -439,6 +446,7 @@ func (s *Server) handleTurnQueue(req Request) error {
 	entry := queuedTurn{id: queueID, msg: msg, snapshot: turnRuntimeSnapshot{}.withPermissions(permissions), origin: session.HeldUserWorkOriginQueue}
 	entry.snapshot.PermissionExplicit = params.PermissionMode != nil
 	entry.snapshot.ForceCompact = isManualCompactPrompt(params.Prompt)
+	entry.snapshot.ActiveDocument = cloneActiveDocument(params.ActiveDocument)
 	queued := queuedTurnSummary(params.ThreadID, entry)
 	th.mu.Lock()
 	if th.interrupting {
@@ -642,9 +650,9 @@ func (s *Server) handleTurnSteer(req Request) error {
 	turnID := th.currentTurn
 	var steerMsg providers.ChatMessage
 	var remaining []queuedTurn
+	var removedTurn queuedTurn
 	if isHeld {
 		var removed bool
-		var removedTurn queuedTurn
 		removedTurn, remaining, removed, err = s.removeHeldUserTurn(params.ThreadID, clientID)
 		if err != nil {
 			th.mu.Unlock()
@@ -666,6 +674,15 @@ func (s *Server) handleTurnSteer(req Request) error {
 	steerMsg.Steered = true
 	removedQueued := s.removeQueuedUserTurn(params.ThreadID, clientID)
 	th.pendingSteers = append(th.pendingSteers, steerMsg)
+	steerDocument := params.ActiveDocument
+	if isHeld {
+		steerDocument = removedTurn.snapshot.ActiveDocument
+	}
+	th.steerDocumentOverrides = append(th.steerDocumentOverrides, activeDocumentOverride{
+		steerID:  clientID,
+		document: cloneActiveDocument(steerDocument),
+	})
+	th.applyLatestSteerDocumentOverrideLocked()
 	th.mu.Unlock()
 	if removedQueued {
 		_ = s.writeNotification(NotificationTurnDequeued, TurnDequeuedNotification{
@@ -732,6 +749,9 @@ func (s *Server) handleTurnUnsteer(req Request) error {
 	}
 	th.mu.Lock()
 	removed := th.removePendingSteerLocked(steerID)
+	if removed {
+		th.removeSteerDocumentOverrideLocked(steerID)
+	}
 	th.mu.Unlock()
 	var held []queuedTurn
 	if !removed {
@@ -1520,7 +1540,79 @@ func frozenWorkerTreeBlock(pending []agentCompletionTurn, frozen []agentcontrol.
 }
 
 func (s *Server) runTurn(ctx context.Context, th *threadState, threadRuntime *runtime.ThreadRuntime, turnID string, turnRuntime turnRuntimeSnapshot, history []providers.ChatMessage) {
-	s.runTurnWithRequestContext(ctx, th, threadRuntime, turnID, turnRuntime, history, turnRuntime.RequestContext)
+	requestContext := cloneContextSegments(turnRuntime.RequestContext)
+	requestContext = append(requestContext, activeDocumentRequestContext(turnRuntime.ActiveDocument)...)
+	s.runTurnWithRequestContext(ctx, th, threadRuntime, turnID, turnRuntime, history, requestContext)
+}
+
+func activeDocumentRequestContext(document *ActiveDocument) []agent.ContextSegment {
+	if document == nil {
+		return nil
+	}
+	path := strings.TrimSpace(document.Path)
+	if path == "" {
+		return nil
+	}
+	return agent.RequestOnlyContextBlocks([]wuucontext.Block{{
+		Kind:   wuucontext.BlockActiveFiles,
+		Title:  "Active document",
+		Source: "desktop.document_focus",
+		Content: fmt.Sprintf(
+			"The user sent this query while viewing workspace file %q. Treat it as the current document and likely edit target. Read its latest contents before making changes; do not assume the copy from earlier conversation history is current.",
+			path,
+		),
+		TokenBudget: 160,
+	}})
+}
+
+func cloneActiveDocument(document *ActiveDocument) *ActiveDocument {
+	if document == nil {
+		return nil
+	}
+	cloned := *document
+	return &cloned
+}
+
+func (th *threadState) applyLatestSteerDocumentOverrideLocked() {
+	if len(th.steerDocumentOverrides) == 0 {
+		th.activeSteerContextSet = false
+		th.activeSteerDocument = nil
+		return
+	}
+	latest := th.steerDocumentOverrides[len(th.steerDocumentOverrides)-1]
+	th.activeSteerContextSet = true
+	th.activeSteerDocument = cloneActiveDocument(latest.document)
+}
+
+func (th *threadState) removeSteerDocumentOverrideLocked(steerID string) {
+	for index := len(th.steerDocumentOverrides) - 1; index >= 0; index-- {
+		if th.steerDocumentOverrides[index].steerID != steerID {
+			continue
+		}
+		th.steerDocumentOverrides = append(
+			th.steerDocumentOverrides[:index],
+			th.steerDocumentOverrides[index+1:]...,
+		)
+		break
+	}
+	th.applyLatestSteerDocumentOverrideLocked()
+}
+
+func activeDocumentContextForTurn(base []agent.ContextSegment, overrideSet bool, document *ActiveDocument) []agent.ContextSegment {
+	context := cloneContextSegments(base)
+	if !overrideSet {
+		return context
+	}
+	filtered := context[:0]
+	for _, segment := range context {
+		if len(segment.Blocks) == 1 &&
+			segment.Blocks[0].Kind == wuucontext.BlockActiveFiles &&
+			segment.Blocks[0].Source == "desktop.document_focus" {
+			continue
+		}
+		filtered = append(filtered, segment)
+	}
+	return append(filtered, activeDocumentRequestContext(document)...)
 }
 
 func turnRuntimeSnapshotLocked(th *threadState) turnRuntimeSnapshot {
@@ -1854,9 +1946,14 @@ func (s *Server) runTurnWithRequestContext(ctx context.Context, th *threadState,
 		if baseBeforeRequestContext != nil {
 			segments = append(segments, baseBeforeRequestContext()...)
 		}
-		if len(turnRequestContext) > 0 {
-			segments = append(segments, cloneContextSegments(turnRequestContext)...)
-		}
+		th.mu.Lock()
+		activeSteerContextSet := th.activeSteerContextSet
+		activeSteerDocument := th.activeSteerDocument
+		th.mu.Unlock()
+		segments = append(
+			segments,
+			activeDocumentContextForTurn(turnRequestContext, activeSteerContextSet, activeSteerDocument)...,
+		)
 		return segments
 	}
 	res, err := runner.RunWithCallback(ctx, history, func(ev providers.StreamEvent) {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1996,6 +1996,10 @@ export type RemoteControlEvent =
   | { kind: "host-log"; message: string }
   | { kind: "host-exit"; code: number | null };
 
+export type ActiveDocumentContext = {
+  path: string;
+};
+
 export type WuuDesktopApi = {
   listProjects: () => Promise<ProjectListResult>;
   createBlankProject: () => Promise<ProjectListResult>;
@@ -2227,6 +2231,7 @@ export type WuuDesktopApi = {
     images?: InputImage[],
     files?: InputFile[],
     permissionMode?: string,
+    activeDocument?: ActiveDocumentContext,
   ) => Promise<{ turn: Turn }>;
   queueTurn: (
     threadId: string,
@@ -2235,6 +2240,7 @@ export type WuuDesktopApi = {
     clientId?: string,
     files?: InputFile[],
     permissionMode?: string,
+    activeDocument?: ActiveDocumentContext,
   ) => Promise<{ queued: QueuedTurn }>;
   updateQueuedTurn: (
     threadId: string,
@@ -2251,6 +2257,7 @@ export type WuuDesktopApi = {
     images?: InputImage[],
     clientId?: string,
     files?: InputFile[],
+    activeDocument?: ActiveDocumentContext,
   ) => Promise<{ turn_id: string }>;
   unsteerTurn: (threadId: string, steerId: string) => Promise<{ ok: boolean }>;
   interruptTurn: (threadId: string) => Promise<{ ok: boolean }>;


### PR DESCRIPTION
## Summary
- move the existing session composer into the globalized active-document view
- send the active document as request-only context without persisting its contents
- preserve queued document snapshots and steer/unsteer context continuity

## Verification
- desktop TypeScript typecheck
- desktop test suite (1858 tests)
- Electron renderer/main build
- full internal/appserver test suite
- gofmt and git diff --check