### PR TITLE
feat(memory): consolidate dreams across sessions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,10 @@ const (
 	// agent.max_parallel is omitted or set to zero.
 	DefaultAgentMaxParallel = 5
 
-	DefaultDreamIntervalDays = 7
+	// DefaultDreamIntervalDays is the minimum elapsed-time gate for background
+	// consolidation. A dream also requires the runtime's minimum number of
+	// completed sessions, so reaching this interval alone never starts a pass.
+	DefaultDreamIntervalDays = 1
 
 	defaultCodexSubscriptionBaseURL = "https://chatgpt.com/backend-api/codex"
 )
@@ -137,9 +140,9 @@ type MemoryConfig struct {
 	// UserCharLimit is retained for compatibility with the retired indexed
 	// memory store. Current notebook memory does not apply this limit.
 	UserCharLimit int `json:"user_char_limit,omitempty"`
-	// DreamIntervalDays controls how often the background dream pass
-	// consolidates recent session history into workspace memory. nil means
-	// the default interval; 0 disables the dream pass.
+	// DreamIntervalDays is the minimum elapsed-time gate for the background
+	// dream pass. The pass also requires five completed sessions since the last
+	// successful consolidation. nil means the default interval; 0 disables it.
 	//
 	// Deprecated: use Dream.IntervalDays instead. This field is retained so
 	// existing configs keep working.

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -639,7 +639,7 @@ func NewSession(opts Options) (*Session, error) {
 	}
 	var afterTurnHooks []func(context.Context, *agent.StreamRunner, []providers.ChatMessage, agent.LoopResult)
 	if toolkit != nil {
-		if dreamScheduler := newSessionDreamScheduler(rootDir, workspaceStateDir, func() string { return toolkit.SessionDir() }, dreamIntervalDays, dreamClient, dreamModel); dreamScheduler != nil {
+		if dreamScheduler := newSessionDreamSchedulerWithSessions(rootDir, workspaceStateDir, sessionDir, workspaceID, func() string { return toolkit.SessionDir() }, dreamIntervalDays, sessionDreamMinSessions, dreamClient, dreamModel); dreamScheduler != nil {
 			afterTurnHooks = append(afterTurnHooks, dreamScheduler.AfterTurn)
 		}
 	}
@@ -1308,7 +1308,7 @@ func (s *Session) NewThreadRuntimeForRoot(sessionID, rootDir string) (*ThreadRun
 	runner.BeforeRequest = pluginRequestInterceptor(s.PluginHost, s.ProviderName, id, threadRoot)
 	var afterTurnHooks []func(context.Context, *agent.StreamRunner, []providers.ChatMessage, agent.LoopResult)
 	if kit != nil {
-		if dreamScheduler := newSessionDreamScheduler(threadRoot, stateDir, func() string { return artifactDir }, s.DreamIntervalDays, s.DreamClient, s.DreamModel); dreamScheduler != nil {
+		if dreamScheduler := newSessionDreamSchedulerWithSessions(s.RootDir, stateDir, s.SessionDir, s.WorkspaceID, func() string { return artifactDir }, s.DreamIntervalDays, sessionDreamMinSessions, s.DreamClient, s.DreamModel); dreamScheduler != nil {
 			afterTurnHooks = append(afterTurnHooks, dreamScheduler.AfterTurn)
 		}
 	}
@@ -2204,7 +2204,7 @@ func (s *Session) ApplyGeneralConfig(cfg config.Config, homeDir string) string {
 		s.Toolkit.SetFileScopeRoots(workspaces.BoundaryRoots(s.Toolkit.RootDir(), s.WuuHome, fileScopeExtras...))
 	}
 	if s.StreamRunner != nil && s.Toolkit != nil {
-		s.StreamRunner.AfterTurn = sessionDreamAfterTurn(s.RootDir, s.StateDir, func() string { return s.Toolkit.SessionDir() }, s.DreamIntervalDays, s.DreamClient, s.DreamModel)
+		s.StreamRunner.AfterTurn = sessionDreamAfterTurn(s.RootDir, s.StateDir, s.SessionDir, s.WorkspaceID, func() string { return s.Toolkit.SessionDir() }, s.DreamIntervalDays, sessionDreamMinSessions, s.DreamClient, s.DreamModel)
 	}
 	apiModel := s.Model
 	if s.StreamRunner != nil && strings.TrimSpace(s.StreamRunner.APIModel) != "" {

--- a/internal/runtime/session_dream.go
+++ b/internal/runtime/session_dream.go
@@ -2,8 +2,11 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -11,6 +14,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/provideroptions"
 	"github.com/blueberrycongee/wuu/internal/providers"
+	sessionstore "github.com/blueberrycongee/wuu/internal/session"
 	"github.com/blueberrycongee/wuu/internal/sessionmemory"
 	"github.com/blueberrycongee/wuu/internal/tools"
 )
@@ -20,13 +24,17 @@ const (
 	sessionDreamStateRecoveryAfter = 2 * sessionDreamTimeout
 	sessionDreamFailureBackoff     = time.Hour
 	sessionDreamMaxSteps           = 6
+	sessionDreamMinSessions        = 5
 )
 
 type sessionDreamScheduler struct {
 	rootDir            string
 	workspaceStateDir  string
+	sessionsDir        string
+	workspaceID        string
 	sessionArtifactDir func() string
 	interval           time.Duration
+	minSessions        int
 	reportError        func(error)
 
 	// Optional dedicated client/model. When client is nil the scheduler falls
@@ -38,16 +46,19 @@ type sessionDreamScheduler struct {
 	running bool
 }
 
-func newSessionDreamScheduler(rootDir, workspaceStateDir string, sessionArtifactDir func() string, intervalDays int, dedicatedClient providers.Client, dedicatedModel string) *sessionDreamScheduler {
+func newSessionDreamSchedulerWithSessions(rootDir, workspaceStateDir, sessionsDir, workspaceID string, sessionArtifactDir func() string, intervalDays, minSessions int, dedicatedClient providers.Client, dedicatedModel string) *sessionDreamScheduler {
 	rootDir = strings.TrimSpace(rootDir)
-	if rootDir == "" || strings.TrimSpace(workspaceStateDir) == "" || sessionArtifactDir == nil || intervalDays <= 0 {
+	if rootDir == "" || strings.TrimSpace(workspaceStateDir) == "" || strings.TrimSpace(sessionsDir) == "" || sessionArtifactDir == nil || intervalDays <= 0 || minSessions <= 0 {
 		return nil
 	}
 	return &sessionDreamScheduler{
 		rootDir:            rootDir,
 		workspaceStateDir:  workspaceStateDir,
+		sessionsDir:        sessionsDir,
+		workspaceID:        strings.TrimSpace(workspaceID),
 		sessionArtifactDir: sessionArtifactDir,
 		interval:           time.Duration(intervalDays) * 24 * time.Hour,
+		minSessions:        minSessions,
 		client:             dedicatedClient,
 		model:              strings.TrimSpace(dedicatedModel),
 		reportError: func(err error) {
@@ -59,8 +70,8 @@ func newSessionDreamScheduler(rootDir, workspaceStateDir string, sessionArtifact
 // sessionDreamAfterTurn builds a fresh dream scheduler AfterTurn hook. It is
 // used to rebuild the hook after live settings changes without recreating the
 // whole StreamRunner.
-func sessionDreamAfterTurn(rootDir, workspaceStateDir string, sessionArtifactDir func() string, intervalDays int, dedicatedClient providers.Client, dedicatedModel string) func(context.Context, *agent.StreamRunner, []providers.ChatMessage, agent.LoopResult) {
-	scheduler := newSessionDreamScheduler(rootDir, workspaceStateDir, sessionArtifactDir, intervalDays, dedicatedClient, dedicatedModel)
+func sessionDreamAfterTurn(rootDir, workspaceStateDir, sessionsDir, workspaceID string, sessionArtifactDir func() string, intervalDays, minSessions int, dedicatedClient providers.Client, dedicatedModel string) func(context.Context, *agent.StreamRunner, []providers.ChatMessage, agent.LoopResult) {
+	scheduler := newSessionDreamSchedulerWithSessions(rootDir, workspaceStateDir, sessionsDir, workspaceID, sessionArtifactDir, intervalDays, minSessions, dedicatedClient, dedicatedModel)
 	if scheduler == nil {
 		return nil
 	}
@@ -78,7 +89,16 @@ func (s *sessionDreamScheduler) AfterTurn(ctx context.Context, runner *agent.Str
 	if err != nil || !acquired {
 		return
 	}
-	if !s.shouldStart(history, result, time.Now().UTC()) {
+	now := time.Now().UTC()
+	sessions, shouldStart, err := s.prepare(history, result, filepath.Base(strings.TrimSpace(s.sessionArtifactDir())), now)
+	if err != nil {
+		_ = lock.Release()
+		if s.reportError != nil {
+			s.reportError(err)
+		}
+		return
+	}
+	if !shouldStart {
 		_ = lock.Release()
 		return
 	}
@@ -120,8 +140,8 @@ func (s *sessionDreamScheduler) AfterTurn(ctx context.Context, runner *agent.Str
 		rootDir:            s.rootDir,
 		workspaceStateDir:  s.workspaceStateDir,
 		sessionArtifactDir: sessionArtifactDir,
-		history:            cloneMemoryReviewHistory(history),
-		now:                time.Now().UTC(),
+		sessions:           sessions,
+		now:                now,
 	}
 	journal := runner.InferenceJournal
 	go func() {
@@ -160,17 +180,17 @@ func isPureSessionDreamCancellation(err error) bool {
 	return errors.Is(err, context.Canceled)
 }
 
-func (s *sessionDreamScheduler) shouldStart(history []providers.ChatMessage, result agent.LoopResult, now time.Time) bool {
+func (s *sessionDreamScheduler) prepare(history []providers.ChatMessage, result agent.LoopResult, currentSessionID string, now time.Time) ([]sessionDreamCandidate, bool, error) {
 	if strings.TrimSpace(result.Content) == "" || countMemoryReviewUserTurns(history) == 0 {
-		return false
+		return nil, false, nil
 	}
 	if !s.tryStart() {
-		return false
+		return nil, false, nil
 	}
 	state, err := sessionmemory.LoadDreamState(s.workspaceStateDir)
 	if err != nil {
 		s.finish()
-		return false
+		return nil, false, err
 	}
 	// Crash self-heal (repair plan 2026-07-04 item #9): a dream that died
 	// with its process leaves LastStatus=running forever — the state file
@@ -181,28 +201,77 @@ func (s *sessionDreamScheduler) shouldStart(history []providers.ChatMessage, res
 	// elapsed when the interrupted dream was allowed to start. Lock ownership
 	// is independent of this timestamp; the OS-backed lock below still rejects
 	// the retry if another process is actually running the dream.
+	forceRetry := false
 	if state.LastStatus == sessionmemory.DreamStatusRunning {
 		if !state.LastStartedAt.IsZero() && now.Sub(state.LastStartedAt) < sessionDreamStateRecoveryAfter {
 			s.finish()
-			return false
+			return nil, false, nil
 		}
 		if err := sessionmemory.RecordDreamFailed(s.workspaceStateDir, now, errors.New("interrupted: process exited while a dream was running (stale running state reconciled)")); err != nil {
 			s.finish()
-			return false
+			return nil, false, err
 		}
-		return true
+		forceRetry = true
 	}
 	if state.LastStatus == sessionmemory.DreamStatusFailed &&
 		!state.LastFinishedAt.IsZero() &&
 		now.Sub(state.LastFinishedAt) < sessionDreamFailureBackoff {
 		s.finish()
-		return false
+		return nil, false, nil
 	}
-	if !state.LastRunAt.IsZero() && now.Sub(state.LastRunAt) < s.interval {
+	if !forceRetry && !state.LastRunAt.IsZero() && now.Sub(state.LastRunAt) < s.interval {
 		s.finish()
-		return false
+		return nil, false, nil
 	}
-	return true
+	sessions, err := listPendingDreamSessions(s.sessionsDir, s.rootDir, s.workspaceID, currentSessionID, state.LastRunAt)
+	if err != nil {
+		s.finish()
+		return nil, false, err
+	}
+	if len(sessions) < s.minSessions {
+		s.finish()
+		return nil, false, nil
+	}
+	return sessions, true, nil
+}
+
+func (s *sessionDreamScheduler) shouldStart(history []providers.ChatMessage, result agent.LoopResult, now time.Time) bool {
+	_, ok, err := s.prepare(history, result, "", now)
+	return err == nil && ok
+}
+
+type sessionDreamCandidate struct {
+	ID        string
+	UpdatedAt time.Time
+}
+
+func listPendingDreamSessions(sessionsDir, rootDir, workspaceID, currentSessionID string, since time.Time) ([]sessionDreamCandidate, error) {
+	sessions, err := sessionstore.ListForCWD(sessionsDir, rootDir, workspaceID, 0)
+	if err != nil {
+		return nil, fmt.Errorf("list dream sessions: %w", err)
+	}
+	currentSessionID = strings.TrimSpace(currentSessionID)
+	candidates := make([]sessionDreamCandidate, 0, len(sessions))
+	for _, candidate := range sessions {
+		if strings.TrimSpace(candidate.ID) == currentSessionID || candidate.Entries <= 0 {
+			continue
+		}
+		updatedAt := candidate.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = candidate.CreatedAt
+		}
+		if !since.IsZero() && !updatedAt.After(since) {
+			continue
+		}
+		candidates = append(candidates, sessionDreamCandidate{ID: candidate.ID, UpdatedAt: updatedAt.UTC()})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].UpdatedAt.Equal(candidates[j].UpdatedAt) {
+			return candidates[i].ID < candidates[j].ID
+		}
+		return candidates[i].UpdatedAt.Before(candidates[j].UpdatedAt)
+	})
+	return candidates, nil
 }
 
 func (s *sessionDreamScheduler) tryStart() bool {
@@ -231,7 +300,7 @@ type sessionDreamJob struct {
 	rootDir            string
 	workspaceStateDir  string
 	sessionArtifactDir string
-	history            []providers.ChatMessage
+	sessions           []sessionDreamCandidate
 	now                time.Time
 }
 
@@ -239,7 +308,7 @@ func (s *sessionDreamScheduler) run(ctx context.Context, job sessionDreamJob) er
 	if job.client == nil || strings.TrimSpace(job.model) == "" {
 		return nil
 	}
-	messages := buildSessionDreamMessages(job.history)
+	messages := buildSessionDreamMessages(job.sessions)
 	if len(messages) == 0 {
 		return nil
 	}
@@ -250,7 +319,7 @@ func (s *sessionDreamScheduler) run(ctx context.Context, job sessionDreamJob) er
 	if err := sessionmemory.RecordDreamStarted(job.workspaceStateDir, started); err != nil {
 		return err
 	}
-	executor := newSessionDreamExecutor(job.rootDir, job.workspaceStateDir, job.sessionArtifactDir)
+	executor := newSessionDreamExecutor(job.rootDir, job.workspaceStateDir, job.sessionArtifactDir, s.sessionsDir, job.sessions)
 	_, err := agent.RunToolLoop(ctx, messages, agent.LoopConfig{
 		Tools:                    executor,
 		Model:                    job.model,
@@ -271,24 +340,31 @@ func (s *sessionDreamScheduler) run(ctx context.Context, job sessionDreamJob) er
 }
 
 type sessionDreamExecutor struct {
-	registry *tools.Registry
-	defs     []providers.ToolDefinition
+	registry          *tools.Registry
+	defs              []providers.ToolDefinition
+	allowedSessionIDs map[string]struct{}
 }
 
-func newSessionDreamExecutor(rootDir, workspaceStateDir, sessionArtifactDir string) *sessionDreamExecutor {
+func newSessionDreamExecutor(rootDir, workspaceStateDir, sessionArtifactDir, sessionsDir string, sessions []sessionDreamCandidate) *sessionDreamExecutor {
 	env := &tools.Env{
-		RootDir:    rootDir,
-		StateDir:   workspaceStateDir,
-		SessionDir: sessionArtifactDir,
+		RootDir:     rootDir,
+		StateDir:    workspaceStateDir,
+		SessionDir:  sessionArtifactDir,
+		SessionsDir: sessionsDir,
 	}
 	registry := tools.NewRegistry(
 		tools.NewReadFileTool(env),
 		tools.NewListFilesTool(env),
 		tools.NewGrepTool(env),
 		tools.NewGlobTool(env),
+		tools.NewThreadGetTool(env),
 		tools.NewSessionMemoryTool(env),
 	)
-	return &sessionDreamExecutor{registry: registry, defs: registry.Definitions()}
+	allowedSessionIDs := make(map[string]struct{}, len(sessions))
+	for _, candidate := range sessions {
+		allowedSessionIDs[candidate.ID] = struct{}{}
+	}
+	return &sessionDreamExecutor{registry: registry, defs: registry.Definitions(), allowedSessionIDs: allowedSessionIDs}
 }
 
 func (e *sessionDreamExecutor) Definitions() []providers.ToolDefinition {
@@ -305,6 +381,17 @@ func (e *sessionDreamExecutor) Execute(ctx context.Context, call providers.ToolC
 	tool := e.registry.Lookup(call.Name)
 	if tool == nil {
 		return "", fmt.Errorf("background dream: tool %q is not available", call.Name)
+	}
+	if call.Name == "thread_get" {
+		var args struct {
+			ThreadID string `json:"thread_id"`
+		}
+		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+			return "", fmt.Errorf("background dream: decode thread_get arguments: %w", err)
+		}
+		if _, allowed := e.allowedSessionIDs[strings.TrimSpace(args.ThreadID)]; !allowed {
+			return "", fmt.Errorf("background dream: thread_get session %q is outside this consolidation batch", args.ThreadID)
+		}
 	}
 	result, err := tool.Execute(ctx, call.Arguments)
 	if err == nil && call.Name == "session_memory" {
@@ -337,31 +424,37 @@ func (e *sessionDreamExecutor) ToolMetadata(call providers.ToolCall) (agent.Tool
 	}, true
 }
 
-func buildSessionDreamMessages(history []providers.ChatMessage) []providers.ChatMessage {
-	out := make([]providers.ChatMessage, 0, len(history)+2)
-	out = append(out, providers.ChatMessage{Role: "system", Content: sessionDreamSystemPrompt})
-	transcript := selectMemoryReviewTranscript(history)
-	if len(transcript) == 0 {
+func buildSessionDreamMessages(sessions []sessionDreamCandidate) []providers.ChatMessage {
+	var review strings.Builder
+	review.WriteString(sessionDreamPrompt)
+	for _, candidate := range sessions {
+		review.WriteString("\n- ")
+		review.WriteString(candidate.ID)
+		review.WriteString(" (updated ")
+		review.WriteString(candidate.UpdatedAt.UTC().Format(time.RFC3339Nano))
+		review.WriteByte(')')
+	}
+	if len(sessions) == 0 {
 		return nil
 	}
-	out = append(out, transcript...)
-	out = append(out, providers.ChatMessage{Role: "user", Content: sessionDreamPrompt})
-	return out
+	return []providers.ChatMessage{
+		{Role: "system", Content: sessionDreamSystemPrompt},
+		{Role: "user", Content: review.String()},
+	}
 }
 
-const sessionDreamSystemPrompt = `You are a background memory review worker. Your only job is to inspect the recent conversation and maintain durable memory. Do not modify workspace files or use capabilities outside the listed memory-review tools.`
+const sessionDreamSystemPrompt = `You are a background memory consolidation worker. Your only job is to inspect the listed completed sessions and maintain durable workspace memory. Do not modify workspace files or use capabilities outside the listed memory-review tools.`
 
-const sessionDreamPrompt = `Review the recent conversation and consolidate durable workspace/session memory.
+const sessionDreamPrompt = `Review the completed session transcripts below and consolidate durable workspace memory across them.
 
-Available tools are read_file, list_files, glob, grep, and session_memory.
+Available tools are read_file, list_files, glob, grep, thread_get, and session_memory.
 
-Use read_file, list_files, glob, and grep only when workspace inspection is required to confirm what should be remembered. Stay within the listed memory-review tools; do not modify source files directly, access network resources, or invoke external programs.
+Use thread_get with each listed session ID to inspect the conversations being consolidated. Calls are read-only and may be issued in parallel. Use read_file, list_files, glob, and grep only when workspace inspection is required to confirm what should be remembered. Stay within the listed memory-review tools; do not modify source files directly, access network resources, or invoke external programs.
 
 Use session_memory for durable writes:
-1. Read existing project_memory, summary, checkpoint, or notes when needed before editing them.
+1. Read existing project_memory when needed before editing it.
 2. Write project_memory only for stable workspace facts, architecture decisions, durable conventions, tool quirks, or recurring workflow lessons that should survive future sessions.
-3. Write summary for compact recoverable state of the active task: active intent, next concrete action, current work, decisions, and open questions. Use checkpoint only when maintaining older checkpoint.md content.
-4. Write notes for useful session scratch details that are not durable enough for project_memory.
+3. Do not write summary, checkpoint, or notes: those belong to an active individual session, while this pass consolidates several completed sessions.
 
 If session_memory is insufficient for a memory artifact, reply with what is missing instead of writing files directly. Do not modify source files.
 

--- a/internal/runtime/session_dream_test.go
+++ b/internal/runtime/session_dream_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/providers"
+	sessionstore "github.com/blueberrycongee/wuu/internal/session"
 	"github.com/blueberrycongee/wuu/internal/sessionmemory"
 )
 
@@ -72,22 +73,35 @@ func makeSessionDreamHistory(userTurns int) []providers.ChatMessage {
 	return history
 }
 
+func newSessionDreamScheduler(root, workspaceState string, sessionArtifactDir func() string, intervalDays int, client providers.Client, model string) *sessionDreamScheduler {
+	sessionsDir := filepath.Join(workspaceState, "global-sessions")
+	for i := 0; i < sessionDreamMinSessions; i++ {
+		id := fmt.Sprintf("dream-history-%d", i)
+		if _, err := sessionstore.CreateWithMetadata(sessionsDir, id, root); err != nil {
+			panic(err)
+		}
+		if err := sessionstore.AppendHistoryRecords(sessionsDir, id, []sessionstore.HistoryRecord{
+			{Role: "user", Content: fmt.Sprintf("durable lesson %d", i)},
+			{Role: "assistant", Content: "noted"},
+		}); err != nil {
+			panic(err)
+		}
+		if err := sessionstore.UpdateIndex(sessionsDir, id, 2, ""); err != nil {
+			panic(err)
+		}
+	}
+	return newSessionDreamSchedulerWithSessions(root, workspaceState, sessionsDir, "", sessionArtifactDir, intervalDays, sessionDreamMinSessions, client, model)
+}
+
 func TestBuildSessionDreamMessagesSkipsToolProtocolAndSyntheticUserMessages(t *testing.T) {
-	messages := buildSessionDreamMessages([]providers.ChatMessage{
-		{Role: "system", Content: "old sys"},
-		{Role: "user", Content: "[Hook context for read_file]: extra"},
-		{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: "call_1", Name: "read_file"}}},
-		{Role: "tool", Name: "read_file", ToolCallID: "call_1", Content: "file"},
-		{Role: "user", Content: "Remember release needs visual QA"},
-		{Role: "assistant", Content: "Noted."},
-	})
+	messages := buildSessionDreamMessages([]sessionDreamCandidate{{ID: "session-1"}})
 
 	for _, msg := range messages {
 		if msg.Role == "tool" {
 			t.Fatalf("tool protocol message should not be included: %+v", messages)
 		}
-		if strings.Contains(msg.Content, "[Hook context") {
-			t.Fatalf("synthetic hook context leaked into dream: %+v", messages)
+		if !strings.Contains(msg.Content, "session-1") && msg.Role == "user" {
+			t.Fatalf("session ID missing from dream request: %+v", messages)
 		}
 	}
 	last := messages[len(messages)-1]
@@ -188,7 +202,7 @@ func TestSessionDreamPrefersNativeStreaming(t *testing.T) {
 		rootDir:            t.TempDir(),
 		workspaceStateDir:  workspaceState,
 		sessionArtifactDir: filepath.Join(workspaceState, "sessions", "session-1"),
-		history:            makeSessionDreamHistory(1),
+		sessions:           []sessionDreamCandidate{{ID: "session-1"}},
 		now:                time.Now().UTC(),
 	}
 
@@ -369,6 +383,58 @@ func TestSessionDreamScheduler_ShouldStartRespectsInterval(t *testing.T) {
 	scheduler.finish()
 }
 
+func TestSessionDreamScheduler_PrepareRequiresTimeAndSessionThresholds(t *testing.T) {
+	root := t.TempDir()
+	workspaceState := t.TempDir()
+	sessionArtifact := filepath.Join(workspaceState, "sessions", "active-session")
+	scheduler := newSessionDreamScheduler(root, workspaceState, func() string { return sessionArtifact }, 1, nil, "")
+	history := makeSessionDreamHistory(1)
+	now := time.Now().UTC()
+
+	if err := sessionmemory.SaveDreamState(workspaceState, sessionmemory.DreamState{LastRunAt: now.Add(-23 * time.Hour)}); err != nil {
+		t.Fatalf("save recent dream state: %v", err)
+	}
+	if _, ok, err := scheduler.prepare(history, agent.LoopResult{Content: "done"}, "active-session", now); err != nil || ok {
+		t.Fatalf("time gate: ok=%t err=%v, want not eligible", ok, err)
+	}
+
+	if err := sessionmemory.SaveDreamState(workspaceState, sessionmemory.DreamState{LastRunAt: now.Add(-25 * time.Hour)}); err != nil {
+		t.Fatalf("save elapsed dream state: %v", err)
+	}
+	if sessions, ok, err := scheduler.prepare(history, agent.LoopResult{Content: "done"}, "dream-history-0", now); err != nil || ok || len(sessions) != 0 {
+		t.Fatalf("session gate after excluding current: sessions=%v ok=%t err=%v", sessions, ok, err)
+	}
+
+	sessions, ok, err := scheduler.prepare(history, agent.LoopResult{Content: "done"}, "active-session", now)
+	if err != nil || !ok || len(sessions) != sessionDreamMinSessions {
+		t.Fatalf("combined gates: sessions=%v ok=%t err=%v", sessions, ok, err)
+	}
+	scheduler.finish()
+}
+
+func TestSessionDreamExecutorRestrictsThreadGetToBatch(t *testing.T) {
+	root := t.TempDir()
+	workspaceState := t.TempDir()
+	sessionsDir := filepath.Join(workspaceState, "global-sessions")
+	for _, id := range []string{"allowed-session", "other-session"} {
+		if _, err := sessionstore.CreateWithMetadata(sessionsDir, id, root); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := sessionstore.AppendHistoryRecord(sessionsDir, id, sessionstore.HistoryRecord{Role: "user", Content: id + " content"}); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+	executor := newSessionDreamExecutor(root, workspaceState, filepath.Join(workspaceState, "sessions", "active"), sessionsDir, []sessionDreamCandidate{{ID: "allowed-session"}})
+
+	result, err := executor.Execute(context.Background(), providers.ToolCall{Name: "thread_get", Arguments: `{"thread_id":"allowed-session"}`})
+	if err != nil || !strings.Contains(result, "allowed-session content") {
+		t.Fatalf("allowed thread_get: result=%q err=%v", result, err)
+	}
+	if _, err := executor.Execute(context.Background(), providers.ToolCall{Name: "thread_get", Arguments: `{"thread_id":"other-session"}`}); err == nil || !strings.Contains(err.Error(), "outside this consolidation batch") {
+		t.Fatalf("out-of-batch thread_get error = %v", err)
+	}
+}
+
 func TestSessionDreamScheduler_ShouldStartBacksOffRecentFailure(t *testing.T) {
 	root := t.TempDir()
 	workspaceState := t.TempDir()
@@ -537,10 +603,7 @@ func TestSessionDream_RunWritesProjectMemoryWithAlignedToolSet(t *testing.T) {
 		workspaceStateDir:  workspaceState,
 		sessionArtifactDir: sessionArtifact,
 		now:                now,
-		history: []providers.ChatMessage{
-			{Role: "user", Content: "Remember release needs visual QA."},
-			{Role: "assistant", Content: "Noted."},
-		},
+		sessions:           []sessionDreamCandidate{{ID: "session-1"}},
 	})
 	if err != nil {
 		t.Fatalf("run: %v", err)
@@ -592,7 +655,7 @@ func TestSessionDream_RunWritesProjectMemoryWithAlignedToolSet(t *testing.T) {
 	for _, def := range client.requests[0].Tools {
 		toolNames[def.Name] = true
 	}
-	wantTools := []string{"read_file", "list_files", "grep", "glob", "session_memory"}
+	wantTools := []string{"read_file", "list_files", "grep", "glob", "thread_get", "session_memory"}
 	if len(toolNames) != len(wantTools) {
 		t.Fatalf("dream tools = %+v, want %v", toolNames, wantTools)
 	}
@@ -607,7 +670,7 @@ func TestSessionDream_RunWritesProjectMemoryWithAlignedToolSet(t *testing.T) {
 		}
 	}
 	firstSystem := client.requests[0].Messages[0]
-	if firstSystem.Role != "system" || !strings.Contains(firstSystem.Content, "background memory review worker") {
+	if firstSystem.Role != "system" || !strings.Contains(firstSystem.Content, "background memory consolidation worker") {
 		t.Fatalf("dream must use a profile-neutral memory system prompt, got %+v", firstSystem)
 	}
 	for _, blocked := range []string{"apply_patch", "edit_file", "write_file", "bash", "terminal", "shell", "git"} {
@@ -662,10 +725,7 @@ func TestSessionDream_RunRecordsFailureState(t *testing.T) {
 		workspaceStateDir:  workspaceState,
 		sessionArtifactDir: sessionArtifact,
 		now:                started,
-		history: []providers.ChatMessage{
-			{Role: "user", Content: "Remember release needs visual QA."},
-			{Role: "assistant", Content: "Noted."},
-		},
+		sessions:           []sessionDreamCandidate{{ID: "session-1"}},
 	})
 	if err == nil || !strings.Contains(err.Error(), "provider unavailable") {
 		t.Fatalf("run error = %v, want provider unavailable", err)
@@ -711,7 +771,7 @@ func TestSessionDream_RunReturnsFailureStatePersistenceError(t *testing.T) {
 		rootDir:            root,
 		workspaceStateDir:  workspaceState,
 		sessionArtifactDir: sessionArtifact,
-		history:            makeSessionDreamHistory(1),
+		sessions:           []sessionDreamCandidate{{ID: "session-1"}},
 	})
 
 	if !errors.Is(err, providerErr) {

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -212,6 +212,10 @@ type Env struct {
 	// Tools check for nil and return a clear error rather than panic.
 	SessionID  string
 	SessionDir string // absolute session artifact path for result budgeting
+	// SessionsDir overrides the user-level SQLite session store location for
+	// tools that read conversations by ID. Empty keeps the canonical WUU_HOME
+	// lookup used by ordinary runtimes.
+	SessionsDir string
 	// ToolResultProjectionMode selects stable tool-result projection behavior
 	// ("off"/"shadow"/"active"); empty resolves to active (on by default). The
 	// WUU_TOOL_RESULT_PROJECTION environment variable overrides it.

--- a/internal/tools/tool_thread_get.go
+++ b/internal/tools/tool_thread_get.go
@@ -91,11 +91,14 @@ func (t *ThreadGetTool) Execute(ctx context.Context, args string) (string, error
 		return "", fmt.Errorf("thread_get: thread_id is required")
 	}
 
-	home, err := statepath.Home("")
-	if err != nil {
-		return "", fmt.Errorf("thread_get: resolve wuu home: %w", err)
+	sessDir := strings.TrimSpace(t.env.SessionsDir)
+	if sessDir == "" {
+		home, err := statepath.Home("")
+		if err != nil {
+			return "", fmt.Errorf("thread_get: resolve wuu home: %w", err)
+		}
+		sessDir = statepath.SessionsDir(home)
 	}
-	sessDir := statepath.SessionsDir(home)
 	if sessDir == "" {
 		return "", errors.New("thread_get: sessions dir is empty")
 	}

--- a/internal/tools/tool_thread_get_test.go
+++ b/internal/tools/tool_thread_get_test.go
@@ -101,6 +101,26 @@ func TestThreadGetToolReturnsErrSessionNotFound(t *testing.T) {
 	}
 }
 
+func TestThreadGetToolUsesInjectedSessionsDir(t *testing.T) {
+	sessDir := t.TempDir()
+	const id = "injected-session"
+	if _, err := session.CreateWithMetadata(sessDir, id, "/tmp/workdir"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if err := session.AppendHistoryRecord(sessDir, id, session.HistoryRecord{Role: "user", Content: "from injected store"}); err != nil {
+		t.Fatalf("append history: %v", err)
+	}
+
+	tool := NewThreadGetTool(&Env{SessionsDir: sessDir})
+	out, err := tool.Execute(context.Background(), `{"thread_id":"injected-session"}`)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out, "from injected store") {
+		t.Fatalf("thread_get ignored injected store: %s", out)
+	}
+}
+
 func TestThreadGetToolRejectsEmptyThreadID(t *testing.T) {
 	tool := NewThreadGetTool(&Env{})
 	_, err := tool.Execute(context.Background(), `{"thread_id":""}`)


### PR DESCRIPTION
## Summary
- gate background Dream consolidation on both 24 elapsed hours and 5 pending workspace sessions
- pass only eligible session IDs and let the restricted worker read them on demand with thread_get
- exclude the active session and retain existing failure backoff, crash recovery, and locking

## Verification
- go test ./...
- go test -race ./internal/runtime
- go vet ./internal/runtime ./internal/tools ./internal/config ./internal/sessionmemory
- git diff --check