### PR TITLE
refactor(tools): drop Wuu progressive tool loading for a stable prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ## [Unreleased]
 
+### Removed
+
+- Removed Wuu's provider-neutral `wuu_tool_search` progressive tool loading.
+  Appending schemas to the top-level `tools` array mid-conversation invalidated
+  the provider prompt-cache prefix past the insertion point, so every load
+  risked another cold prefix. Loading is now `native` where the provider and
+  model support deferred discovery and `flat` everywhere else, which keeps the
+  request prefix stable for the fixed cost of the full tool schema. The local
+  search executor stays: provider-native discovery still needs it to search the
+  catalog and return loadable schemas. Existing configs setting
+  `agent.tool_loading` to `wuu_tool_search` (or the `tool_search` alias, or
+  `tool_search: true`) keep starting and now resolve to `auto`, printing a
+  one-time deprecation notice. Explicit `native` on a provider or model without
+  native discovery now falls back to `flat` with a visible notice instead of
+  silently selecting Wuu progressive loading.
+
 ### Fixed
 
 - Fixed the composer slash command panel hiding every skill until the user typed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,10 +37,9 @@ const (
 type ToolLoadingMode string
 
 const (
-	ToolLoadingAuto          ToolLoadingMode = "auto"
-	ToolLoadingFlat          ToolLoadingMode = "flat"
-	ToolLoadingNative        ToolLoadingMode = "native"
-	ToolLoadingWuuToolSearch ToolLoadingMode = "wuu_tool_search"
+	ToolLoadingAuto   ToolLoadingMode = "auto"
+	ToolLoadingFlat   ToolLoadingMode = "flat"
+	ToolLoadingNative ToolLoadingMode = "native"
 )
 
 // ErrConfigNotFound is returned by LoadFrom when none of the candidate
@@ -375,11 +374,17 @@ type AgentConfig struct {
 	CatwalkAutoupdate bool `json:"catwalk_autoupdate,omitempty"`
 	// ToolLoading controls how Wuu exposes large/deferred tool surfaces.
 	// Empty means "auto": first-party native provider paths use provider
-	// deferred-loading protocol; compatible endpoints use a flat tool list.
-	// Valid: auto, flat, native, wuu_tool_search.
+	// deferred-loading protocol; every other path uses a flat tool list.
+	// Valid: auto, flat, native.
+	//
+	// The retired "wuu_tool_search" / "tool_search" values still parse, but
+	// resolve to auto and print a one-time deprecation notice. Wuu's own
+	// progressive loading rewrote the top-level tools array mid-conversation,
+	// which invalidated the provider prompt cache after the insertion point.
 	ToolLoading ToolLoadingMode `json:"tool_loading,omitempty"`
 	// ToolSearch is a legacy alias kept for older config files. New configs
-	// should use tool_loading.
+	// should use tool_loading. true now means auto, not Wuu progressive
+	// loading, which no longer exists.
 	ToolSearch *bool `json:"tool_search,omitempty"`
 	// ExperimentalDeferredToolBundles enables the provider-native bundle
 	// activation path where successful tools can attach follow-on schemas.
@@ -780,7 +785,7 @@ func (c Config) Validate() error {
 		return errors.New("agent.compact_keep_recent_tokens cannot be negative (use 0 for default)")
 	}
 	if strings.TrimSpace(string(c.Agent.ToolLoading)) != "" && NormalizeToolLoadingMode(c.Agent.ToolLoading) == "" {
-		return errors.New("agent.tool_loading must be one of auto, flat, native, or wuu_tool_search")
+		return errors.New("agent.tool_loading must be one of auto, flat, or native")
 	}
 	if c.Memory.DreamIntervalDays != nil && *c.Memory.DreamIntervalDays < 0 {
 		return errors.New("memory.dream_interval_days cannot be negative")
@@ -1008,18 +1013,35 @@ func (a AgentConfig) ToolSearchEnabled() bool {
 }
 
 func (a AgentConfig) ToolLoadingPreference() ToolLoadingMode {
-	if strings.TrimSpace(string(a.ToolLoading)) != "" {
+	if raw := strings.TrimSpace(string(a.ToolLoading)); raw != "" {
 		if mode := NormalizeToolLoadingMode(a.ToolLoading); mode != "" {
+			if isRetiredToolLoadingMode(a.ToolLoading) {
+				warnRetiredToolLoadingOnce(raw, fmt.Sprintf(
+					"wuu: agent.tool_loading = %q was removed and now behaves as %q. Wuu's own progressive tool loading rewrote the tools array mid-conversation and invalidated the provider prompt cache. Set agent.tool_loading to auto, flat, or native to silence this notice.",
+					raw, ToolLoadingAuto))
+			}
 			return mode
 		}
 	}
 	if a.ToolSearch != nil {
 		if *a.ToolSearch {
-			return ToolLoadingWuuToolSearch
+			return ToolLoadingAuto
 		}
 		return ToolLoadingFlat
 	}
 	return ToolLoadingAuto
+}
+
+// isRetiredToolLoadingMode reports whether a configured value names the removed
+// Wuu progressive-loading mode. Those spellings still parse so an existing
+// config keeps starting; they resolve to auto.
+func isRetiredToolLoadingMode(mode ToolLoadingMode) bool {
+	switch strings.ToLower(strings.TrimSpace(string(mode))) {
+	case "wuu_tool_search", "tool_search":
+		return true
+	default:
+		return false
+	}
 }
 
 func NormalizeToolLoadingMode(mode ToolLoadingMode) ToolLoadingMode {
@@ -1030,8 +1052,8 @@ func NormalizeToolLoadingMode(mode ToolLoadingMode) ToolLoadingMode {
 		return ToolLoadingFlat
 	case string(ToolLoadingNative):
 		return ToolLoadingNative
-	case string(ToolLoadingWuuToolSearch), "tool_search":
-		return ToolLoadingWuuToolSearch
+	case "wuu_tool_search", "tool_search":
+		return ToolLoadingAuto
 	default:
 		return ""
 	}

--- a/internal/config/tool_loading_notice.go
+++ b/internal/config/tool_loading_notice.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// retiredToolLoadingWarned de-duplicates the deprecation notice across the
+// process lifetime. The app-server resolves the tool-loading preference on
+// every session build and on every provider switch, so without this the same
+// line would repeat for the whole run. Keyed by the configured spelling.
+var retiredToolLoadingWarned sync.Map
+
+// retiredToolLoadingWarnWriter is the sink for the notice. It defaults to
+// stderr and is a test seam so the output can be asserted without pipe
+// plumbing, matching the mcp_json diagnostics above.
+var retiredToolLoadingWarnWriter io.Writer = os.Stderr
+
+func warnRetiredToolLoadingOnce(key, msg string) {
+	if _, seen := retiredToolLoadingWarned.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	fmt.Fprintln(retiredToolLoadingWarnWriter, msg)
+}
+
+// resetRetiredToolLoadingWarnings clears the process-level dedupe set.
+// Test-only.
+func resetRetiredToolLoadingWarnings() {
+	retiredToolLoadingWarned.Range(func(k, _ any) bool {
+		retiredToolLoadingWarned.Delete(k)
+		return true
+	})
+}

--- a/internal/config/tool_loading_notice_test.go
+++ b/internal/config/tool_loading_notice_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// captureRetiredToolLoadingWarnings redirects the deprecation notice into buf
+// and clears the process-level dedupe set so each test starts clean.
+func captureRetiredToolLoadingWarnings(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+	previous := retiredToolLoadingWarnWriter
+	retiredToolLoadingWarnWriter = buf
+	resetRetiredToolLoadingWarnings()
+	return func() {
+		retiredToolLoadingWarnWriter = previous
+		resetRetiredToolLoadingWarnings()
+	}
+}
+
+func TestRetiredToolLoadingValuesResolveToAuto(t *testing.T) {
+	var warnings bytes.Buffer
+	restore := captureRetiredToolLoadingWarnings(t, &warnings)
+	defer restore()
+
+	for _, raw := range []string{"wuu_tool_search", "tool_search", "WUU_TOOL_SEARCH", " wuu_tool_search "} {
+		agent := AgentConfig{ToolLoading: ToolLoadingMode(raw)}
+		if got := agent.ToolLoadingPreference(); got != ToolLoadingAuto {
+			t.Fatalf("ToolLoadingPreference(%q) = %q, want auto", raw, got)
+		}
+	}
+}
+
+// An existing config naming the removed mode must keep starting. Failing
+// validation would turn a retired tuning knob into a hard startup error.
+func TestRetiredToolLoadingValueStillValidates(t *testing.T) {
+	cfg := Config{
+		DefaultProvider: "generic",
+		Providers: map[string]ProviderConfig{
+			"generic": {Type: "openai-compatible", BaseURL: "https://example.com/v1", APIKey: "abc", Model: "generic-coder"},
+		},
+		Agent: AgentConfig{ToolLoading: ToolLoadingMode("wuu_tool_search")},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil for a retired tool_loading value", err)
+	}
+
+	cfg.Agent.ToolLoading = ToolLoadingMode("nonsense")
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil, want an error for an unknown tool_loading value")
+	}
+	if strings.Contains(err.Error(), "wuu_tool_search") {
+		t.Fatalf("validation error should no longer advertise the removed mode: %v", err)
+	}
+}
+
+func TestRetiredToolLoadingNoticeIsEmittedOncePerSpelling(t *testing.T) {
+	var warnings bytes.Buffer
+	restore := captureRetiredToolLoadingWarnings(t, &warnings)
+	defer restore()
+
+	agent := AgentConfig{ToolLoading: ToolLoadingMode("wuu_tool_search")}
+	for range 3 {
+		agent.ToolLoadingPreference()
+	}
+	if got := strings.Count(warnings.String(), "was removed"); got != 1 {
+		t.Fatalf("notice count = %d, want 1 (the app-server resolves this on every session build):\n%s", got, warnings.String())
+	}
+	if !strings.Contains(warnings.String(), "auto") {
+		t.Fatalf("notice should name the replacement value: %q", warnings.String())
+	}
+}
+
+func TestSupportedToolLoadingValuesAreSilent(t *testing.T) {
+	var warnings bytes.Buffer
+	restore := captureRetiredToolLoadingWarnings(t, &warnings)
+	defer restore()
+
+	for _, mode := range []ToolLoadingMode{ToolLoadingAuto, ToolLoadingFlat, ToolLoadingNative, ""} {
+		agent := AgentConfig{ToolLoading: mode}
+		agent.ToolLoadingPreference()
+	}
+	if warnings.Len() != 0 {
+		t.Fatalf("supported values must not warn, got %q", warnings.String())
+	}
+}
+
+// The legacy boolean no longer selects Wuu progressive loading: true means
+// auto (native where the provider supports it, flat elsewhere).
+func TestLegacyToolSearchBooleanMapsToAutoAndFlat(t *testing.T) {
+	enabled, disabled := true, false
+	if got := (AgentConfig{ToolSearch: &enabled}).ToolLoadingPreference(); got != ToolLoadingAuto {
+		t.Fatalf("tool_search=true resolved to %q, want auto", got)
+	}
+	if got := (AgentConfig{ToolSearch: &disabled}).ToolLoadingPreference(); got != ToolLoadingFlat {
+		t.Fatalf("tool_search=false resolved to %q, want flat", got)
+	}
+	// tool_loading wins over the legacy alias when both are present.
+	if got := (AgentConfig{ToolLoading: ToolLoadingFlat, ToolSearch: &enabled}).ToolLoadingPreference(); got != ToolLoadingFlat {
+		t.Fatalf("explicit tool_loading should win over tool_search, got %q", got)
+	}
+}

--- a/internal/providerfactory/factory.go
+++ b/internal/providerfactory/factory.go
@@ -132,20 +132,6 @@ func nativeToolSearchOption(options map[string]any) (bool, bool) {
 	return false, false
 }
 
-func ShouldFallbackToWuuToolSearchByDefault(provider config.ProviderConfig, model string, _ map[string]any) bool {
-	profile, err := resolveProviderProfile(provider)
-	if err != nil {
-		return false
-	}
-	switch profile.Wire {
-	case wireOpenAIResponses:
-		return !openAIModelSupportsNativeToolSearch(model) &&
-			(isFirstPartyOpenAIResponsesBaseURL(provider.BaseURL) || profile.Auth == authCodexOAuth)
-	default:
-		return false
-	}
-}
-
 func openAIModelSupportsNativeToolSearch(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if !strings.HasPrefix(model, "gpt-") {

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -808,16 +808,20 @@ func resolveToolLoadingModeForProvider(mode config.ToolLoadingMode, providerCfg 
 		if providerfactory.SupportsNativeToolDiscovery(providerCfg, model, providerOptions) {
 			return mode, true, true
 		}
-		return config.ToolLoadingWuuToolSearch, true, false
-	case config.ToolLoadingWuuToolSearch:
-		return mode, true, false
+		// Explicit native on a path that cannot carry the provider's own
+		// deferred-discovery protocol degrades to flat rather than silently
+		// selecting a different loading strategy. Say so: the user asked for
+		// deferred tools and is not getting them.
+		warnUnsupportedNativeToolLoadingOnce(providerCfg, model)
+		return config.ToolLoadingFlat, false, false
 	default:
 		if providerfactory.SupportsNativeToolDiscoveryByDefault(providerCfg, model, providerOptions) {
 			return config.ToolLoadingNative, true, true
 		}
-		if providerfactory.ShouldFallbackToWuuToolSearchByDefault(providerCfg, model, providerOptions) {
-			return config.ToolLoadingWuuToolSearch, true, false
-		}
+		// Everything else is flat. Paying the fixed schema cost once keeps the
+		// provider prompt-cache prefix stable, which progressive loading could
+		// not do: appending to the top-level tools array invalidated the cached
+		// prefix past the insertion point on every load.
 		return config.ToolLoadingFlat, false, false
 	}
 }

--- a/internal/runtime/session_test.go
+++ b/internal/runtime/session_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -2079,7 +2080,7 @@ func TestReconfigureToolLoadingClearsNativeDiscoveryForCompatibleProvider(t *tes
 	}
 }
 
-func TestNewSessionAutoFallsBackToWuuToolSearchForUnsupportedFirstPartyOpenAIResponsesModel(t *testing.T) {
+func TestNewSessionAutoFallsBackToFlatForUnsupportedFirstPartyOpenAIResponsesModel(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("WUU_HOME", filepath.Join(home, "state"))
@@ -2104,23 +2105,28 @@ func TestNewSessionAutoFallsBackToWuuToolSearchForUnsupportedFirstPartyOpenAIRes
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
-	if rt.ToolLoadingMode != config.ToolLoadingWuuToolSearch {
-		t.Fatalf("ToolLoadingMode = %q, want wuu_tool_search", rt.ToolLoadingMode)
+	if rt.ToolLoadingMode != config.ToolLoadingFlat {
+		t.Fatalf("ToolLoadingMode = %q, want flat", rt.ToolLoadingMode)
 	}
-	if rt.Toolkit == nil || !rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
-		t.Fatalf("unsupported OpenAI model should use Wuu tool_search fallback, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
+	if rt.Toolkit == nil || rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
+		t.Fatalf("unsupported OpenAI model should declare tools flat, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
 	}
 	if rt.StreamRunner == nil || rt.StreamRunner.NativeDeferredToolDiscovery {
 		t.Fatal("unsupported OpenAI model must not mark provider requests as native deferred")
 	}
-	for _, want := range []string{
-		"# Deferred Tool Catalog",
-		"<available-deferred-tools>",
-		"send_message",
-	} {
-		if !strings.Contains(rt.BaseSystemPrompt, want) {
-			t.Fatalf("Wuu tool_search prompt missing static catalog entry %q:\n%s", want, rt.BaseSystemPrompt)
+	// A flat surface declares every tool up front, so the deferred catalog
+	// prompt that Wuu progressive loading needed must not be emitted at all.
+	for _, unwanted := range []string{"# Deferred Tool Catalog", "<available-deferred-tools>"} {
+		if strings.Contains(rt.BaseSystemPrompt, unwanted) {
+			t.Fatalf("flat fallback must not ship the deferred catalog prompt, found %q:\n%s", unwanted, rt.BaseSystemPrompt)
 		}
+	}
+	defs := rt.Toolkit.Definitions()
+	if _, ok := sessionToolDefByName(defs, "tool_search"); ok {
+		t.Fatalf("flat fallback must not expose tool_search, got %+v", defs)
+	}
+	if _, ok := sessionToolDefByName(defs, "send_message"); !ok {
+		t.Fatalf("flat fallback must declare formerly deferred tools directly, got %+v", defs)
 	}
 	for _, block := range rt.Toolkit.ContextBlocks() {
 		if block.Kind == wuucontext.BlockAvailableDeferred {
@@ -2248,10 +2254,27 @@ func TestNewSessionAllowsCompatibleOpenAIResponsesToOptIntoNativeDeferred(t *tes
 	}
 }
 
-func TestNewSessionExplicitNativeFallsBackToWuuToolSearchForUnsupportedOpenAIResponsesModel(t *testing.T) {
+// captureUnsupportedNativeWarnings redirects the fallback notice into buf and
+// clears the process-level dedupe set so each test starts from a clean slate.
+func captureUnsupportedNativeWarnings(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+	previous := unsupportedNativeWarnWriter
+	unsupportedNativeWarnWriter = buf
+	resetUnsupportedNativeWarnings()
+	return func() {
+		unsupportedNativeWarnWriter = previous
+		resetUnsupportedNativeWarnings()
+	}
+}
+
+func TestNewSessionExplicitNativeFallsBackToFlatForUnsupportedOpenAIResponsesModel(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("WUU_HOME", filepath.Join(home, "state"))
+
+	var warnings bytes.Buffer
+	restore := captureUnsupportedNativeWarnings(t, &warnings)
+	defer restore()
 
 	rt, err := NewSession(Options{
 		RootDir:    root,
@@ -2274,18 +2297,51 @@ func TestNewSessionExplicitNativeFallsBackToWuuToolSearchForUnsupportedOpenAIRes
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
-	if rt.ToolLoadingMode != config.ToolLoadingWuuToolSearch {
-		t.Fatalf("ToolLoadingMode = %q, want wuu_tool_search", rt.ToolLoadingMode)
+	if rt.ToolLoadingMode != config.ToolLoadingFlat {
+		t.Fatalf("ToolLoadingMode = %q, want flat", rt.ToolLoadingMode)
 	}
-	if rt.Toolkit == nil || !rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
-		t.Fatalf("unsupported explicit OpenAI native should fall back to Wuu tool_search, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
+	if rt.Toolkit == nil || rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
+		t.Fatalf("unsupported explicit OpenAI native should fall back to flat, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
 	}
 	if rt.StreamRunner == nil || rt.StreamRunner.NativeDeferredToolDiscovery {
 		t.Fatal("unsupported explicit OpenAI native should not mark provider requests as native deferred")
 	}
+	// The user asked for deferred tools and is not getting them, so the
+	// downgrade has to be visible rather than silent.
+	notice := warnings.String()
+	for _, want := range []string{"native", "flat", "gpt-test"} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("fallback notice missing %q, got %q", want, notice)
+		}
+	}
 }
 
-func TestNewSessionAllowsExplicitWuuToolSearchFallback(t *testing.T) {
+func TestUnsupportedNativeFallbackNoticeIsEmittedOncePerProviderModel(t *testing.T) {
+	var warnings bytes.Buffer
+	restore := captureUnsupportedNativeWarnings(t, &warnings)
+	defer restore()
+
+	providerCfg := config.ProviderConfig{
+		Type:    "openai-compatible",
+		BaseURL: "https://compatible.example.com/v1",
+		APIKey:  "abc",
+		WireAPI: "responses",
+	}
+	for range 3 {
+		resolveToolLoadingModeForProvider(config.ToolLoadingNative, providerCfg, "gpt-test", nil)
+	}
+	if got := strings.Count(warnings.String(), "does not support provider-native"); got != 1 {
+		t.Fatalf("notice count = %d, want 1 (dedupe across repeated provider switches):\n%s", got, warnings.String())
+	}
+
+	// A different unsupported pair is a different problem and reports again.
+	resolveToolLoadingModeForProvider(config.ToolLoadingNative, providerCfg, "gpt-other", nil)
+	if got := strings.Count(warnings.String(), "does not support provider-native"); got != 2 {
+		t.Fatalf("notice count = %d, want 2 after switching model:\n%s", got, warnings.String())
+	}
+}
+
+func TestNewSessionTreatsRetiredWuuToolSearchConfigAsAuto(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("WUU_HOME", filepath.Join(home, "state"))
@@ -2304,30 +2360,34 @@ func TestNewSessionAllowsExplicitWuuToolSearchFallback(t *testing.T) {
 					Model:   "generic-coder",
 				},
 			},
-			Agent: config.AgentConfig{ToolLoading: config.ToolLoadingWuuToolSearch},
+			// An existing config still naming the removed mode must keep
+			// starting rather than failing validation.
+			Agent: config.AgentConfig{ToolLoading: config.ToolLoadingMode("wuu_tool_search")},
 		},
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
-	if rt.ToolLoadingMode != config.ToolLoadingWuuToolSearch {
-		t.Fatalf("ToolLoadingMode = %q, want wuu_tool_search", rt.ToolLoadingMode)
+	// A generic compatible endpoint has no native discovery, so auto lands on
+	// flat — the retired value no longer selects a loading strategy of its own.
+	if rt.ToolLoadingPreference != config.ToolLoadingAuto {
+		t.Fatalf("ToolLoadingPreference = %q, want auto", rt.ToolLoadingPreference)
+	}
+	if rt.ToolLoadingMode != config.ToolLoadingFlat {
+		t.Fatalf("ToolLoadingMode = %q, want flat", rt.ToolLoadingMode)
 	}
 	if rt.Toolkit == nil {
 		t.Fatal("expected toolkit")
 	}
-	if !rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
-		t.Fatalf("wuu_tool_search should expose Wuu tool_search without native provider defer, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
-	}
-	if rt.StreamRunner == nil || rt.StreamRunner.NativeDeferredToolDiscovery {
-		t.Fatal("wuu_tool_search should not mark provider requests as native deferred")
+	if rt.Toolkit.ToolSearchEnabled() || rt.Toolkit.NativeDeferredToolDiscovery() {
+		t.Fatalf("retired mode must not resurrect progressive loading, tool_search=%v native=%v", rt.Toolkit.ToolSearchEnabled(), rt.Toolkit.NativeDeferredToolDiscovery())
 	}
 	defs := rt.Toolkit.Definitions()
-	if _, ok := sessionToolDefByName(defs, "tool_search"); !ok {
-		t.Fatalf("wuu_tool_search should expose tool_search, got %+v", defs)
+	if _, ok := sessionToolDefByName(defs, "tool_search"); ok {
+		t.Fatalf("retired mode must not expose tool_search, got %+v", defs)
 	}
-	if _, ok := sessionToolDefByName(defs, "send_message"); ok {
-		t.Fatalf("wuu_tool_search should keep deferred tools behind tool_search until loaded, got %+v", defs)
+	if _, ok := sessionToolDefByName(defs, "send_message"); !ok {
+		t.Fatalf("retired mode should declare formerly deferred tools directly, got %+v", defs)
 	}
 }
 

--- a/internal/runtime/tool_loading_notice.go
+++ b/internal/runtime/tool_loading_notice.go
@@ -1,0 +1,53 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/blueberrycongee/wuu/internal/config"
+)
+
+// unsupportedNativeWarned de-duplicates the fallback notice across the process
+// lifetime. Tool loading is resolved on every session build and again on every
+// provider or model switch, so an undeduped notice would repeat all run.
+// The key includes provider and model so a switch to a different unsupported
+// pair still reports once.
+var unsupportedNativeWarned sync.Map
+
+// unsupportedNativeWarnWriter is the sink for the notice. It defaults to
+// stderr and is a test seam so the output can be asserted without pipe
+// plumbing, matching the config package's mcp_json diagnostics.
+var unsupportedNativeWarnWriter io.Writer = os.Stderr
+
+func warnUnsupportedNativeToolLoadingOnce(providerCfg config.ProviderConfig, model string) {
+	provider := strings.TrimSpace(providerCfg.BaseURL)
+	if provider == "" {
+		provider = strings.TrimSpace(providerCfg.Type)
+	}
+	if provider == "" {
+		provider = "the configured provider"
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = "the configured model"
+	}
+	key := provider + "\x00" + model
+	if _, seen := unsupportedNativeWarned.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	fmt.Fprintf(unsupportedNativeWarnWriter,
+		"wuu: agent.tool_loading = %q, but %s with model %q does not support provider-native deferred tool discovery. Falling back to %q, which declares every tool up front.\n",
+		config.ToolLoadingNative, provider, model, config.ToolLoadingFlat)
+}
+
+// resetUnsupportedNativeWarnings clears the process-level dedupe set.
+// Test-only.
+func resetUnsupportedNativeWarnings() {
+	unsupportedNativeWarned.Range(func(k, _ any) bool {
+		unsupportedNativeWarned.Delete(k)
+		return true
+	})
+}


### PR DESCRIPTION
## Summary

Implements the decision in #168: removes Wuu's provider-neutral `wuu_tool_search` progressive loading mode so the inference-request prefix stays stable, and keeps the local search executor that provider-native discovery depends on.

## Changes

- **Loading policy is now `native` or `flat`.** `resolveToolLoadingModeForProvider` resolves to `native` when the provider and model support deferred discovery, and `flat` otherwise. `ShouldFallbackToWuuToolSearchByDefault` had no remaining caller and is deleted.
- **Explicit `native` on an unsupported path degrades to `flat`, visibly.** Previously it silently selected Wuu progressive loading. It now falls back to `flat` and prints a notice naming the provider, the model, and the mode actually in effect — the user asked for deferred tools and is not getting them. Deduped per provider+model over the process lifetime, because tool loading is re-resolved on every session build and every provider switch.
- **The local search executor is untouched.** `internal/tools/tool_search.go` and the discovery path stay: OpenAI and Anthropic native tool search still need Wuu to search the local catalog and return loadable schemas through `tool_search_output` / `tool_reference`. Every `Native*` runtime test still passes unchanged.

### One deviation from the issue, worth a look

The scope says to remove the legacy `tool_search` alias and boolean migration path. Removing them outright makes any existing config that sets `agent.tool_loading = "wuu_tool_search"` fail `Validate()`, which turns a retired tuning knob into a hard startup error for someone who set it once and forgot.

This keeps those spellings parsing and resolves them to `auto`, with a one-time deprecation notice naming the replacement:

| config | before | after |
| --- | --- | --- |
| `tool_loading: "wuu_tool_search"` | Wuu progressive | `auto` + notice |
| `tool_loading: "tool_search"` (alias) | Wuu progressive | `auto` + notice |
| `tool_search: true` | Wuu progressive | `auto` |
| `tool_search: false` | flat | flat (unchanged) |

`auto` rather than `flat` because the intent behind those values was "defer tools where you can", and `auto` still gives native discovery on providers that support it. The validation message no longer advertises the removed mode, and an unknown value still errors. Happy to make it a hard error instead if you would rather force the edit.

## Test plan

- [x] Added or updated unit tests for the change
- [x] `go test ./...` passes
- [x] `cd desktop && npm test` passes
- [ ] Manually verified the behavior in the desktop shell (if applicable)

Three existing runtime tests asserted the removed behavior and now assert the flat outcome, including that the flat surface stops shipping the deferred-catalog prompt and declares the formerly deferred tools directly. New tests cover: the fallback notice contents and its per-provider+model dedupe, the retired values resolving to `auto`, a retired value still passing `Validate()`, supported values staying silent, and the legacy boolean mapping. `make check` passes; `gofmt` clean.

Not verified in the desktop shell — this is core-side resolution with no renderer surface, and I could not launch Electron in this environment.

## Risk and rollback

- Risk level: medium — changes the tool surface sent to providers. No protocol or persisted-state change; the desktop and CLI read the resolved mode but do not set it.
- Behaviour change to call out: anyone previously on the Wuu progressive path now gets a flat tool list, so their first request carries roughly 7.8 KB (~2.6K tokens by Wuu's estimator) more schema, in exchange for a prefix that stays cacheable.
- Rollback: revert the commit.

## Linked issues / docs

Closes #168
