### PR TITLE
fix(desktop): bootstrap Electron binary before dev host setup

### DIFF
--- a/desktop/scripts/prepare-dev-electron-app.cjs
+++ b/desktop/scripts/prepare-dev-electron-app.cjs
@@ -7,7 +7,7 @@ const {
   writeFileSync,
 } = require("node:fs");
 const { createHash } = require("node:crypto");
-const { join, resolve } = require("node:path");
+const { dirname, join, resolve } = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const desktopRoot = resolve(__dirname, "..");
@@ -38,6 +38,7 @@ function prepareDevElectronApp(signing = { identity: "-", fingerprint: "adhoc", 
   )) return devApp;
 
   console.log(`preparing stable Wuu Dev host for Electron ${electronVersion}...`);
+  ensureSourceElectronApp({ electronVersion });
   mkdirSync(hostRoot, { recursive: true });
   rmSync(devApp, { recursive: true, force: true });
 
@@ -185,7 +186,54 @@ function run(command, args) {
   }
 }
 
+function installedElectronVersion() {
+  return JSON.parse(readFileSync(electronPackagePath, "utf8")).version;
+}
+
+function electronInstallerScriptFromManifest(manifest) {
+  return manifest.bin?.["install-electron"] || "install.js";
+}
+
+function electronInstallerPath() {
+  const manifest = JSON.parse(readFileSync(electronPackagePath, "utf8"));
+  return join(dirname(electronPackagePath), electronInstallerScriptFromManifest(manifest));
+}
+
+function installElectronBinary() {
+  const installerPath = electronInstallerPath();
+  console.log(`running local Electron installer: node ${installerPath}`);
+  return spawnSync(process.execPath, [installerPath], { stdio: "inherit" });
+}
+
+function ensureSourceElectronApp({
+  sourceAppExists = () => existsSync(sourceApp),
+  installElectron = installElectronBinary,
+  electronVersion = installedElectronVersion(),
+} = {}) {
+  if (sourceAppExists()) return true;
+
+  console.log(
+    `Electron ${electronVersion} binary is not downloaded yet; installing before preparing the Wuu Dev host...`,
+  );
+  const result = installElectron();
+  if (result.status !== 0) {
+    throw new Error(
+      `Electron ${electronVersion} install failed with status ${result.status ?? "unknown"}. `
+      + `Run the local installer directly to see the full error: node ${electronInstallerPath()}`,
+    );
+  }
+  if (!sourceAppExists()) {
+    throw new Error(
+      `Electron ${electronVersion} installer finished but ${sourceApp} is still missing; `
+      + "cannot prepare the Wuu Dev host without it.",
+    );
+  }
+  return true;
+}
+
 module.exports = {
+  electronInstallerScriptFromManifest,
+  ensureSourceElectronApp,
   helperPathForApp,
   pipHelperPathForApp,
   speechHelperPathForApp,

--- a/desktop/scripts/test-dev-launcher.cjs
+++ b/desktop/scripts/test-dev-launcher.cjs
@@ -8,6 +8,8 @@ const {
   processIDForLaunchToken,
 } = require("./launch-electron-via-open.cjs");
 const {
+  electronInstallerScriptFromManifest,
+  ensureSourceElectronApp,
   helperPathForApp,
   pipHelperPathForApp,
   speechHelperPathForApp,
@@ -149,6 +151,96 @@ assert.equal(
 assert.equal(
   matchingIdentity(identities, "0123456789abcdef0123456789abcdef01234567")?.name,
   DEFAULT_DEV_SIGNING_ID,
+);
+
+// Electron bootstrap for the dev host. The real installer downloads a binary
+// over the network; these tests replace that step with a fake so they verify
+// our decision logic without touching the network or the real Electron.app.
+const realSourceApp = resolve(
+  __dirname,
+  "..",
+  "node_modules",
+  "electron",
+  "dist",
+  "Electron.app",
+);
+
+assert.equal(
+  electronInstallerScriptFromManifest({ bin: { "install-electron": "install.js" } }),
+  "install.js",
+);
+assert.equal(electronInstallerScriptFromManifest({}), "install.js");
+
+// Test 1: source Electron.app already present -> installer not called.
+let installCalls = 0;
+let appExists = true;
+assert.equal(
+  ensureSourceElectronApp({
+    sourceAppExists: () => appExists,
+    installElectron: () => {
+      installCalls += 1;
+      return { status: 0 };
+    },
+    electronVersion: "42.3.0",
+  }),
+  true,
+);
+assert.equal(installCalls, 0);
+
+// Test 2: missing first, then present after install -> installer called once.
+let installCallsTwo = 0;
+let appExistsTwo = false;
+assert.equal(
+  ensureSourceElectronApp({
+    sourceAppExists: () => appExistsTwo,
+    installElectron: () => {
+      installCallsTwo += 1;
+      appExistsTwo = true;
+      return { status: 0 };
+    },
+    electronVersion: "42.3.0",
+  }),
+  true,
+);
+assert.equal(installCallsTwo, 1);
+
+// Test 3: installer reports success but the app is still missing -> clear error.
+assert.throws(
+  () => ensureSourceElectronApp({
+    sourceAppExists: () => false,
+    installElectron: () => ({ status: 0 }),
+    electronVersion: "42.3.0",
+  }),
+  (error) => {
+    assert.ok(error instanceof Error);
+    assert.ok(error.message.includes("still missing"));
+    assert.ok(error.message.includes(realSourceApp));
+    return true;
+  },
+);
+
+// Test 4: installer itself fails -> error keeps the exit status.
+assert.throws(
+  () => ensureSourceElectronApp({
+    sourceAppExists: () => false,
+    installElectron: () => ({ status: 1 }),
+    electronVersion: "42.3.0",
+  }),
+  /status 1/,
+);
+
+// Test 5: an already-current Wuu Dev.app fast-returns before the source
+// Electron.app is ever checked or installed. The source order in
+// prepareDevElectronApp encodes that guarantee: the `return devApp;` short
+// circuit must appear before the `ensureSourceElectronApp(` call.
+const prepareSource = readFileSync(resolve(__dirname, "prepare-dev-electron-app.cjs"), "utf8");
+const fastReturnIndex = prepareSource.indexOf("return devApp;");
+const bootstrapCallIndex = prepareSource.indexOf("ensureSourceElectronApp({ electronVersion });");
+assert.ok(fastReturnIndex >= 0, "fast path return must exist");
+assert.ok(bootstrapCallIndex >= 0, "bootstrap call must exist");
+assert.ok(
+  bootstrapCallIndex > fastReturnIndex,
+  "existing Wuu Dev.app must return before checking/installing source Electron.app",
 );
 
 console.log("dev launcher tests passed");


### PR DESCRIPTION
## Summary

Fix `make dev` on fresh macOS checkouts where Electron 42 has installed its JavaScript package but has not downloaded the project-local `Electron.app` binary yet.

When the binary is missing, the development launcher now runs Electron's own local installer before preparing the stable `Wuu Dev.app` host.

## Changes

* Preserve the existing fast path when the current `Wuu Dev.app` is still valid, without checking or installing the source Electron app.
* Check for `desktop/node_modules/electron/dist/Electron.app` only when the development host must be rebuilt.
* Resolve and run the installer from the locally installed `electron` package using the current Node executable.
* Avoid `npx`, global Electron installations, new dependencies, and hard-coded download URLs.
* Re-check that `Electron.app` exists after installation.
* Report a clear error when the installer fails or completes without producing the expected app.
* Add regression coverage using injected file checks and a fake installer, without downloading Electron during the automated test suite.

Before this fix, a fresh checkout could fail before Electron had a chance to download its binary:

```text
cp: .../electron/dist/Electron.app: No such file or directory
ditto: Cannot get the real path for source ...
Error: ditto failed with status 1
```

## Test plan

* [x] Added or updated unit tests for the change
* [x] Go test suite passes via `make ci`
* [x] `cd desktop && npm test` passes via `make ci`
* [x] Manually verified the behavior in the desktop shell

Additional verification:

* `npm --prefix desktop run test:dev-launcher`
* `npm --prefix desktop run typecheck`
* `make check-desktop`
* `make test-desktop`
* `make build-desktop`
* `make ci`
* Created a fresh macOS Apple Silicon checkout and confirmed that `desktop/node_modules/electron/dist/Electron.app` was absent after `make setup`.
* Applied the fix and verified that the first `make dev` invocation downloaded the project-local Electron binary, prepared and signed `Wuu Dev.app`, started Electron through LaunchServices, and connected the renderer.
* Ran `make dev` a second time and confirmed that Electron was not downloaded again.

## Risk and rollback

* Risk level: low. The new behavior is limited to the macOS development-host preparation path and runs only when the project-local Electron binary is missing.
* Rollback: revert this commit to restore the previous development-host preparation behavior.

## Linked issues / docs

None. This is a focused developer-workflow regression fix and does not require a prior issue.
