### PR TITLE
fix(desktop): make session actions responsive

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -763,6 +763,7 @@ export function App(): JSX.Element {
     pendingComposerMessagesForThread: pendingComposerMessagesForActiveThread,
     updateThreadPendingComposerMessages,
     clearThreadPendingComposerMessages,
+    removePendingComposerMessageByID,
     syncPendingComposerMessagesFromServerEvent,
     reconcilePendingComposerMessagesForState,
     enqueueComposerMessage,
@@ -3073,6 +3074,7 @@ export function App(): JSX.Element {
     ) {
       return false;
     }
+    enqueueComposerMessage(targetThread.id, message);
     try {
       const encodedImages = await awaitComposerImages(message.images);
       const images = inputImagesFromComposer(encodedImages);
@@ -3085,13 +3087,21 @@ export function App(): JSX.Element {
         targetThread.permission_mode || currentState.initialized.permissions?.mode,
         message.activeDocument,
       );
-      enqueueComposerMessage(targetThread.id, {
-        ...message,
-        id: result.queued.id || message.id,
-        images: encodedImages,
-      });
+      updateThreadPendingComposerMessages(targetThread.id, (previous) => ({
+        ...previous,
+        queued: previous.queued.map((candidate) =>
+          candidate.id === message.id
+            ? {
+                ...candidate,
+                id: result.queued.id || message.id,
+                images: encodedImages,
+              }
+            : candidate,
+        ),
+      }));
       return true;
     } catch (error) {
+      removePendingComposerMessageByID(targetThread.id, message.id, "queue");
       setState((current) => ({
         ...current,
         status:
@@ -3120,6 +3130,10 @@ export function App(): JSX.Element {
     ) {
       return false;
     }
+    updateThreadPendingComposerMessages(targetThread.id, (previous) => ({
+      ...previous,
+      guides: [...previous.guides, { ...message, origin: "steer" }],
+    }));
     try {
       const encodedImages = await awaitComposerImages(message.images);
       await window.wuu.steerTurn(
@@ -3133,13 +3147,15 @@ export function App(): JSX.Element {
       );
       updateThreadPendingComposerMessages(targetThread.id, (previous) => ({
         ...previous,
-        guides: [
-          ...previous.guides,
-          { ...message, images: encodedImages, origin: "steer" },
-        ],
+        guides: previous.guides.map((candidate) =>
+          candidate.id === message.id
+            ? { ...candidate, images: encodedImages }
+            : candidate,
+        ),
       }));
       return true;
     } catch (error) {
+      removePendingComposerMessageByID(targetThread.id, message.id, "guide");
       setState((current) => ({
         ...current,
         status:

--- a/desktop/src/renderer/AppQueuedTurnReconciliation.test.tsx
+++ b/desktop/src/renderer/AppQueuedTurnReconciliation.test.tsx
@@ -40,6 +40,11 @@ vi.mock("./ComposerView", async (importOriginal) => {
         <button type="button" onClick={props.onSend}>
           send
         </button>
+        {props.onSteer ? (
+          <button type="button" aria-label="steer" onClick={props.onSteer}>
+            steer
+          </button>
+        ) : null}
         {props.queuedMessages[0] ? (
           <button
             type="button"
@@ -155,7 +160,10 @@ function installWindowStubs(): void {
   });
 }
 
-function installWuuApi(): {
+function installWuuApi(options: {
+  queueTurn?: WuuDesktopApi["queueTurn"];
+  steerTurn?: WuuDesktopApi["steerTurn"];
+} = {}): {
   queuedClientIDs: string[];
   dequeuedClientIDs: string[];
 } {
@@ -174,7 +182,7 @@ function installWuuApi(): {
     listThreads: vi.fn().mockResolvedValue({ threads: [runningThread()] }),
     listArchivedThreads: vi.fn().mockResolvedValue({ threads: [] }),
     resumeThread: vi.fn().mockResolvedValue({ thread: runningThread() }),
-    queueTurn: vi
+    queueTurn: options.queueTurn ?? vi
       .fn()
       .mockImplementation(
         (
@@ -189,6 +197,7 @@ function installWuuApi(): {
           });
         },
       ),
+    steerTurn: options.steerTurn ?? vi.fn().mockResolvedValue({ turn_id: "turn-current" }),
     dequeueTurn: vi
       .fn()
       .mockImplementation((_threadID: string, clientID: string) => {
@@ -342,6 +351,91 @@ describe("queued turn reconciliation", () => {
     await flushAsync();
 
     expect(composerProbe().dataset.queuedIds).toBe("");
+  });
+
+  it("shows a steer in pending state before the IPC response resolves", async () => {
+    let resolveSteer: ((value: { turn_id: string }) => void) | undefined;
+    const steerTurn = vi.fn(
+      () =>
+        new Promise<{ turn_id: string }>((resolve) => {
+          resolveSteer = resolve;
+        }),
+    );
+    installWuuApi({ steerTurn: steerTurn as WuuDesktopApi["steerTurn"] });
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+    await flushAsync();
+
+    const textarea = composerProbe().querySelector("textarea");
+    const steer = composerProbe().querySelector<HTMLButtonElement>(
+      'button[aria-label="steer"]',
+    );
+    await act(async () => {
+      if (!textarea || !steer) throw new Error("steer controls not rendered");
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "guide the running turn");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      steer.click();
+      await Promise.resolve();
+    });
+
+    expect(steerTurn).toHaveBeenCalledTimes(1);
+    expect(composerProbe().querySelector("textarea")?.value).toBe("");
+    expect(composerProbe().dataset.guideIds).not.toBe("");
+
+    await act(async () => {
+      resolveSteer?.({ turn_id: "turn-current" });
+      await Promise.resolve();
+    });
+  });
+
+  it("rolls back an optimistic steer and restores the draft on IPC failure", async () => {
+    let rejectSteer: ((reason: Error) => void) | undefined;
+    const steerTurn = vi.fn(
+      () =>
+        new Promise<{ turn_id: string }>((_resolve, reject) => {
+          rejectSteer = reject;
+        }),
+    );
+    installWuuApi({ steerTurn: steerTurn as WuuDesktopApi["steerTurn"] });
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<App />);
+    });
+    await flushAsync();
+
+    const textarea = composerProbe().querySelector("textarea");
+    const steer = composerProbe().querySelector<HTMLButtonElement>(
+      'button[aria-label="steer"]',
+    );
+    await act(async () => {
+      if (!textarea || !steer) throw new Error("steer controls not rendered");
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "restore this guide");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      steer.click();
+      await Promise.resolve();
+    });
+    expect(composerProbe().dataset.guideIds).not.toBe("");
+
+    await act(async () => {
+      rejectSteer?.(new Error("IPC unavailable"));
+      await Promise.resolve();
+    });
+    await flushAsync();
+
+    expect(composerProbe().dataset.guideIds).toBe("");
+    expect(composerProbe().querySelector("textarea")?.value).toBe(
+      "restore this guide",
+    );
   });
 
   it("restores the authoritative held order from a resumed thread notification", async () => {

--- a/desktop/src/renderer/SessionTabActions.test.ts
+++ b/desktop/src/renderer/SessionTabActions.test.ts
@@ -202,6 +202,57 @@ describe("createSessionTabActions", () => {
     ]);
   });
 
+  it("removes the active tab before the fallback thread finishes resuming", async () => {
+    const context = projectContext();
+    const source = {
+      id: "thread-source",
+      preview: "Source",
+      model_provider: "fake",
+      model: "fake-model",
+      cwd: context.cwd,
+      status: "idle" as const,
+      archived: false,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      turns: [],
+    };
+    const fallback = { ...source, id: "thread-fallback", preview: "Fallback" };
+    const sourceTab = createThreadSessionTab(source, context);
+    const fallbackTab = createThreadSessionTab(fallback, context);
+    let resolveResume: ((value: { thread: typeof fallback }) => void) | undefined;
+    const resumeThread = vi.fn(
+      () =>
+        new Promise<{ thread: typeof fallback }>((resolve) => {
+          resolveResume = resolve;
+        }),
+    );
+    Object.defineProperty(window, "wuu", {
+      configurable: true,
+      value: { resumeThread },
+    });
+    const harness = buildActions({
+      initial: {
+        ...initialState,
+        activeContext: context,
+        thread: source,
+        threads: [source, fallback],
+        sessionTabs: [sourceTab, fallbackTab],
+        activeSessionTabID: sourceTab.id,
+      },
+    });
+
+    const closing = harness.actions.closeSessionTab(sourceTab.id);
+
+    expect(harness.getAppState().sessionTabs.map((tab) => tab.id)).toEqual([
+      fallbackTab.id,
+    ]);
+    expect(harness.getAppState().activeSessionTabID).toBe(fallbackTab.id);
+    expect(resumeThread).toHaveBeenCalledWith(fallback.id);
+
+    resolveResume?.({ thread: fallback });
+    await closing;
+  });
+
   it("pops out a draft tab and closes it after the detached window opens", async () => {
     const context = projectContext();
     const activeDraft = createDraftSessionTab("draft:active", context);

--- a/desktop/src/renderer/SessionTabActions.ts
+++ b/desktop/src/renderer/SessionTabActions.ts
@@ -293,6 +293,11 @@ export function createSessionTabActions(
       nextTabs[Math.min(tabIndex, Math.max(nextTabs.length - 1, 0))] ??
       deps.nextDraftSessionTab(closedTab.context);
     const tabsWithFallback = nextTabs.length > 0 ? nextTabs : [fallbackTab];
+    deps.setAppState((current) => ({
+      ...current,
+      sessionTabs: tabsWithFallback,
+      activeSessionTabID: fallbackTab.id,
+    }));
     
     if (fallbackTab.kind === "skills") {
       const sameContext = sameRuntimeContext(
@@ -319,7 +324,7 @@ export function createSessionTabActions(
           const next = loadedState ? { ...current, ...loadedState } : current;
           return {
             ...next,
-            sessionTabs: tabsWithFallback,
+            sessionTabs: current.sessionTabs,
             activeSessionTabID: fallbackTab.id,
             secondaryThread: undefined,
             activePane: "primary",
@@ -362,7 +367,7 @@ export function createSessionTabActions(
           const next = loadedState ? { ...current, ...loadedState } : current;
           return {
             ...next,
-            sessionTabs: tabsWithFallback,
+            sessionTabs: current.sessionTabs,
             activeSessionTabID: fallbackTab.id,
             thread: undefined,
             secondaryThread: undefined,
@@ -411,7 +416,7 @@ export function createSessionTabActions(
           activePane: "primary",
           allowThreadAutoActivation: true,
           sessionTabs: ensureSessionTab(
-            tabsWithFallback,
+            current.sessionTabs,
             createThreadSessionTab(thread, fallbackTab.context, restoredDraft),
           ),
           activeSessionTabID: threadSessionTabID(thread.id),


### PR DESCRIPTION
## Summary
- show queued and steer messages in the pending drawer immediately, then reconcile encoded attachments after IPC confirmation
- roll back optimistic pending messages and restore the composer draft when IPC fails
- remove the active session tab immediately while the fallback session resumes asynchronously

## Tests
- `npm run typecheck`
- `npm run test:unit` (174 files, 1873 tests)
- affected suites: 36 tests across composer reconciliation, session tab actions, tab rendering, and switch latency