### PR TITLE
fix(appserver): stabilize fork targets across compaction

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -98,6 +98,7 @@ import type {
   ThreadContextCompositionResult,
   ThreadEditMessageResult,
   ThreadForkResult,
+  ThreadForkTarget,
   ThreadResumeResult,
   ThreadStartParams,
   Turn,
@@ -1468,11 +1469,13 @@ app.whenReady().then(async () => {
       turnId?: string,
       itemId?: string,
       mode?: "local" | "worktree",
+      target?: ThreadForkTarget,
     ) =>
       appServerRequest<ThreadForkResult>(event, "thread/fork", {
         thread_id: threadId,
         turn_id: turnId ?? "",
         item_id: itemId ?? "",
+        ...(target ? { target } : {}),
         ...(mode ? { mode } : {}),
       }),
   );

--- a/desktop/src/main/preload.ts
+++ b/desktop/src/main/preload.ts
@@ -19,6 +19,7 @@ import {
   type SideThreadEventEnvelope,
   type SideThreadSendParams,
   type ThreadStartParams,
+  type ThreadForkTarget,
   type ThemePreference,
   type LanguagePreference,
   type WindowResizeState,
@@ -272,7 +273,8 @@ const api: WuuDesktopApi = {
     turnId?: string,
     itemId?: string,
     mode?: "local" | "worktree",
-  ) => ipcRenderer.invoke("wuu:thread-fork", threadId, turnId, itemId, mode),
+    target?: ThreadForkTarget,
+  ) => ipcRenderer.invoke("wuu:thread-fork", threadId, turnId, itemId, mode, target),
   editThreadMessage: (threadId: string, turnId: string, itemId: string) =>
     ipcRenderer.invoke("wuu:thread-edit-message", threadId, turnId, itemId),
   getThreadContextComposition: (threadId: string) =>

--- a/desktop/src/renderer/ConversationHistoryActions.test.ts
+++ b/desktop/src/renderer/ConversationHistoryActions.test.ts
@@ -279,7 +279,20 @@ describe("createConversationHistoryActions", () => {
   });
 
   it("forks a pending conversation and clears the pending dialog", async () => {
-    const source = thread("source-thread");
+    const source = thread("source-thread", {
+      turns: [
+        turn("turn-1", [
+          {
+            id: "item-1",
+            seq: 42,
+            source_id: "msg-42",
+            type: "agent_message",
+            role: "assistant",
+            text: "Checkpoint",
+          },
+        ]),
+      ],
+    });
     const fork = thread("fork-thread");
     const api = installWuuApi({ forkThreadResult: fork });
     const harness = buildActions({
@@ -300,6 +313,7 @@ describe("createConversationHistoryActions", () => {
       "turn-1",
       "item-1",
       "local",
+      { seq: 42, source_id: "msg-42", type: "agent_message" },
     );
     expect(harness.enableConversationAutoFollow).toHaveBeenCalled();
     expect(harness.getPendingFork()).toBeUndefined();

--- a/desktop/src/renderer/ConversationHistoryActions.ts
+++ b/desktop/src/renderer/ConversationHistoryActions.ts
@@ -167,8 +167,23 @@ export function createConversationHistoryActions(
       status: localizedText("history.forking"),
     }));
     try {
+      const targetItem = sourceThread.turns
+        .find((turn) => turn.id === turnID)
+        ?.items.find((item) => item.id === itemID);
       const fork = requireThread(
-        await window.wuu.forkThread(sourceThread.id, turnID, itemID, mode),
+        await window.wuu.forkThread(
+          sourceThread.id,
+          turnID,
+          itemID,
+          mode,
+          targetItem
+            ? {
+                seq: targetItem.seq,
+                source_id: targetItem.source_id,
+                type: targetItem.type,
+              }
+            : undefined,
+        ),
         "thread/fork did not return a thread",
       );
       deps.enableConversationAutoFollow();

--- a/internal/appserver/fork.go
+++ b/internal/appserver/fork.go
@@ -17,6 +17,10 @@ var (
 )
 
 func forkHistoryAtTarget(history []providers.ChatMessage, sourceThreadID string, turns []Turn, targetTurnID, targetItemID string) ([]providers.ChatMessage, error) {
+	return forkHistoryAtTargetWithIdentity(history, sourceThreadID, turns, targetTurnID, targetItemID, ThreadItem{})
+}
+
+func forkHistoryAtTargetWithIdentity(history []providers.ChatMessage, sourceThreadID string, turns []Turn, targetTurnID, targetItemID string, target ThreadItem) ([]providers.ChatMessage, error) {
 	targetTurnID = strings.TrimSpace(targetTurnID)
 	targetItemID = strings.TrimSpace(targetItemID)
 	if targetTurnID == "" && targetItemID == "" {
@@ -24,12 +28,43 @@ func forkHistoryAtTarget(history []providers.ChatMessage, sourceThreadID string,
 	}
 
 	projection := projectHistory(sourceThreadID, history, time.Time{})
+	origin, err := forkOriginAtTarget(projection, turns, targetTurnID, targetItemID, target)
+	if err != nil {
+		return nil, err
+	}
+	if origin.EndIndex < 0 || origin.EndIndex >= len(history) {
+		return nil, errForkTargetNotFound
+	}
+	return cloneForkHistory(history[:origin.EndIndex+1]), nil
+}
+
+func forkPersistedHistoryAtTarget(history []persistedMessage, sourceThreadID string, turns []Turn, targetTurnID, targetItemID string, target ThreadItem) ([]providers.ChatMessage, error) {
+	targetTurnID = strings.TrimSpace(targetTurnID)
+	targetItemID = strings.TrimSpace(targetItemID)
+	if targetTurnID == "" && targetItemID == "" {
+		return cloneForkHistory(chatMessagesFromPersistedMessages(history)), nil
+	}
+	projection := projectPersistedHistory(sourceThreadID, history, time.Time{}, nil)
+	origin, err := forkOriginAtTarget(projection, turns, targetTurnID, targetItemID, target)
+	if err != nil {
+		return nil, err
+	}
+	if origin.EndIndex < 0 || origin.EndIndex >= len(history) {
+		return nil, errForkTargetNotFound
+	}
+	return cloneForkHistory(chatMessagesFromPersistedMessages(history[:origin.EndIndex+1])), nil
+}
+
+func forkOriginAtTarget(projection historyProjection, turns []Turn, targetTurnID, targetItemID string, target ThreadItem) (historyItemOrigin, error) {
 	var origin historyItemOrigin
 	var ok bool
 	if targetItemID != "" {
-		origin, ok = projectionOriginForTarget(projection, turns, targetTurnID, targetItemID)
+		origin, ok = projectionOriginForIdentity(projection, target)
+		if !ok {
+			origin, ok = projectionOriginForTarget(projection, turns, targetTurnID, targetItemID)
+		}
 		if ok && !origin.Complete {
-			return nil, errForkToolResultsNotFound
+			return historyItemOrigin{}, errForkToolResultsNotFound
 		}
 	} else {
 		origin, ok = projection.TurnSpans[targetTurnID]
@@ -41,10 +76,28 @@ func forkHistoryAtTarget(history []providers.ChatMessage, sourceThreadID string,
 			}
 		}
 	}
-	if !ok || origin.EndIndex < 0 || origin.EndIndex >= len(history) {
-		return nil, errForkTargetNotFound
+	if !ok {
+		return historyItemOrigin{}, errForkTargetNotFound
 	}
-	return cloneForkHistory(history[:origin.EndIndex+1]), nil
+	return origin, nil
+}
+
+func projectionOriginForIdentity(projection historyProjection, target ThreadItem) (historyItemOrigin, bool) {
+	if target.Type == "" {
+		return historyItemOrigin{}, false
+	}
+	for _, origin := range projection.ItemOrigins {
+		if origin.Item.Type != target.Type {
+			continue
+		}
+		if target.Seq > 0 && origin.Item.Seq == target.Seq && (target.SourceID == "" || origin.Item.SourceID == target.SourceID) {
+			return origin, true
+		}
+		if target.Seq <= 0 && strings.TrimSpace(target.SourceID) != "" && origin.Item.SourceID == target.SourceID {
+			return origin, true
+		}
+	}
+	return historyItemOrigin{}, false
 }
 
 func projectionOriginForTarget(projection historyProjection, turns []Turn, turnID, itemID string) (historyItemOrigin, bool) {

--- a/internal/appserver/fork_test.go
+++ b/internal/appserver/fork_test.go
@@ -115,6 +115,61 @@ func TestForkHistoryUsesStableOriginsAcrossProviderCheckpoint(t *testing.T) {
 	}
 }
 
+func TestForkRawHistoryResolvesLiveItemIDAfterDisplayPruning(t *testing.T) {
+	threadID := "thread-live-checkpoint"
+	rawMessages := []providers.ChatMessage{
+		{Seq: 1, Role: "user", Content: "older prompt"},
+		{
+			Seq:              2,
+			Role:             "assistant",
+			Content:          "checking the repository",
+			ReasoningContent: "plan the inspection",
+			ToolCalls: []providers.ToolCall{{
+				ID: "call-read", Name: "read_file", Arguments: `{"path":"README.md"}`,
+			}},
+		},
+		{Seq: 3, Role: "tool", ToolCallID: "call-read", Content: "contents"},
+		{Seq: 4, Role: "assistant", Content: "older answer", Phase: providers.MessagePhaseFinalAnswer},
+		{Seq: 5, Role: "system", Content: compact.ConversationSummaryPrefix + "\nOlder context"},
+		{Seq: 6, Role: "user", Content: "recent prompt"},
+	}
+	raw := make([]persistedMessage, 0, len(rawMessages))
+	for _, msg := range rawMessages {
+		raw = append(raw, persistedMessageFromChatMessage(msg))
+	}
+	liveTurns := turnsFromPersistedHistory(threadID, raw[:4], time.Unix(0, 0).UTC(), nil)
+	targetTurn, targetItem := finalAnswerItemForForkTest(t, liveTurns, "older answer")
+	if targetItem.ID != targetTurn.ID+"-item-5" {
+		t.Fatalf("live target ID = %q, want item-5 after reasoning and tool items", targetItem.ID)
+	}
+	// Live items created from stream events in v0.11.1 did not carry a durable
+	// seq or provider source id, so only their original positional id survives.
+	targetItem.Seq = 0
+	targetItem.SourceID = ""
+	for turnIndex := range liveTurns {
+		for itemIndex := range liveTurns[turnIndex].Items {
+			if liveTurns[turnIndex].Items[itemIndex].ID == targetItem.ID {
+				liveTurns[turnIndex].Items[itemIndex].Seq = 0
+				liveTurns[turnIndex].Items[itemIndex].SourceID = ""
+			}
+		}
+	}
+
+	display := displayHistoryAcrossProviderCheckpoint(raw, raw[4:])
+	displayMessages := chatMessagesFromPersistedMessages(display)
+	if _, err := forkHistoryAtTargetWithIdentity(displayMessages, threadID, liveTurns, targetTurn.ID, targetItem.ID, targetItem); !errors.Is(err, errForkTargetNotFound) {
+		t.Fatalf("pruned display history unexpectedly resolved stale live ID: %v", err)
+	}
+
+	forked, err := forkPersistedHistoryAtTarget(raw, threadID, liveTurns, targetTurn.ID, targetItem.ID, targetItem)
+	if err != nil {
+		t.Fatalf("fork raw history at stale live ID: %v", err)
+	}
+	if last := forked[len(forked)-1]; last.Seq != 4 || last.Content != "older answer" {
+		t.Fatalf("fork resolved the wrong raw origin: %+v", forked)
+	}
+}
+
 func TestForkHistoryAtFinalAnswerSkipsRetiredContextArtifacts(t *testing.T) {
 	threadID := "thread-retired-context"
 	history := []providers.ChatMessage{

--- a/internal/appserver/model.go
+++ b/internal/appserver/model.go
@@ -743,10 +743,12 @@ func (th *threadState) applyMessageItemLocked(turnID string, msg providers.ChatM
 		var out []outboundNotification
 		if strings.TrimSpace(msg.ReasoningContent) != "" && th.activeReasoningItemID == "" && !th.hasReasoningTextLocked(turnID, msg.ReasoningContent) {
 			item := ThreadItem{
-				ID:     th.nextItemIDLocked(turnID),
-				Type:   ThreadItemReasoning,
-				Status: ThreadItemStatusCompleted,
-				Text:   msg.ReasoningContent,
+				ID:       th.nextItemIDLocked(turnID),
+				Seq:      msg.Seq,
+				SourceID: msg.ProviderItemID,
+				Type:     ThreadItemReasoning,
+				Status:   ThreadItemStatusCompleted,
+				Text:     msg.ReasoningContent,
 			}
 			th.upsertItemLocked(turnID, item, now)
 			out = append(out, itemStarted(th.ID, turnID, item, now), itemCompleted(th.ID, turnID, item, now))
@@ -763,6 +765,8 @@ func (th *threadState) applyMessageItemLocked(turnID string, msg providers.ChatM
 			out = append(out, itemStarted(th.ID, turnID, item, now))
 		}
 		item.Text = msg.Content
+		item.Seq = msg.Seq
+		item.SourceID = msg.ProviderItemID
 		item.Phase = phase
 		item.Status = ThreadItemStatusCompleted
 		item.FinishReason = string(msg.FinishReason)
@@ -1367,6 +1371,7 @@ func chatMessageItem(id string, msg providers.ChatMessage) ThreadItem {
 			return ThreadItem{
 				ID:           id,
 				Seq:          msg.Seq,
+				SourceID:     msg.ProviderItemID,
 				Type:         ThreadItemAgentMessage,
 				Status:       ThreadItemStatusCompleted,
 				Phase:        assistantMessagePhase(msg),
@@ -1379,11 +1384,12 @@ func chatMessageItem(id string, msg providers.ChatMessage) ThreadItem {
 		}
 		if strings.TrimSpace(msg.ReasoningContent) != "" {
 			return ThreadItem{
-				ID:     id,
-				Seq:    msg.Seq,
-				Type:   ThreadItemReasoning,
-				Status: ThreadItemStatusCompleted,
-				Text:   msg.ReasoningContent,
+				ID:       id,
+				Seq:      msg.Seq,
+				SourceID: msg.ProviderItemID,
+				Type:     ThreadItemReasoning,
+				Status:   ThreadItemStatusCompleted,
+				Text:     msg.ReasoningContent,
 			}
 		}
 	case "tool":

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -950,10 +950,17 @@ type ThreadResumeResult struct {
 }
 
 type ThreadForkParams struct {
-	ThreadID string `json:"thread_id"`
-	TurnID   string `json:"turn_id,omitempty"`
-	ItemID   string `json:"item_id,omitempty"`
-	Mode     string `json:"mode,omitempty"`
+	ThreadID string            `json:"thread_id"`
+	TurnID   string            `json:"turn_id,omitempty"`
+	ItemID   string            `json:"item_id,omitempty"`
+	Target   *ThreadForkTarget `json:"target,omitempty"`
+	Mode     string            `json:"mode,omitempty"`
+}
+
+type ThreadForkTarget struct {
+	Seq      int            `json:"seq,omitempty"`
+	Type     ThreadItemType `json:"type,omitempty"`
+	SourceID string         `json:"source_id,omitempty"`
 }
 
 type ThreadForkResult struct {

--- a/internal/appserver/thread_handlers.go
+++ b/internal/appserver/thread_handlers.go
@@ -238,6 +238,7 @@ type persistedThreadSnapshot struct {
 	repairNeeded    bool
 	baselineSeq     int
 	displayHistory  []persistedMessage
+	rawHistory      []persistedMessage
 	tokenMetas      []persistedMessage
 }
 
@@ -277,6 +278,7 @@ func (s *Server) loadPersistedThreadSnapshot(id string) (persistedThreadSnapshot
 	if err != nil {
 		return persistedThreadSnapshot{}, err
 	}
+	rawHistory := append([]persistedMessage(nil), displayHistory...)
 	displayHistory = displayHistoryAcrossProviderCheckpoint(displayHistory, providerRecords)
 	tokenMetas, err := loadMetaMessages(s.rt.SessionDir, id)
 	if err != nil {
@@ -288,6 +290,7 @@ func (s *Server) loadPersistedThreadSnapshot(id string) (persistedThreadSnapshot
 		repairNeeded:    !reflect.DeepEqual(repaired, history),
 		baselineSeq:     historyHeadSeq,
 		displayHistory:  displayHistory,
+		rawHistory:      rawHistory,
 		tokenMetas:      tokenMetas,
 	}
 	systemPrompt := s.rt.StreamRunner.SystemPrompt
@@ -300,6 +303,7 @@ func (s *Server) loadPersistedThreadSnapshot(id string) (persistedThreadSnapshot
 type forkSourceThread struct {
 	history        []providers.ChatMessage
 	displayHistory []providers.ChatMessage
+	rawHistory     []persistedMessage
 	modelProvider  string
 	model          string
 	modelVariant   string
@@ -331,9 +335,18 @@ func (s *Server) handleThreadFork(req Request) error {
 	if err != nil {
 		return s.writeResponse(req.ID, nil, err)
 	}
-	history, err := forkHistoryAtTarget(source.history, source.thread.ID, source.thread.Turns, params.TurnID, params.ItemID)
+	target := ThreadItem{}
+	if params.Target != nil {
+		target.Seq = params.Target.Seq
+		target.Type = params.Target.Type
+		target.SourceID = strings.TrimSpace(params.Target.SourceID)
+	}
+	history, err := forkHistoryAtTargetWithIdentity(source.history, source.thread.ID, source.thread.Turns, params.TurnID, params.ItemID, target)
+	if errors.Is(err, errForkTargetNotFound) && len(source.rawHistory) > 0 {
+		history, err = forkPersistedHistoryAtTarget(source.rawHistory, source.thread.ID, source.thread.Turns, params.TurnID, params.ItemID, target)
+	}
 	if errors.Is(err, errForkTargetNotFound) && len(source.displayHistory) > 0 {
-		history, err = forkHistoryAtTarget(source.displayHistory, source.thread.ID, source.thread.Turns, params.TurnID, params.ItemID)
+		history, err = forkHistoryAtTargetWithIdentity(source.displayHistory, source.thread.ID, source.thread.Turns, params.TurnID, params.ItemID, target)
 	}
 	if err != nil {
 		return s.writeResponse(req.ID, nil, err)
@@ -551,6 +564,7 @@ func (s *Server) loadForkSourceThread(id string, now time.Time) (forkSourceThrea
 				return forkSourceThread{}, err
 			}
 			source.displayHistory = chatMessagesFromPersistedMessages(loaded.displayHistory)
+			source.rawHistory = loaded.rawHistory
 		}
 		return source, nil
 	}
@@ -573,10 +587,12 @@ func (s *Server) loadForkSourceThread(id string, now time.Time) (forkSourceThrea
 	history = replaceBaseSystemPrompt(repaired, s.rt.StreamRunner.SystemPrompt)
 	th := newThreadState(id, history, s.rt.ProviderName, s.rt.Model, s.rt.RootDir, true, now)
 	displayHistory := cloneHistory(history)
+	var rawHistory []persistedMessage
 	if loaded, loadErr := s.loadPersistedThreadSnapshot(id); loadErr != nil {
 		return forkSourceThread{}, loadErr
 	} else {
 		displayHistory = chatMessagesFromPersistedMessages(loaded.displayHistory)
+		rawHistory = loaded.rawHistory
 		th.Turns = turnsFromPersistedHistory(id, loaded.displayHistory, now, s.resolveParticipantSummary)
 	}
 	if metas, err := loadMetaMessages(s.rt.SessionDir, id); err != nil {
@@ -595,6 +611,7 @@ func (s *Server) loadForkSourceThread(id string, now time.Time) (forkSourceThrea
 	return forkSourceThread{
 		history:        cloneHistory(th.History),
 		displayHistory: displayHistory,
+		rawHistory:     rawHistory,
 		modelProvider:  th.ModelProvider,
 		model:          th.Model,
 		modelVariant:   th.ModelVariant,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1633,6 +1633,8 @@ export type ThreadItem = {
   reason?: string;
 };
 
+export type ThreadForkTarget = Pick<ThreadItem, "type" | "seq" | "source_id">;
+
 export type PlanStepStatus = "pending" | "in_progress" | "completed";
 
 export type PlanStep = {
@@ -2063,6 +2065,7 @@ export type WuuDesktopApi = {
     turnId?: string,
     itemId?: string,
     mode?: "local" | "worktree",
+    target?: ThreadForkTarget,
   ) => Promise<ThreadForkResult>;
   editThreadMessage: (threadId: string, turnId: string, itemId: string) => Promise<ThreadEditMessageResult>;
   getThreadContextComposition: (threadId: string) => Promise<ThreadContextCompositionResult>;


### PR DESCRIPTION
## Summary

- address fork targets with stable message identity (`seq`, item type, and source id) instead of relying only on projected `item-N` positions
- resolve pre-checkpoint targets against raw persisted history before falling back to the pruned display projection
- preserve provider item ids on assistant/reasoning items and pass target identity through the desktop IPC protocol
- cover a live-session compaction case where pruning reasoning/tool items shifts the visible target from `item-5` to `item-3`

## Root cause

A long-running thread retained live positional item ids across compaction, while fork reprojected checkpointed/display history after old reasoning and tool payloads had been removed. The same visible assistant message then had a different `item-N`, and v0.11.1 could not use its seq fallback because live items had no stable address.

## Verification

- `go test ./internal/appserver -run 'TestForkHistory|TestForkRaw|TestServerThreadFork' -count=1`\n- `go test ./internal/appserver -count=1`\n- `git diff --check origin/main...HEAD`\n- `gofmt -d` on changed Go files\n\nDesktop unit tests and typecheck were not run because this environment has no Node/npm runtime.