### PR TITLE
feat(process): record the owner and host generation of background commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,11 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ### Changed
 
-- Background command records now carry the conversation that owns them and the
-  app-server generation that started them, so a later thread-delete or
-  subagent-close cascade has a durable owner to key off instead of scanning
-  thread state after the fact. The owning conversation is taken from host state
-  rather than a model argument. No behavior change yet; `lifecycle` still parses
-  and round-trips. First step of the background command lifecycle work.
-
-### Changed
+- Background command records now add durable owning-conversation and app-server
+  host-generation data. The owning conversation is taken from host state rather
+  than a model argument. This is additive record data only: no lifecycle cleanup
+  or cascade behavior is implemented yet, and legacy `lifecycle` data continues
+  to parse and round-trip.
 
 - Slash command rows now lead with the command to type (`/review`) and carry a
   short summary beside it, so built-in commands and skills read the same way.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ### Changed
 
+- Background command records now carry the conversation that owns them and the
+  app-server generation that started them, so a later thread-delete or
+  subagent-close cascade has a durable owner to key off instead of scanning
+  thread state after the fact. The owning conversation is taken from host state
+  rather than a model argument. No behavior change yet; `lifecycle` still parses
+  and round-trips. First step of the background command lifecycle work.
+
+### Changed
+
 - Slash command rows now lead with the command to type (`/review`) and carry a
   short summary beside it, so built-in commands and skills read the same way.
 

