### PR TITLE
fix(desktop): retry hero focus after send failure

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -2897,13 +2897,11 @@ export function App(): JSX.Element {
     const sent = await sendComposerMessage(message, true);
     if (!sent && focusRequest) {
       cancelMainComposerFocusRequest(focusRequest);
-      window.requestAnimationFrame(() => {
-        focusMainComposer(
-          "hero",
-          focusRequest.origin,
-          focusRequest.interactionVersion,
-        );
-      });
+      requestMainComposerFocus(
+        "hero",
+        focusRequest.origin,
+        focusRequest.interactionVersion,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- route failed first-turn focus restoration through the existing composer focus request mechanism
- wait for the hero composer to remount instead of making a single requestAnimationFrame attempt
- preserve the original interaction version so later user focus changes are not stolen

## Context
The post-merge `main` CI run failed twice in `AppComposerFocus.test.tsx` because the hero composer had not remounted when the one-shot focus callback ran.

## Verification
- `npm run typecheck`
- `AppComposerFocus.test.tsx` passed in 5 consecutive runs
- `git diff --check`
