### PR TITLE
fix(appserver): gate replayed completion turns

### DIFF
--- a/internal/appserver/process_notifications_test.go
+++ b/internal/appserver/process_notifications_test.go
@@ -261,6 +261,73 @@ func TestProcessCompletionHistoryMarkerPreventsDuplicateModelTurn(t *testing.T) 
 	}
 }
 
+func TestQueuedProcessCompletionAlreadyAnsweredSkipsProvider(t *testing.T) {
+	mainClient := &fakeClient{response: providers.ChatResponse{Content: "should not run"}}
+	rt := newTestRuntime(t, mainClient)
+	manager, err := process.NewManager(rt.RootDir, filepath.Join(rt.RootDir, "process-runtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	threadID := "thread-queued-process-already-answered"
+	threadRuntime := &runtime.ThreadRuntime{StreamRunner: rt.StreamRunner, ProcessManager: manager}
+	out := &lockedBuffer{}
+	server := New(rt, out)
+	t.Cleanup(server.Close)
+	started, err := manager.Start(context.Background(), process.StartOptions{
+		Command:   "printf 'done\\n'",
+		OwnerKind: process.OwnerMainAgent,
+		OwnerID:   threadID,
+		Lifecycle: process.LifecycleManaged,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pending, err := manager.CompletionPending(started.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pending {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	history := []providers.ChatMessage{
+		{Role: "user", Content: "run and continue"},
+		{Role: "user", ClientID: processCompletionClientID([]string{started.ID}), Content: "process done"},
+		{Role: "assistant", ClientID: processCompletionAnswerClientIDPrefix + started.ID, Content: "already handled"},
+	}
+	rootThread := newThreadState(threadID, history, rt.ProviderName, rt.Model, rt.RootDir, false, time.Now().UTC())
+	rootThread.execRuntime = threadRuntime
+	server.mu.Lock()
+	server.threads[threadID] = rootThread
+	server.mu.Unlock()
+	rootThread.runtimeSubscription = server.subscribeThreadRuntime(threadID, threadRuntime)
+	t.Cleanup(func() { releaseThreadRuntime(rootThread) })
+
+	queuedID := processCompletionClientID([]string{started.ID})
+	startedTurn, err := server.startQueuedTurn(context.Background(), threadID, queuedTurn{
+		id:       queuedID,
+		msg:      providers.ChatMessage{Role: "user", ClientID: queuedID, Content: "process done"},
+		snapshot: turnRuntimeSnapshot{ProcessCompletionIDs: []string{started.ID}},
+	})
+	if err != nil {
+		t.Fatalf("startQueuedTurn: %v", err)
+	}
+	if !startedTurn {
+		t.Fatal("already answered queued completion should be settled")
+	}
+	assertFakeClientRequestCount(t, mainClient, 0)
+	pending, err := manager.CompletionPending(started.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending {
+		t.Fatal("answered process completion was not marked delivered")
+	}
+}
+
 func TestProcessCompletionDrainYieldsToQueuedUserWork(t *testing.T) {
 	threadID := "thread-user-priority"
 	server := &Server{

--- a/internal/appserver/turn_handlers.go
+++ b/internal/appserver/turn_handlers.go
@@ -2957,9 +2957,15 @@ func (s *Server) startQueuedTurn(ctx context.Context, threadID string, entry que
 		turnAdmissionHooks{afterLease: func(admitted *threadState, _ *providers.ChatMessage) error {
 			var runtimeErr error
 			threadRuntime, runtimeErr = s.ensureThreadRuntimeAfterAdmission(admitted)
-			return runtimeErr
+			if runtimeErr != nil {
+				return runtimeErr
+			}
+			return gateAlreadyDeliveredCompletions(admitted.History, threadRuntime, snapshot.AgentCompletionResultIDs, snapshot.ProcessCompletionIDs)
 		}},
 	)
+	if errors.Is(err, errAgentCompletionAlreadyDelivered) {
+		return true, nil
+	}
 	if err != nil || !ok {
 		return ok, err
 	}
@@ -2990,6 +2996,59 @@ func (s *Server) startQueuedTurn(ctx context.Context, threadID string, entry que
 	}
 	launch.Commit()
 	return true, nil
+}
+
+func gateAlreadyDeliveredCompletions(history []providers.ChatMessage, threadRuntime *runtime.ThreadRuntime, agentResultIDs, processIDs []string) error {
+	agentResultIDs = uniqueSortedCompletionIDs(agentResultIDs)
+	processIDs = uniqueSortedCompletionIDs(processIDs)
+	if len(agentResultIDs) == 0 && len(processIDs) == 0 {
+		return nil
+	}
+	if len(agentResultIDs) > 0 {
+		if threadRuntime == nil || threadRuntime.AgentControl == nil {
+			return errors.Join(errRetryableTurnAdmission, errors.New("agent completion control is unavailable"))
+		}
+		for _, resultID := range agentResultIDs {
+			consumer, err := threadRuntime.AgentControl.AgentResultDeliveryConsumer(resultID)
+			if err != nil {
+				return errors.Join(errRetryableTurnAdmission, err)
+			}
+			if consumer != "" {
+				return errAgentCompletionAlreadyDelivered
+			}
+			if agentCompletionMarkerAnswered(history, resultID) {
+				claimed, consumedBy, err := threadRuntime.AgentControl.ClaimAgentResultDeliveryID(resultID, "auto_completion")
+				if err != nil {
+					return errors.Join(errRetryableTurnAdmission, err)
+				}
+				if !claimed && consumedBy == "" {
+					return errors.Join(errRetryableTurnAdmission, fmt.Errorf("agent result delivery %q is unavailable", resultID))
+				}
+				return errAgentCompletionAlreadyDelivered
+			}
+		}
+	}
+	if len(processIDs) > 0 {
+		if threadRuntime == nil || threadRuntime.ProcessManager == nil {
+			return errors.Join(errRetryableTurnAdmission, errors.New("process completion manager is unavailable"))
+		}
+		for _, processID := range processIDs {
+			pending, err := threadRuntime.ProcessManager.CompletionPending(processID)
+			if err != nil {
+				return errors.Join(errRetryableTurnAdmission, err)
+			}
+			if !pending {
+				return errAgentCompletionAlreadyDelivered
+			}
+			if processCompletionMarkerAnswered(history, processID) {
+				if _, err := threadRuntime.ProcessManager.MarkCompletionDelivered(processID, "history_answer"); err != nil {
+					return errors.Join(errRetryableTurnAdmission, err)
+				}
+				return errAgentCompletionAlreadyDelivered
+			}
+		}
+	}
+	return nil
 }
 
 func (s *Server) takeNextQueuedUserTurn(threadID string) (queuedTurn, bool) {
@@ -3346,42 +3405,8 @@ func (s *Server) startSyntheticTurn(ctx context.Context, threadID string, userMs
 				if err != nil {
 					return err
 				}
-				for _, resultID := range completionResultIDs {
-					consumer, err := threadRuntime.AgentControl.AgentResultDeliveryConsumer(resultID)
-					if err != nil {
-						return errors.Join(errRetryableTurnAdmission, err)
-					}
-					if consumer != "" {
-						return errAgentCompletionAlreadyDelivered
-					}
-					if agentCompletionMarkerAnswered(admitted.History, resultID) {
-						claimed, consumedBy, err := threadRuntime.AgentControl.ClaimAgentResultDeliveryID(resultID, "auto_completion")
-						if err != nil {
-							return errors.Join(errRetryableTurnAdmission, err)
-						}
-						if !claimed && consumedBy == "" {
-							return errors.Join(errRetryableTurnAdmission, fmt.Errorf("agent result delivery %q is unavailable", resultID))
-						}
-						return errAgentCompletionAlreadyDelivered
-					}
-				}
-				for _, processID := range processCompletionIDs {
-					if threadRuntime.ProcessManager == nil {
-						return errors.Join(errRetryableTurnAdmission, errors.New("process completion manager is unavailable"))
-					}
-					pending, err := threadRuntime.ProcessManager.CompletionPending(processID)
-					if err != nil {
-						return errors.Join(errRetryableTurnAdmission, err)
-					}
-					if !pending {
-						return errAgentCompletionAlreadyDelivered
-					}
-					if processCompletionMarkerAnswered(admitted.History, processID) {
-						if _, err := threadRuntime.ProcessManager.MarkCompletionDelivered(processID, "history_answer"); err != nil {
-							return errors.Join(errRetryableTurnAdmission, err)
-						}
-						return errAgentCompletionAlreadyDelivered
-					}
+				if err := gateAlreadyDeliveredCompletions(admitted.History, threadRuntime, completionResultIDs, processCompletionIDs); err != nil {
+					return err
 				}
 				*admittedMsg = combineAgentCompletionMessages(pending)
 				if clientID := agentCompletionClientID(pending); clientID != "" {


### PR DESCRIPTION
## Summary

Fixes replayed queued completion turns so already-answered process completions are settled without invoking the provider again.

## Changes

- Gates queued completion turns through the same already-delivered completion checks used by synthetic turns.
- Marks already-answered process completions as delivered when history already contains the answer marker.
- Adds regression coverage for a queued process completion that was already answered.

## Test plan

- [x] Added or updated unit tests for the change
- [x] `git diff --check upstream/main...HEAD`
- [x] `gofmt -l internal/appserver/turn_handlers.go internal/appserver/process_notifications_test.go`
- [x] `go test -p 1 ./internal/appserver -run 'TestQueuedProcessCompletionAlreadyAnsweredSkipsProvider|TestProcessCompletionDrainYieldsToQueuedUserWork' -count=1`
- [ ] `go test ./...` not run; local Windows runs hit existing platform cleanup/permission issues around temp lock files
- [ ] `cd desktop && npm test` not applicable; this PR only touches Go appserver code
- [ ] Manually verified in desktop shell

## Risk and rollback

- Risk level: low
- Rollback: revert this commit to restore the previous queued completion replay behavior.

## Linked issues / docs

Closes #179.