--- a/internal/process/command_session_record_test.go
+++ b/internal/process/command_session_record_test.go
@@ -37,6 +37,7 @@ func newTestManager(t *testing.T) *Manager {
 // thread or subagent is gone there is nothing left to scan to recover it.
 func TestStartPersistsOwnerAndHostGeneration(t *testing.T) {
 	m := newTestManager(t)
+	t.Cleanup(func() { _ = m.CleanupSession() })
 
 	p, err := m.Start(context.Background(), StartOptions{
 		Command:      "true",
@@ -64,7 +65,7 @@ func TestStartPersistsOwnerAndHostGeneration(t *testing.T) {
 	}
 }
 
-func TestHostGenerationIDIsUniquePerManager(t *testing.T) {
+func TestTopLevelManagersHaveDistinctHostGenerations(t *testing.T) {
 	first := newTestManager(t)
 	second := newTestManager(t)
 
@@ -79,25 +80,18 @@ func TestHostGenerationIDIsUniquePerManager(t *testing.T) {
 	}
 }
 
-// A record only belongs to the running host when the generation matches
-// exactly. Pre-upgrade records carry no generation and must read as foreign,
-// since this host has no stdin, PTY, or exit watcher for them either.
-func TestStartedByCurrentHostRejectsForeignAndLegacyRecords(t *testing.T) {
-	m := newTestManager(t)
-
-	p, err := m.Start(context.Background(), StartOptions{Command: "true", OwnerKind: OwnerMainAgent, OwnerID: "main", RootThreadID: "thread-1"})
+func TestThreadLocalManagersShareTopLevelHostGeneration(t *testing.T) {
+	runtimeRoot := filepath.Join(t.TempDir(), "runtime")
+	workspace, err := NewManager(t.TempDir(), runtimeRoot)
 	if err != nil {
-		t.Fatalf("Start: %v", err)
+		t.Fatalf("NewManager: %v", err)
 	}
-	if !m.StartedByCurrentHost(*p) {
-		t.Fatal("a command this host started must read as owned by it")
+	thread, err := NewManagerWithHostGeneration(t.TempDir(), workspace.HostGenerationID(), runtimeRoot)
+	if err != nil {
+		t.Fatalf("NewManagerWithHostGeneration: %v", err)
 	}
-
-	if m.StartedByCurrentHost(Process{HostGenerationID: "host-from-a-previous-run"}) {
-		t.Fatal("a record from another host generation must not read as ours")
-	}
-	if m.StartedByCurrentHost(Process{}) {
-		t.Fatal("a pre-upgrade record without a generation must not read as ours")
+	if workspace.HostGenerationID() != thread.HostGenerationID() {
+		t.Fatalf("thread-local manager generation = %q, want workspace generation %q", thread.HostGenerationID(), workspace.HostGenerationID())
 	}
 }
 
@@ -132,8 +126,5 @@ func TestLegacyRecordWithoutNewFieldsStillLoads(t *testing.T) {
 	}
 	if found.Lifecycle != LifecycleManaged {
 		t.Fatalf("deprecated lifecycle must round-trip, got %q", found.Lifecycle)
-	}
-	if m.StartedByCurrentHost(*found) {
-		t.Fatal("legacy record must not be claimed by the running host")
 	}
 }

--- a/internal/process/command_session_record_test.go
+++ b/internal/process/command_session_record_test.go
@@ -1,0 +1,139 @@
+package process
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func startedRecordOnDisk(t *testing.T, m *Manager, id string) Process {
+	t.Helper()
+	path := filepath.Join(m.registryDir, id+".json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read registry record: %v", err)
+	}
+	var p Process
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decode registry record: %v", err)
+	}
+	return p
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	root := t.TempDir()
+	m, err := NewManager(root, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	return m
+}
+
+// The owner of a command has to survive into the registry, because once the
+// thread or subagent is gone there is nothing left to scan to recover it.
+func TestStartPersistsOwnerAndHostGeneration(t *testing.T) {
+	m := newTestManager(t)
+
+	p, err := m.Start(context.Background(), StartOptions{
+		Command:      "true",
+		OwnerKind:    OwnerSubagent,
+		OwnerID:      "worker-7",
+		RootThreadID: "thread-42",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if p.RootThreadID != "thread-42" {
+		t.Fatalf("RootThreadID = %q, want thread-42", p.RootThreadID)
+	}
+	if p.HostGenerationID != m.HostGenerationID() {
+		t.Fatalf("HostGenerationID = %q, want %q", p.HostGenerationID, m.HostGenerationID())
+	}
+
+	stored := startedRecordOnDisk(t, m, p.ID)
+	if stored.RootThreadID != "thread-42" || stored.OwnerKind != OwnerSubagent || stored.OwnerID != "worker-7" {
+		t.Fatalf("registry record lost owner fields: %+v", stored)
+	}
+	if stored.HostGenerationID != m.HostGenerationID() {
+		t.Fatalf("registry record lost host generation: %+v", stored)
+	}
+}
+
+func TestHostGenerationIDIsUniquePerManager(t *testing.T) {
+	first := newTestManager(t)
+	second := newTestManager(t)
+
+	if first.HostGenerationID() == "" {
+		t.Fatal("host generation id must not be empty")
+	}
+	if first.HostGenerationID() == second.HostGenerationID() {
+		t.Fatalf("two hosts share a generation id: %q", first.HostGenerationID())
+	}
+	if !strings.HasPrefix(first.HostGenerationID(), "host-") {
+		t.Fatalf("unexpected generation id shape: %q", first.HostGenerationID())
+	}
+}
+
+// A record only belongs to the running host when the generation matches
+// exactly. Pre-upgrade records carry no generation and must read as foreign,
+// since this host has no stdin, PTY, or exit watcher for them either.
+func TestStartedByCurrentHostRejectsForeignAndLegacyRecords(t *testing.T) {
+	m := newTestManager(t)
+
+	p, err := m.Start(context.Background(), StartOptions{Command: "true", OwnerKind: OwnerMainAgent, OwnerID: "main", RootThreadID: "thread-1"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !m.StartedByCurrentHost(*p) {
+		t.Fatal("a command this host started must read as owned by it")
+	}
+
+	if m.StartedByCurrentHost(Process{HostGenerationID: "host-from-a-previous-run"}) {
+		t.Fatal("a record from another host generation must not read as ours")
+	}
+	if m.StartedByCurrentHost(Process{}) {
+		t.Fatal("a pre-upgrade record without a generation must not read as ours")
+	}
+}
+
+// Existing registry files predate both fields. They must keep loading, and the
+// deprecated lifecycle value must round-trip untouched so this step stays a
+// pure data-plane change.
+func TestLegacyRecordWithoutNewFieldsStillLoads(t *testing.T) {
+	m := newTestManager(t)
+
+	legacy := `{"id":"legacy-1","owner_kind":"main_agent","owner_id":"main","lifecycle":"managed","status":"stopped","pid":4242,"command":"sleep 1","cwd":"/tmp","exit_code":0}`
+	path := filepath.Join(m.registryDir, "legacy-1.json")
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy record: %v", err)
+	}
+
+	list, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found *Process
+	for i := range list {
+		if list[i].ID == "legacy-1" {
+			found = &list[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("legacy record disappeared from List: %+v", list)
+	}
+	if found.RootThreadID != "" || found.HostGenerationID != "" {
+		t.Fatalf("legacy record must not invent owner fields: %+v", found)
+	}
+	if found.Lifecycle != LifecycleManaged {
+		t.Fatalf("deprecated lifecycle must round-trip, got %q", found.Lifecycle)
+	}
+	if m.StartedByCurrentHost(*found) {
+		t.Fatal("legacy record must not be claimed by the running host")
+	}
+}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -62,10 +62,25 @@ const (
 )
 
 type Process struct {
-	Action                string         `json:"action,omitempty"`
-	ID                    string         `json:"id"`
-	OwnerKind             OwnerKind      `json:"owner_kind"`
-	OwnerID               string         `json:"owner_id"`
+	Action    string    `json:"action,omitempty"`
+	ID        string    `json:"id"`
+	OwnerKind OwnerKind `json:"owner_kind"`
+	OwnerID   string    `json:"owner_id"`
+	// RootThreadID is the conversation that owns this command. It is stamped
+	// at start from host state, never derived afterwards: once a thread or
+	// subagent is gone there is nothing left to scan to recover the owner, and
+	// thread-delete cascade, isolation, and UI routing all key off this field.
+	RootThreadID string `json:"root_thread_id,omitempty"`
+	// HostGenerationID identifies the app-server process that started this
+	// command. A record carrying a different generation than the running host
+	// cannot be controlled by it — no stdin, no PTY, no exit watcher — so the
+	// field is what lets startup tell "still ours" from "left over". Records
+	// written before this field existed have it empty, which reads the same as
+	// a foreign generation.
+	HostGenerationID string `json:"host_generation_id,omitempty"`
+	// Deprecated: Lifecycle is being retired with the managed process class.
+	// It still parses and round-trips so existing registry records keep
+	// loading; new behavior must not branch on it.
 	Lifecycle             Lifecycle      `json:"lifecycle"`
 	CompletionMode        CompletionMode `json:"completion_mode,omitempty"`
 	Status                Status         `json:"status"`
@@ -96,11 +111,15 @@ type Process struct {
 }
 
 type StartOptions struct {
-	Command               string
-	CommandPrefix         string
-	CWD                   string
-	OwnerKind             OwnerKind
-	OwnerID               string
+	Command       string
+	CommandPrefix string
+	CWD           string
+	OwnerKind     OwnerKind
+	OwnerID       string
+	// RootThreadID is host-supplied. Callers pass the conversation the command
+	// belongs to; it is not a model-declared argument.
+	RootThreadID string
+	// Deprecated: see Process.Lifecycle.
 	Lifecycle             Lifecycle
 	CompletionMode        CompletionMode
 	TTY                   bool
@@ -142,14 +161,46 @@ type OutputSnapshot struct {
 }
 
 type Manager struct {
-	rootDir     string
-	registryDir string
-	logDir      string
-	mu          sync.Mutex
-	subMu       sync.Mutex
-	handles     map[string]*processHandle
-	subscribers []chan<- Event
-	recheckWake chan struct{}
+	rootDir string
+	// hostGenerationID is minted once per Manager and stamped on every command
+	// it starts. It is the identity that survives into the registry, so a later
+	// host can tell its own live records from a previous host's leftovers.
+	hostGenerationID string
+	registryDir      string
+	logDir           string
+	mu               sync.Mutex
+	subMu            sync.Mutex
+	handles          map[string]*processHandle
+	subscribers      []chan<- Event
+	recheckWake      chan struct{}
+}
+
+// newHostGenerationID mints an identifier for one app-server lifetime. Time
+// alone would collide across a fast restart, so it is paired with random bytes.
+func newHostGenerationID() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("host-%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("host-%d-%s", time.Now().UnixNano(), hex.EncodeToString(buf))
+}
+
+// HostGenerationID returns the identity of the currently running host.
+func (m *Manager) HostGenerationID() string {
+	if m == nil {
+		return ""
+	}
+	return m.hostGenerationID
+}
+
+// StartedByCurrentHost reports whether this record was created by the running
+// host. Records from an earlier generation — including pre-upgrade records with
+// no generation at all — cannot be controlled by it.
+func (m *Manager) StartedByCurrentHost(p Process) bool {
+	if m == nil {
+		return false
+	}
+	return p.HostGenerationID != "" && p.HostGenerationID == m.hostGenerationID
 }
 
 type processHandle struct {
@@ -187,11 +238,12 @@ func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
 		return nil, err
 	}
 	m := &Manager{
-		rootDir:     abs,
-		registryDir: filepath.Join(runtimeDir, "processes"),
-		logDir:      filepath.Join(runtimeDir, "logs"),
-		handles:     make(map[string]*processHandle),
-		recheckWake: make(chan struct{}, 1),
+		rootDir:          abs,
+		hostGenerationID: newHostGenerationID(),
+		registryDir:      filepath.Join(runtimeDir, "processes"),
+		logDir:           filepath.Join(runtimeDir, "logs"),
+		handles:          make(map[string]*processHandle),
+		recheckWake:      make(chan struct{}, 1),
 	}
 	if err := os.MkdirAll(m.registryDir, 0o755); err != nil {
 		return nil, err
@@ -261,7 +313,7 @@ func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error)
 		opt.TTY = false
 	}
 	id := "proc-" + randomHex(4)
-	p := &Process{ID: id, OwnerKind: opt.OwnerKind, OwnerID: opt.OwnerID, Lifecycle: opt.Lifecycle, CompletionMode: opt.CompletionMode, Status: StatusStarting, Command: opt.Command, CWD: cwd, TTY: opt.TTY, LogPath: filepath.Join(m.logDir, id+".log"), StartedAt: time.Now(), UpdatedAt: time.Now(), ExitCode: -1, RecheckMinutes: opt.RecheckMinutes}
+	p := &Process{ID: id, OwnerKind: opt.OwnerKind, OwnerID: opt.OwnerID, RootThreadID: strings.TrimSpace(opt.RootThreadID), HostGenerationID: m.hostGenerationID, Lifecycle: opt.Lifecycle, CompletionMode: opt.CompletionMode, Status: StatusStarting, Command: opt.Command, CWD: cwd, TTY: opt.TTY, LogPath: filepath.Join(m.logDir, id+".log"), StartedAt: time.Now(), UpdatedAt: time.Now(), ExitCode: -1, RecheckMinutes: opt.RecheckMinutes}
 	if opt.RecheckMinutes > 0 {
 		p.NextRecheckAt = p.StartedAt.Add(time.Duration(opt.RecheckMinutes) * time.Minute)
 	}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -68,15 +68,13 @@ type Process struct {
 	OwnerID   string    `json:"owner_id"`
 	// RootThreadID is the conversation that owns this command. It is stamped
 	// at start from host state, never derived afterwards: once a thread or
-	// subagent is gone there is nothing left to scan to recover the owner, and
-	// thread-delete cascade, isolation, and UI routing all key off this field.
+	// subagent is gone there is nothing left to scan to recover the owner. This
+	// step only persists the association; lifecycle cleanup is not implemented.
 	RootThreadID string `json:"root_thread_id,omitempty"`
-	// HostGenerationID identifies the app-server process that started this
-	// command. A record carrying a different generation than the running host
-	// cannot be controlled by it — no stdin, no PTY, no exit watcher — so the
-	// field is what lets startup tell "still ours" from "left over". Records
-	// written before this field existed have it empty, which reads the same as
-	// a foreign generation.
+	// HostGenerationID identifies the top-level app-server host lifetime that
+	// started this command. It is durable record identity, not proof that the
+	// running process still has an in-memory control handle. Records written
+	// before this field existed have it empty.
 	HostGenerationID string `json:"host_generation_id,omitempty"`
 	// Deprecated: Lifecycle is being retired with the managed process class.
 	// It still parses and round-trips so existing registry records keep
@@ -162,9 +160,9 @@ type OutputSnapshot struct {
 
 type Manager struct {
 	rootDir string
-	// hostGenerationID is minted once per Manager and stamped on every command
-	// it starts. It is the identity that survives into the registry, so a later
-	// host can tell its own live records from a previous host's leftovers.
+	// hostGenerationID is shared by Managers belonging to one top-level
+	// app-server lifetime and stamped on every command they start. The handles
+	// map, not this label, is the authority for live in-memory control.
 	hostGenerationID string
 	registryDir      string
 	logDir           string
@@ -185,22 +183,13 @@ func newHostGenerationID() string {
 	return fmt.Sprintf("host-%d-%s", time.Now().UnixNano(), hex.EncodeToString(buf))
 }
 
-// HostGenerationID returns the identity of the currently running host.
+// HostGenerationID returns the durable identity label for this manager's host
+// lifetime. Matching this value does not establish live controllability.
 func (m *Manager) HostGenerationID() string {
 	if m == nil {
 		return ""
 	}
 	return m.hostGenerationID
-}
-
-// StartedByCurrentHost reports whether this record was created by the running
-// host. Records from an earlier generation — including pre-upgrade records with
-// no generation at all — cannot be controlled by it.
-func (m *Manager) StartedByCurrentHost(p Process) bool {
-	if m == nil {
-		return false
-	}
-	return p.HostGenerationID != "" && p.HostGenerationID == m.hostGenerationID
 }
 
 type processHandle struct {
@@ -211,8 +200,20 @@ type processHandle struct {
 }
 
 func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
+	return NewManagerWithHostGeneration(rootDir, newHostGenerationID(), runtimeDirs...)
+}
+
+// NewManagerWithHostGeneration creates a manager using an existing top-level
+// host lifetime label. Runtime sessions use this for thread-local managers so
+// records from one app-server host share durable identity; standalone callers
+// should use NewManager, which mints its own label for compatibility.
+func NewManagerWithHostGeneration(rootDir, hostGenerationID string, runtimeDirs ...string) (*Manager, error) {
 	if strings.TrimSpace(rootDir) == "" {
 		return nil, errors.New("root directory is required")
+	}
+	hostGenerationID = strings.TrimSpace(hostGenerationID)
+	if hostGenerationID == "" {
+		return nil, errors.New("host generation id is required")
 	}
 	abs, err := filepath.Abs(rootDir)
 	if err != nil {
@@ -239,7 +240,7 @@ func NewManager(rootDir string, runtimeDirs ...string) (*Manager, error) {
 	}
 	m := &Manager{
 		rootDir:          abs,
-		hostGenerationID: newHostGenerationID(),
+		hostGenerationID: hostGenerationID,
 		registryDir:      filepath.Join(runtimeDir, "processes"),
 		logDir:           filepath.Join(runtimeDir, "logs"),
 		handles:          make(map[string]*processHandle),
@@ -276,6 +277,9 @@ func (m *Manager) SetRootDir(rootDir string) {
 	m.mu.Unlock()
 }
 
+// Start is the low-level manager launch path. Model-facing command tools must
+// bind a SessionID before using it; internal callers may use it for legitimate
+// non-thread work and provide RootThreadID when they own that association.
 func (m *Manager) Start(ctx context.Context, opt StartOptions) (*Process, error) {
 	if strings.TrimSpace(opt.Command) == "" {
 		return nil, errors.New("command is required")

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -1138,13 +1138,9 @@ func (s *Session) NewThreadRuntimeForRoot(sessionID, rootDir string) (*ThreadRun
 		agentControl *agentcontrol.AgentControl
 		toolExecutor = s.StreamRunner.Tools
 	)
-	threadProcessManager := s.ProcessManager
-	if !sameRuntimeRoot(threadRoot, s.RootDir) && threadProcessManager != nil {
-		manager, err := process.NewManager(threadRoot, statepath.RuntimeDir(stateDir))
-		if err != nil {
-			return nil, fmt.Errorf("thread process manager: %w", err)
-		}
-		threadProcessManager = manager
+	threadProcessManager, err := s.processManagerForThread(threadRoot, stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("thread process manager: %w", err)
 	}
 
 	// Prepare every fallible thread-local dependency before AgentControl. The
@@ -1383,6 +1379,20 @@ func sameRuntimeRoot(left, right string) bool {
 	left = cleanRuntimeRoot(left)
 	right = cleanRuntimeRoot(right)
 	return left != "" && left == right
+}
+
+func (s *Session) processManagerForThread(threadRoot, stateDir string) (*process.Manager, error) {
+	if s == nil || s.ProcessManager == nil || sameRuntimeRoot(threadRoot, s.RootDir) {
+		if s == nil {
+			return nil, nil
+		}
+		return s.ProcessManager, nil
+	}
+	return process.NewManagerWithHostGeneration(
+		threadRoot,
+		s.ProcessManager.HostGenerationID(),
+		statepath.RuntimeDir(stateDir),
+	)
 }
 
 // sessionParticipantStore adapts the session store to

--- a/internal/runtime/session_test.go
+++ b/internal/runtime/session_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blueberrycongee/wuu/internal/mcp"
 	"github.com/blueberrycongee/wuu/internal/memdir"
 	pluginpkg "github.com/blueberrycongee/wuu/internal/plugin"
+	"github.com/blueberrycongee/wuu/internal/process"
 	"github.com/blueberrycongee/wuu/internal/providers"
 	"github.com/blueberrycongee/wuu/internal/skills"
 	"github.com/blueberrycongee/wuu/internal/statepath"
@@ -62,6 +63,26 @@ func TestSessionUltraModeIsConcurrencySafe(t *testing.T) {
 	var zero Session
 	if zero.MaxParallel() != config.DefaultAgentMaxParallel {
 		t.Fatalf("zero-value MaxParallel = %d, want %d", zero.MaxParallel(), config.DefaultAgentMaxParallel)
+	}
+}
+
+func TestThreadProcessManagerSharesRuntimeHostGeneration(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	workspaceManager, err := process.NewManager(workspaceRoot, filepath.Join(t.TempDir(), "workspace-runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	s := &Session{RootDir: workspaceRoot, ProcessManager: workspaceManager}
+
+	threadManager, err := s.processManagerForThread(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("processManagerForThread: %v", err)
+	}
+	if threadManager == workspaceManager {
+		t.Fatal("a different thread root should receive a thread-local manager")
+	}
+	if threadManager.HostGenerationID() != workspaceManager.HostGenerationID() {
+		t.Fatalf("thread host generation = %q, want workspace generation %q", threadManager.HostGenerationID(), workspaceManager.HostGenerationID())
 	}
 }
 

--- a/internal/tools/git_test.go
+++ b/internal/tools/git_test.go
@@ -169,6 +169,7 @@ func TestBashBackgroundGitAttributionUsesWrapper(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-background-git-attribution")
 	runBash(t, root, "printf 'background\\n' > hello.txt")
 	args, _ := json.Marshal(map[string]any{
 		"action":          "start_background",

--- a/internal/tools/tool_bash.go
+++ b/internal/tools/tool_bash.go
@@ -421,7 +421,7 @@ func (t *BashTool) executeStartBackground(ctx context.Context, args bashArgs) (s
 	if args.TTY != nil {
 		tty = *args.TTY
 	}
-	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: tty, AllowOutsideWorkspace: t.env.BypassToolHardProtections(), RecheckMinutes: args.RecheckMinutes})
+	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, RootThreadID: processRootThreadID(t.env), Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: tty, AllowOutsideWorkspace: t.env.BypassToolHardProtections(), RecheckMinutes: args.RecheckMinutes})
 	response := startProcessResponse{}
 	if p != nil {
 		response.Process = redactProcess(t.env, *p)

--- a/internal/tools/tool_bash.go
+++ b/internal/tools/tool_bash.go
@@ -413,6 +413,10 @@ func (t *BashTool) executeStartBackground(ctx context.Context, args bashArgs) (s
 	if strings.TrimSpace(args.OwnerID) == "" {
 		args.OwnerID = defaultProcessOwnerID(t.env)
 	}
+	rootThreadID := processRootThreadID(t.env)
+	if rootThreadID == "" {
+		return "", errors.New("bash start_background requires a bound session ID")
+	}
 	m, err := t.env.ProcessManager()
 	if err != nil {
 		return "", err
@@ -421,7 +425,7 @@ func (t *BashTool) executeStartBackground(ctx context.Context, args bashArgs) (s
 	if args.TTY != nil {
 		tty = *args.TTY
 	}
-	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, RootThreadID: processRootThreadID(t.env), Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: tty, AllowOutsideWorkspace: t.env.BypassToolHardProtections(), RecheckMinutes: args.RecheckMinutes})
+	p, startErr := m.Start(context.WithoutCancel(ctx), proc.StartOptions{Command: args.Command, CommandPrefix: commandPrefix, CWD: args.CWD, OwnerKind: proc.OwnerKind(args.OwnerKind), OwnerID: args.OwnerID, RootThreadID: rootThreadID, Lifecycle: proc.Lifecycle(args.Lifecycle), CompletionMode: proc.CompletionMode(args.CompletionMode), TTY: tty, AllowOutsideWorkspace: t.env.BypassToolHardProtections(), RecheckMinutes: args.RecheckMinutes})
 	response := startProcessResponse{}
 	if p != nil {
 		response.Process = redactProcess(t.env, *p)

--- a/internal/tools/tool_bash_background_test.go
+++ b/internal/tools/tool_bash_background_test.go
@@ -67,6 +67,7 @@ func TestBashUpdateBackgroundScheduleLifecycle(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-update-background")
 
 	startResp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -133,6 +134,7 @@ func TestBashStartBackgroundAllowsExplicitLogOnlyMode(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-log-only-background")
 
 	response, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -168,6 +170,7 @@ func TestBashStartBackgroundRejectsInvalidRecheck(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-invalid-recheck")
 
 	_, err = kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",

--- a/internal/tools/tool_bash_root_thread_test.go
+++ b/internal/tools/tool_bash_root_thread_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	proc "github.com/blueberrycongee/wuu/internal/process"
+	"github.com/blueberrycongee/wuu/internal/providers"
+)
+
+func startBackgroundForRootThreadTest(t *testing.T, arguments string, bind func(kit *Toolkit)) proc.Process {
+	t.Helper()
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	manager, err := proc.NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = manager.CleanupSession() })
+	kit.SetProcessManager(manager)
+	bind(kit)
+
+	if _, err := kit.Execute(context.Background(), providers.ToolCall{Name: "bash", Arguments: arguments}); err != nil {
+		t.Fatalf("start background: %v", err)
+	}
+
+	list, err := manager.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected exactly one command session, got %d", len(list))
+	}
+	return list[0]
+}
+
+// The record has to name the conversation that owns the command, so a later
+// thread-delete cascade has something to key off.
+func TestStartBackgroundStampsBoundThreadOnRecord(t *testing.T) {
+	got := startBackgroundForRootThreadTest(t,
+		`{"action":"start_background","command":"sleep 60"}`,
+		func(kit *Toolkit) { kit.SetSessionID("thread-abc") },
+	)
+	if got.RootThreadID != "thread-abc" {
+		t.Fatalf("RootThreadID = %q, want thread-abc", got.RootThreadID)
+	}
+}
+
+// root_thread_id is host state, not a model argument. A model that invents one
+// must not be able to point the record at another conversation and escape its
+// owner's cleanup.
+func TestStartBackgroundIgnoresModelSuppliedRootThread(t *testing.T) {
+	got := startBackgroundForRootThreadTest(t,
+		`{"action":"start_background","command":"sleep 60","root_thread_id":"someone-elses-thread"}`,
+		func(kit *Toolkit) { kit.SetSessionID("thread-abc") },
+	)
+	if got.RootThreadID != "thread-abc" {
+		t.Fatalf("RootThreadID = %q, want the bound thread-abc, not the model-supplied value", got.RootThreadID)
+	}
+}
+
+// A toolkit with no bound conversation (headless or workspace-level) records an
+// empty owner rather than a fabricated one.
+func TestStartBackgroundLeavesRootThreadEmptyWithoutSession(t *testing.T) {
+	got := startBackgroundForRootThreadTest(t,
+		`{"action":"start_background","command":"sleep 60"}`,
+		func(kit *Toolkit) {},
+	)
+	if got.RootThreadID != "" {
+		t.Fatalf("RootThreadID = %q, want empty for an unbound toolkit", got.RootThreadID)
+	}
+}

--- a/internal/tools/tool_bash_root_thread_test.go
+++ b/internal/tools/tool_bash_root_thread_test.go
@@ -3,13 +3,14 @@ package tools
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	proc "github.com/blueberrycongee/wuu/internal/process"
 	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
-func startBackgroundForRootThreadTest(t *testing.T, arguments string, bind func(kit *Toolkit)) proc.Process {
+func startBackgroundForRootThreadTest(t *testing.T, arguments string, bind func(kit *Toolkit)) ([]string, proc.Process) {
 	t.Helper()
 	root := t.TempDir()
 	kit, err := New(root)
@@ -24,7 +25,8 @@ func startBackgroundForRootThreadTest(t *testing.T, arguments string, bind func(
 	kit.SetProcessManager(manager)
 	bind(kit)
 
-	if _, err := kit.Execute(context.Background(), providers.ToolCall{Name: "bash", Arguments: arguments}); err != nil {
+	startResponse, err := kit.Execute(context.Background(), providers.ToolCall{Name: "bash", Arguments: arguments})
+	if err != nil {
 		t.Fatalf("start background: %v", err)
 	}
 
@@ -35,13 +37,24 @@ func startBackgroundForRootThreadTest(t *testing.T, arguments string, bind func(
 	if len(list) != 1 {
 		t.Fatalf("expected exactly one command session, got %d", len(list))
 	}
-	return list[0]
+	listResponse, err := kit.Execute(context.Background(), providers.ToolCall{Name: "bash", Arguments: `{"action":"list_background"}`})
+	if err != nil {
+		t.Fatalf("list background: %v", err)
+	}
+	readResponse, err := kit.Execute(context.Background(), providers.ToolCall{
+		Name:      "bash",
+		Arguments: `{"action":"read_background","process_id":"` + list[0].ID + `"}`,
+	})
+	if err != nil {
+		t.Fatalf("read background: %v", err)
+	}
+	return []string{startResponse, listResponse, readResponse}, list[0]
 }
 
-// The record has to name the conversation that owns the command, so a later
-// thread-delete cascade has something to key off.
+// The durable record names the conversation that owns the command without
+// claiming lifecycle cleanup behavior in this step.
 func TestStartBackgroundStampsBoundThreadOnRecord(t *testing.T) {
-	got := startBackgroundForRootThreadTest(t,
+	_, got := startBackgroundForRootThreadTest(t,
 		`{"action":"start_background","command":"sleep 60"}`,
 		func(kit *Toolkit) { kit.SetSessionID("thread-abc") },
 	)
@@ -51,10 +64,9 @@ func TestStartBackgroundStampsBoundThreadOnRecord(t *testing.T) {
 }
 
 // root_thread_id is host state, not a model argument. A model that invents one
-// must not be able to point the record at another conversation and escape its
-// owner's cleanup.
+// must not be able to point durable ownership at another conversation.
 func TestStartBackgroundIgnoresModelSuppliedRootThread(t *testing.T) {
-	got := startBackgroundForRootThreadTest(t,
+	_, got := startBackgroundForRootThreadTest(t,
 		`{"action":"start_background","command":"sleep 60","root_thread_id":"someone-elses-thread"}`,
 		func(kit *Toolkit) { kit.SetSessionID("thread-abc") },
 	)
@@ -63,14 +75,48 @@ func TestStartBackgroundIgnoresModelSuppliedRootThread(t *testing.T) {
 	}
 }
 
-// A toolkit with no bound conversation (headless or workspace-level) records an
-// empty owner rather than a fabricated one.
-func TestStartBackgroundLeavesRootThreadEmptyWithoutSession(t *testing.T) {
-	got := startBackgroundForRootThreadTest(t,
+func TestStartBackgroundRejectsUnboundOrPendingSession(t *testing.T) {
+	root := t.TempDir()
+	kit, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	manager, err := proc.NewManager(root, filepath.Join(t.TempDir(), "runtime"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	kit.SetProcessManager(manager)
+
+	for _, sessionID := range []string{"", "session-pending"} {
+		kit.SetSessionID(sessionID)
+		_, err = kit.Execute(context.Background(), providers.ToolCall{
+			Name:      "bash",
+			Arguments: `{"action":"start_background","command":"sleep 60","root_thread_id":"model-invented"}`,
+		})
+		if err == nil || !strings.Contains(err.Error(), "bound session ID") {
+			t.Fatalf("session %q start_background error = %v, want bound session requirement", sessionID, err)
+		}
+	}
+	list, listErr := manager.List()
+	if listErr != nil {
+		t.Fatalf("List: %v", listErr)
+	}
+	if len(list) != 0 {
+		t.Fatalf("unbound model command created records: %+v", list)
+	}
+}
+
+func TestBashResponsesOmitInternalCommandIdentityFields(t *testing.T) {
+	responses, stored := startBackgroundForRootThreadTest(t,
 		`{"action":"start_background","command":"sleep 60"}`,
-		func(kit *Toolkit) {},
+		func(kit *Toolkit) { kit.SetSessionID("thread-redaction") },
 	)
-	if got.RootThreadID != "" {
-		t.Fatalf("RootThreadID = %q, want empty for an unbound toolkit", got.RootThreadID)
+	for i, response := range responses {
+		if strings.Contains(response, "root_thread_id") || strings.Contains(response, "host_generation_id") {
+			t.Fatalf("response %d exposed internal command identity: %s", i, response)
+		}
+	}
+	if stored.RootThreadID != "thread-redaction" || stored.HostGenerationID == "" {
+		t.Fatalf("persisted record lost internal command identity: %+v", stored)
 	}
 }

--- a/internal/tools/tool_bash_test.go
+++ b/internal/tools/tool_bash_test.go
@@ -412,6 +412,7 @@ func TestBashBackgroundModeUsesManagedProcessBackend(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-bash-background")
 
 	resp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -476,6 +477,7 @@ func TestBashReadBackgroundConsumesCompletionWhenTerminalResultIsReturned(t *tes
 		t.Fatalf("NewManager: %v", err)
 	}
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-bash-completion")
 
 	resp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -632,6 +634,7 @@ func TestBashBackgroundUsesCWD(t *testing.T) {
 	}
 	defer func() { _ = manager.CleanupSession() }()
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-bash-background-cwd")
 
 	resp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",

--- a/internal/tools/tool_process.go
+++ b/internal/tools/tool_process.go
@@ -39,6 +39,19 @@ func defaultProcessOwnerKind(env *Env, ownerKind string) string {
 	return string(proc.OwnerMainAgent)
 }
 
+// processRootThreadID resolves the conversation a background command belongs
+// to. It is deliberately host-derived rather than a model argument: the record
+// is what a later thread-delete or subagent-close cascade keys off, so the
+// model must not be able to point it elsewhere or leave it blank. Subagents
+// inherit the root conversation's SessionID from their controller, so the same
+// lookup is correct for main-agent and subagent commands alike.
+func processRootThreadID(env *Env) string {
+	if env == nil {
+		return ""
+	}
+	return strings.TrimSpace(env.SessionID)
+}
+
 func defaultProcessOwnerID(env *Env) string {
 	if env == nil {
 		return "main"

--- a/internal/tools/tool_process.go
+++ b/internal/tools/tool_process.go
@@ -41,15 +41,19 @@ func defaultProcessOwnerKind(env *Env, ownerKind string) string {
 
 // processRootThreadID resolves the conversation a background command belongs
 // to. It is deliberately host-derived rather than a model argument: the record
-// is what a later thread-delete or subagent-close cascade keys off, so the
-// model must not be able to point it elsewhere or leave it blank. Subagents
-// inherit the root conversation's SessionID from their controller, so the same
-// lookup is correct for main-agent and subagent commands alike.
+// preserves durable ownership for later lifecycle work, so the model cannot
+// point it elsewhere. The model-facing start boundary rejects an empty result;
+// low-level internal Manager.Start callers may have another legitimate
+// ownership model.
 func processRootThreadID(env *Env) string {
 	if env == nil {
 		return ""
 	}
-	return strings.TrimSpace(env.SessionID)
+	id := strings.TrimSpace(env.SessionID)
+	if id == "session-pending" {
+		return ""
+	}
+	return id
 }
 
 func defaultProcessOwnerID(env *Env) string {
@@ -76,6 +80,11 @@ func redactProcessPtr(env *Env, p *proc.Process) *proc.Process {
 func redactProcess(env *Env, p proc.Process) proc.Process {
 	p.Command = env.RedactToolOutput(p.Command)
 	p.LastError = env.RedactToolOutput(p.LastError)
+	// These fields are durable routing/identity metadata, not useful model
+	// controls. Keep them in persisted records while omitting them from the
+	// model-facing response boundary.
+	p.RootThreadID = ""
+	p.HostGenerationID = ""
 	return p
 }
 

--- a/internal/tools/toolkit_test.go
+++ b/internal/tools/toolkit_test.go
@@ -4262,6 +4262,7 @@ func TestToolkit_StartProcessSupportsTTY(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-process-tty")
 
 	resp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -4310,6 +4311,7 @@ func TestToolkit_ProcessAndPortTelemetryRecordsResultActions(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-process-telemetry")
 
 	startResp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",
@@ -4420,6 +4422,7 @@ func TestToolkit_ProcessOutputRedactsSecrets(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	kit.SetProcessManager(manager)
+	kit.SetSessionID("thread-process-redaction")
 
 	resp, err := kit.Execute(context.Background(), providers.ToolCall{
 		Name:      "bash",


### PR DESCRIPTION
## Summary

First of the four steps I proposed in #157: give every background command a durable owner and a host identity. Pure data plane — nothing reads the new fields yet, so this can land without committing to the rest of the design.

## Changes

- **`Process.RootThreadID`** — the conversation that owns the command, stamped at start. Invariant 2 in the issue requires this precisely because owner cannot be recovered afterwards: once the thread is deleted or the subagent closes, there is nothing left to scan.
- **`Process.HostGenerationID`** — minted once per `Manager` and stamped on every command it starts. This is what lets a later host separate its own live records from a previous host's leftovers; a record from another generation carries no stdin, PTY, or exit watcher in this process. `StartedByCurrentHost` encodes that check in one place.
- **`lifecycle` marked deprecated** — still parses and round-trips so existing registry records keep loading. Removing it belongs to step 4.

### One judgement call, worth a look

`root_thread_id` is taken from the toolkit's bound conversation (`Env.SessionID`), **not** from the `bash` tool arguments.

This answers the open question I asked on the issue. `owner_kind` / `owner_id` are model-influenced today — `executeStartBackground` reads them from `bashArgs` and only falls back to host defaults when blank. Extending that to the thread would let a command point its own record at another conversation and escape its owner's cleanup, which defeats the cascade the field exists for. So the thread is host-derived and there is a test asserting a model-supplied `root_thread_id` is ignored.

I did **not** change `owner_kind` / `owner_id` to match, because that is a behavior change and this step is meant to be inert. It is worth doing before step 3 wires the cascade — flagging it rather than smuggling it in here.

Subagents inherit the root conversation's session id from their `agentcontrol` controller (`c.sessionID`), so the single lookup is correct for main-agent and subagent commands alike.

### Migration

No data migration. Pre-upgrade records simply have both fields empty, and an absent generation reads the same as a foreign one — which is correct, since this host cannot control those processes either. That matches the "restart means lost" semantics in the issue and avoids a one-shot migration path. A test pins that a legacy record without the new fields still loads, keeps its deprecated `lifecycle`, and is not claimed by the running host.

## Test plan

- [x] Added or updated unit tests for the change
- [x] `go test ./...` passes
- [x] `cd desktop && npm test` passes
- [ ] Manually verified the behavior in the desktop shell (if applicable)

Seven new tests: owner and generation persisted to the registry file, generation unique per Manager, `StartedByCurrentHost` rejecting foreign and legacy records, legacy record still loading with `lifecycle` intact, and three at the tool layer covering the bound thread being stamped, a model-supplied thread being ignored, and an unbound toolkit recording an empty owner rather than a fabricated one. `make check` passes; `gofmt` clean.

Not verified in the desktop shell — core-only change with no renderer surface.

## Risk and rollback

- Risk level: low — additive fields, no reader, no protocol change.
- Rollback: revert the commit. Records written meanwhile keep the extra fields, which older code ignores.

## Linked issues / docs

Refs #157. Deliberately not `Closes` — steps 2 to 4 (status vocabulary, owner-close cascade, execution convergence) are still open.
