### PR TITLE
fix(gitattribution): resolve Git Bash exe paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Git attribution in Windows Git Bash shells when Git resolves without an
+  `.exe` suffix.
+
 ## [0.12.2] - 2026-07-25
 
 ### Added

--- a/internal/gitattribution/wrapper.go
+++ b/internal/gitattribution/wrapper.go
@@ -118,7 +118,7 @@ func Dispatch(args []string) (bool, int) {
 		return true, 127
 	}
 	wrapperPath := args[1]
-	realGit := args[2]
+	realGit := resolveRealGitExecutable(args[2])
 	if err := validateRealGit(wrapperPath, realGit); err != nil {
 		fmt.Fprintf(os.Stderr, "wuu: internal git wrapper rejected executable %q: %v\n", realGit, err)
 		return true, 127
@@ -140,6 +140,23 @@ func Dispatch(args []string) (bool, int) {
 		return true, 126
 	}
 	return true, 0
+}
+
+func resolveRealGitExecutable(realGit string) string {
+	if runtime.GOOS != "windows" || strings.EqualFold(filepath.Ext(realGit), ".exe") {
+		return realGit
+	}
+	if _, err := os.Stat(realGit); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return realGit
+	}
+
+	// Git Bash omits .exe from command -v output before MSYS converts the path
+	// for this native Windows process.
+	executablePath := realGit + ".exe"
+	if _, err := os.Stat(executablePath); err == nil {
+		return executablePath
+	}
+	return realGit
 }
 
 func validateRealGit(wrapperPath, realGit string) error {

--- a/internal/gitattribution/wrapper_test.go
+++ b/internal/gitattribution/wrapper_test.go
@@ -3,6 +3,7 @@ package gitattribution
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -34,6 +35,79 @@ func TestValidateRealGitAcceptsDifferentGitExecutable(t *testing.T) {
 
 	if err := validateRealGit(wrapperPath, realGit); err != nil {
 		t.Fatalf("validateRealGit() error = %v", err)
+	}
+}
+
+func TestResolveRealGitExecutableAddsWindowsSuffix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable resolution")
+	}
+
+	realGit := filepath.Join(t.TempDir(), "git")
+	executablePath := realGit + ".exe"
+	if err := os.WriteFile(executablePath, nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveRealGitExecutable(realGit); got != executablePath {
+		t.Fatalf("resolveRealGitExecutable() = %q, want %q", got, executablePath)
+	}
+}
+
+func TestResolveRealGitExecutableKeepsExistingWindowsPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable resolution")
+	}
+
+	realGit := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(realGit, nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(realGit+".exe", nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveRealGitExecutable(realGit); got != realGit {
+		t.Fatalf("resolveRealGitExecutable() = %q, want original path %q", got, realGit)
+	}
+}
+
+func TestResolveRealGitExecutableKeepsMissingWindowsPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable resolution")
+	}
+
+	realGit := filepath.Join(t.TempDir(), "git")
+	if got := resolveRealGitExecutable(realGit); got != realGit {
+		t.Fatalf("resolveRealGitExecutable() = %q, want original missing path %q", got, realGit)
+	}
+}
+
+func TestResolveRealGitExecutableKeepsWindowsExeExtension(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable resolution")
+	}
+
+	realGit := filepath.Join(t.TempDir(), "git.EXE")
+	if got := resolveRealGitExecutable(realGit); got != realGit {
+		t.Fatalf("resolveRealGitExecutable() = %q, want original .EXE path %q", got, realGit)
+	}
+}
+
+func TestResolveRealGitExecutableStillRejectsWrapperExe(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable resolution")
+	}
+
+	realGit := filepath.Join(t.TempDir(), "git")
+	wrapperPath := realGit + ".exe"
+	if err := os.WriteFile(wrapperPath, nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved := resolveRealGitExecutable(realGit)
+	if err := validateRealGit(wrapperPath, resolved); err == nil || !strings.Contains(err.Error(), "wrapper itself") {
+		t.Fatalf("validateRealGit() error = %v, want self-wrapper rejection after resolving %q", err, resolved)
 	}
 }
 


### PR DESCRIPTION
Clean integration of the Windows Git Bash executable-resolution fix from #183.

The commit retains Rosemary1812 as the author while rebasing the intended three-file change onto current `main`; unrelated branch history from #183 is intentionally excluded.

On Windows, Git Bash can return a native Git path without the `.exe` suffix. The native Wuu dispatcher now resolves the existing `.exe` variant before applying the existing executable-name and self-wrapper checks.

Validation:
- `make check-go test-go build-go`
- `make repository-check`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/gitattribution/...`