### PR TITLE
fix(desktop): preserve composer focus across project switches

### DIFF
--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -312,6 +312,7 @@ type MainComposerFocusRequest = {
   target: ComposerVariant;
   origin: Element | null;
   interactionVersion: number;
+  matchesDestination?: (state: AppState) => boolean;
 };
 
 export function App(): JSX.Element {
@@ -1792,11 +1793,13 @@ export function App(): JSX.Element {
       target: ComposerVariant,
       origin: Element | null = document.activeElement,
       interactionVersion: number = userInteractionVersionRef.current,
+      matchesDestination?: (state: AppState) => boolean,
     ): MainComposerFocusRequest => {
       const request = {
         target,
         origin,
         interactionVersion,
+        matchesDestination,
       };
       setMainComposerFocusRequest(request);
       return request;
@@ -1817,6 +1820,12 @@ export function App(): JSX.Element {
       return;
     }
     if (
+      mainComposerFocusRequest.matchesDestination &&
+      !mainComposerFocusRequest.matchesDestination(state)
+    ) {
+      return;
+    }
+    if (
       !focusMainComposer(
         mainComposerFocusRequest.target,
         mainComposerFocusRequest.origin,
@@ -1833,7 +1842,7 @@ export function App(): JSX.Element {
     focusMainComposer,
     mainComposerFocusRequest,
     mainConversationDockVisible,
-    state.activeSessionTabID,
+    state,
   ]);
   const handleTurnCollapseComplete = useCallback(() => {
     scheduleStreamScroll();
@@ -2658,22 +2667,16 @@ export function App(): JSX.Element {
       if (succeeded === false) {
         return;
       }
-      window.requestAnimationFrame(() => {
-        const current = appStateRef.current;
-        if (
+      requestMainComposerFocus(
+        "hero",
+        origin,
+        interactionVersion,
+        (current) =>
           !current.thread &&
           !current.secondaryThread &&
           activeSessionTab(current)?.kind === "draft" &&
-          matchesDestination(current)
-        ) {
-          // Queue the focus through the layout effect instead of making a
-          // one-shot attempt in this frame. React may not have committed the
-          // destination hero composer yet, so the request must survive until
-          // that element is mounted. Preserve the interaction version from
-          // the original click so later user input still cancels the handoff.
-          requestMainComposerFocus("hero", origin, interactionVersion);
-        }
-      });
+          matchesDestination(current),
+      );
     });
   }
 

--- a/desktop/src/renderer/AppComposerFocus.test.tsx
+++ b/desktop/src/renderer/AppComposerFocus.test.tsx
@@ -417,6 +417,15 @@ describe("main composer focus continuity", () => {
 
   it("waits for the destination hero before focusing across projects", async () => {
     await renderApp(false, { deferProjectSelection: true });
+    // Resolve animation frames synchronously to model the race where the
+    // project action settles before React commits the destination state.
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      },
+    });
     const button = container.querySelector<HTMLButtonElement>(
       'button[aria-label="在 Focus Project 中新建会话"]',
     );


### PR DESCRIPTION
## Summary
- keep a pending composer-focus request until the destination project state is committed
- evaluate the destination predicate against the current render state instead of a lagging ref
- make the cross-project focus regression deterministic when animation frames run before React commits

## Verification
- `npm run typecheck`
- `npx vitest run src/renderer/AppComposerFocus.test.tsx --maxWorkers=1 --minWorkers=1`
- focused suite passed 30 consecutive isolated runs
- `make check-desktop test-desktop build-desktop`