### PR TITLE
Fix provider client refresh and MiniMax API key handling

### DIFF
--- a/desktop/src/renderer/SettingsView.test.tsx
+++ b/desktop/src/renderer/SettingsView.test.tsx
@@ -517,7 +517,7 @@ describe("SettingsView provider configuration", () => {
     expect(onRemoveProvider).not.toHaveBeenCalled();
   });
 
-  it("submits a new Anthropic-compatible provider with bearer token auth", async () => {
+  it("submits a new Anthropic-compatible provider with API key auth", async () => {
     installBuildInfoStub({
       core: undefined,
       desktop: { version: "0.0.0-test", date: "1970-01-01T00:00:00Z" },
@@ -559,12 +559,12 @@ describe("SettingsView provider configuration", () => {
     });
 
     const inputs = Array.from(container.querySelectorAll("input"));
-    const [providerInput, modelInput, baseURLInput, authTokenInput] = inputs;
+    const [providerInput, modelInput, baseURLInput, apiKeyInput] = inputs;
     await act(async () => {
       setInputValue(providerInput, "anthropic-gateway");
       setInputValue(modelInput, "claude-sonnet-4-6[1M]");
       setInputValue(baseURLInput, "https://anthropic-gateway.example.test/");
-      setInputValue(authTokenInput, "sk-token");
+      setInputValue(apiKeyInput, "sk-token");
     });
 
     const submitButton = Array.from(container.querySelectorAll("button")).find((button) =>
@@ -582,7 +582,7 @@ describe("SettingsView provider configuration", () => {
       undefined,
       {
         base_url: "https://anthropic-gateway.example.test/",
-        auth_token: "sk-token",
+        api_key: "sk-token",
         type: "anthropic",
         create_provider: true,
       },

--- a/desktop/src/renderer/SettingsView.tsx
+++ b/desktop/src/renderer/SettingsView.tsx
@@ -431,11 +431,7 @@ export function SettingsView({
     const connection: RuntimeConnectionUpdate = {
       base_url: baseURLDraft.trim() || selectedProvider?.base_url || ""
     };
-    if (isAnthropicProviderType(selectedProvider?.type)) {
-      connection.auth_token = apiKey;
-    } else {
-      connection.api_key = apiKey;
-    }
+    connection.api_key = apiKey;
     setError("");
     try {
       await onSave(providerDraft, modelDraft, undefined, connection, variantDraft);
@@ -457,11 +453,7 @@ export function SettingsView({
         type: providerTypeDraft,
         create_provider: true
       };
-      if (isAnthropicProviderType(providerTypeDraft)) {
-        connection.auth_token = apiKeyDraft.trim();
-      } else {
-        connection.api_key = apiKeyDraft.trim();
-      }
+      connection.api_key = apiKeyDraft.trim();
       await onSave(providerDraft, modelDraft, undefined, connection, variantDraft);
       setAddingProvider(false);
       setAPIKeyDraft("");
@@ -1129,10 +1121,7 @@ function SettingsProvidersPage({
 }): JSX.Element {
   const { t } = useI18n();
   const reasoningMode = providerModelReasoningMode(selectedProvider, modelDraft);
-  const authFieldUsesToken = isAnthropicProviderType(addingProvider ? providerTypeDraft : selectedProvider?.type);
-  const authFieldLabel = authFieldUsesToken
-    ? t("provider.authToken")
-    : t("provider.apiKey");
+  const authFieldLabel = t("provider.apiKey");
   // Text fields commit on blur, or on Enter — except while creating a
   // provider, where Enter submits the create transaction instead.
   const commitOnEnter =

--- a/internal/appserver/config_handlers.go
+++ b/internal/appserver/config_handlers.go
@@ -973,7 +973,7 @@ func (s *Server) handleConfigModelUpdate(req Request) error {
 	}
 	ruleProviderName, ruleProviderCfg := modelcatalog.EnrichProvider(resolvedName, providerCfg, model)
 	_, previousRuleProviderCfg := modelcatalog.EnrichProvider(resolvedName, previousProviderCfg, previousModel)
-	modelHeadersChanged := !reflect.DeepEqual(previousRuleProviderCfg.Headers, ruleProviderCfg.Headers)
+	providerClientChanged := providerClientConfigChanged(previousRuleProviderCfg, ruleProviderCfg)
 	// Variant/effort params validate against the effective model they will
 	// pin, not the workspace model: rejecting an effort change on a thread
 	// pinned to a different model against the workspace model would break
@@ -1012,7 +1012,7 @@ func (s *Server) handleConfigModelUpdate(req Request) error {
 	}
 
 	var client providers.StreamClient
-	if resolvedName != s.rt.ProviderName || connectionChanged || modelHeadersChanged {
+	if resolvedName != s.rt.ProviderName || connectionChanged || providerClientChanged {
 		client, err = providerfactory.BuildStreamClient(ruleProviderCfg, resolvedName)
 		if err != nil {
 			return s.writeResponse(req.ID, nil, err)
@@ -1087,7 +1087,7 @@ func (s *Server) handleConfigModelUpdate(req Request) error {
 		}
 		s.rt.TitleClient = titleClient
 	}
-	if s.rt.Toolkit != nil && (!roleSelections.Worker.Inherited || connectionChanged || modelHeadersChanged || resolvedName != previousRuntimeProvider) {
+	if s.rt.Toolkit != nil && (!roleSelections.Worker.Inherited || connectionChanged || providerClientChanged || resolvedName != previousRuntimeProvider) {
 		workerClient, workerErr := providerfactory.BuildStreamClient(roleSelections.Worker.RuleProviderConfig, roleSelections.Worker.Provider)
 		if workerErr != nil {
 			return s.writeResponse(req.ID, nil, fmt.Errorf("build worker client: %w", workerErr))
@@ -1220,6 +1220,26 @@ func isUltraOnlyModelUpdate(params ConfigModelUpdateParams) bool {
 		params.AuthToken == nil &&
 		params.Type == nil &&
 		!params.CreateProvider
+}
+
+func providerClientConfigChanged(previous, next config.ProviderConfig) bool {
+	return strings.TrimSpace(previous.Type) != strings.TrimSpace(next.Type) ||
+		strings.TrimSpace(previous.BaseURL) != strings.TrimSpace(next.BaseURL) ||
+		strings.TrimSpace(previous.API) != strings.TrimSpace(next.API) ||
+		strings.TrimSpace(previous.NPM) != strings.TrimSpace(next.NPM) ||
+		strings.TrimSpace(previous.WireAPI) != strings.TrimSpace(next.WireAPI) ||
+		strings.TrimSpace(previous.APIKey) != strings.TrimSpace(next.APIKey) ||
+		strings.TrimSpace(previous.APIKeyEnv) != strings.TrimSpace(next.APIKeyEnv) ||
+		strings.TrimSpace(previous.AuthToken) != strings.TrimSpace(next.AuthToken) ||
+		strings.TrimSpace(previous.AuthTokenEnv) != strings.TrimSpace(next.AuthTokenEnv) ||
+		previous.ReuseCodexCredentials != next.ReuseCodexCredentials ||
+		previous.StreamConnectTimeoutMS != next.StreamConnectTimeoutMS ||
+		previous.StreamHeaderTimeoutMS != next.StreamHeaderTimeoutMS ||
+		previous.StreamIdleTimeoutMS != next.StreamIdleTimeoutMS ||
+		strings.TrimSpace(previous.StreamTransport) != strings.TrimSpace(next.StreamTransport) ||
+		previous.CacheCreationInputTokensOmitted != next.CacheCreationInputTokensOmitted ||
+		previous.InputTokensIncludeCacheRead != next.InputTokensIncludeCacheRead ||
+		!reflect.DeepEqual(previous.Headers, next.Headers)
 }
 
 func (s *Server) currentConfigModelUpdateResult() ConfigModelUpdateResult {

--- a/internal/appserver/server_test.go
+++ b/internal/appserver/server_test.go
@@ -1184,6 +1184,25 @@ func TestServerConfigModelUpdate(t *testing.T) {
 	}
 }
 
+func TestProviderClientConfigChangedDetectsAuthAndEndpointChanges(t *testing.T) {
+	base := config.ProviderConfig{
+		Type:      "openai-compatible",
+		BaseURL:   "https://api.deepseek.example/v1",
+		APIKeyEnv: "DEEPSEEK_API_KEY",
+		Headers:   map[string]string{"X-Test": "same"},
+	}
+	next := base
+	next.Type = "anthropic"
+	next.BaseURL = "https://api.minimax.example/anthropic/v1"
+	next.APIKeyEnv = "MINIMAX_API_KEY"
+	if !providerClientConfigChanged(base, next) {
+		t.Fatal("expected provider client config change for endpoint/wire/auth env switch")
+	}
+	if providerClientConfigChanged(base, base) {
+		t.Fatal("identical provider client config should not require a rebuild")
+	}
+}
+
 func TestCachedThreadRestoresPersistedModelSelection(t *testing.T) {
 	rt := newTestRuntime(t, &fakeClient{})
 	if err := os.WriteFile(rt.ConfigPath, []byte(`{

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -325,6 +325,8 @@ func ResolveAPIKeyWithHome(provider config.ProviderConfig, providerName, home st
 		if store, err := authstorage.ForHome(home); err == nil {
 			if credentials, err := store.Get(providerName); err == nil && strings.TrimSpace(credentials.APIKey) != "" {
 				return strings.TrimSpace(credentials.APIKey), nil
+			} else if err == nil && shouldTreatStoredAuthTokenAsAPIKey(provider, providerName) && strings.TrimSpace(credentials.AuthToken) != "" {
+				return strings.TrimSpace(credentials.AuthToken), nil
 			}
 		}
 	}
@@ -366,11 +368,22 @@ func resolveAuthToken(provider config.ProviderConfig, providerName string) strin
 	if providerName != "" {
 		if store, err := authstorage.ForHome(os.Getenv("HOME")); err == nil {
 			if credentials, err := store.Get(providerName); err == nil && strings.TrimSpace(credentials.AuthToken) != "" {
+				if shouldTreatStoredAuthTokenAsAPIKey(provider, providerName) {
+					return ""
+				}
 				return strings.TrimSpace(credentials.AuthToken)
 			}
 		}
 	}
 	return ""
+}
+
+func shouldTreatStoredAuthTokenAsAPIKey(provider config.ProviderConfig, providerName string) bool {
+	name := strings.ToLower(strings.TrimSpace(providerName))
+	baseURL := strings.ToLower(strings.TrimSpace(provider.BaseURL))
+	return strings.Contains(name, "minimax") ||
+		strings.Contains(baseURL, "minimax.io") ||
+		strings.Contains(baseURL, "minimaxi.com")
 }
 
 func defaultAPIKeyEnv(providerType string) string {

--- a/internal/providerfactory/factory_test.go
+++ b/internal/providerfactory/factory_test.go
@@ -379,6 +379,52 @@ func TestResolveAPIKey_AuthStoreFallback(t *testing.T) {
 	}
 }
 
+func TestResolveAPIKey_MiniMaxMigratesStoredAuthTokenFallback(t *testing.T) {
+	home := t.TempDir()
+	store, err := authstorage.ForHome(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("minimax", authstorage.Credentials{Type: "auth_token", AuthToken: "sk-minimax-from-old-ui"}); err != nil {
+		t.Fatalf("save auth token: %v", err)
+	}
+
+	provider := config.ProviderConfig{
+		Type:    "anthropic",
+		BaseURL: "https://api.minimaxi.com/anthropic",
+		Model:   "MiniMax-M3",
+	}
+	key, err := ResolveAPIKeyWithHome(provider, "minimax", home)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if key != "sk-minimax-from-old-ui" {
+		t.Fatalf("expected migrated MiniMax key, got %q", key)
+	}
+}
+
+func TestResolveAuthToken_NonMiniMaxStoredAuthTokenStaysBearer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	store, err := authstorage.ForHome(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("anthropic", authstorage.Credentials{Type: "auth_token", AuthToken: "bearer-token"}); err != nil {
+		t.Fatalf("save auth token: %v", err)
+	}
+
+	provider := config.ProviderConfig{
+		Type:    "anthropic",
+		BaseURL: "https://api.anthropic.com",
+		Model:   "claude-3-5-sonnet-latest",
+	}
+	if got := resolveAuthToken(provider, "anthropic"); got != "bearer-token" {
+		t.Fatalf("auth token = %q, want bearer-token", got)
+	}
+}
+
 func TestBuildClient_MissingAPIKey(t *testing.T) {
 	_ = os.Unsetenv("MISSING_WUU_KEY")
 


### PR DESCRIPTION
## Summary

This PR fixes a provider switching/authentication issue observed when switching between DeepSeek and MiniMax in the desktop app.

The reported behavior was:

- DeepSeek worked.
- Switching to MiniMax could produce 401 responses.
- Re-entering the API key in Settings made MiniMax work again.

The issue was originally suspected to be a Windows locking/state problem, but the failure pattern and code path point to stale provider clients and incorrect credential handling rather than a sqlite/file lock.

This PR updates the provider switching path so runtime clients are refreshed when connection-relevant provider settings change, and fixes MiniMax API key handling for both new and legacy credentials.

## What was wrong

### 1. Provider clients were not always refreshed after switching providers

`config/model/update` previously only considered provider header changes when deciding whether to rebuild the runtime client.

That was too narrow. Switching providers can change provider type, base URL, API/wire API, API key/env, auth token/env, stream transport settings, and token accounting flags.

When those values changed but the client was not refreshed, the UI could show the newly selected provider/model while the backend still had a client configured from the previous provider connection.

### 2. MiniMax API keys could be treated as Anthropic auth tokens

MiniMax uses an Anthropic-compatible messages endpoint, so it is configured as an `anthropic` provider type. However, protocol compatibility does not mean it uses Anthropic Bearer/OAuth authentication.

The old Settings behavior treated credentials for `anthropic` providers as `auth_token`, which the Anthropic client sends as `Authorization: Bearer <token>`.

MiniMax expects API-key style authentication instead, so legacy MiniMax credentials saved as `auth_token` could produce 401 responses.

## Changes

- Replace the header-only client refresh check with a provider client configuration comparison.
- Refresh the main runtime client when connection-relevant provider settings change.
- Apply the same refresh decision to title and worker clients.
- Submit Settings provider credentials through the `api_key` path.
- Treat legacy MiniMax credentials saved as `auth_token` as API keys.
- Preserve non-MiniMax Anthropic `auth_token` behavior as Bearer token authentication.

## Why this is not a lock fix

The observed failure was a provider 401, not a sqlite/file lock error. A lock issue would normally show up as failed state reads/writes, sqlite busy errors, or missing persisted credentials.

Here, the credentials existed, but the runtime could use a stale client or send the credential with the wrong authentication scheme.

## Tests

```bash
go test ./internal/providerfactory -count=1
```

```bash
go test ./internal/providerfactory -run 'TestResolve(APIKey_MiniMaxMigratesStoredAuthTokenFallback|AuthToken_NonMiniMaxStoredAuthTokenStaysBearer)' -count=1
```

```bash
go test ./internal/appserver -run TestProviderClientConfigChangedDetectsAuthAndEndpointChanges -count=1
```

```bash
cd desktop && npx vitest run src/renderer/SettingsView.test.tsx -t "submits a new Anthropic-compatible provider with API key auth"
```

Manual verification:

- Launched a desktop client from the patched workspace.
- Switched between DeepSeek and MiniMax.
- The previously observed MiniMax 401 behavior no longer reproduced.