### PR TITLE
fix(process): retire background commands a restarted host cannot account for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ## [Unreleased]
 
+### Fixed
+
+- A background command left behind by a crashed app-server no longer sits at
+  `running` forever. An app-server that boots as the sole live host now retires
+  records no live host can own as `lost`, records why, and terminates the
+  leftover process tree on a best-effort basis after verifying the recorded
+  process identity. The sweep runs only while exclusive app-server presence is
+  held, so a peer that is still alive keeps its own running commands. `lost` is
+  deliberately not `stopped`: this host never observed how the command ended,
+  and a successful cleanup afterwards does not tell it. The desktop shows these
+  runs distinctly instead of leaving them pending, and no longer offers a
+  terminal for a process that is gone.
+
 ## [0.15.0] - 2026-08-05
 
 ### Added

--- a/desktop/src/renderer/WorkspaceTerminalPanel.test.tsx
+++ b/desktop/src/renderer/WorkspaceTerminalPanel.test.tsx
@@ -405,6 +405,30 @@ describe("WorkspaceTerminalPanel", () => {
     expect(terminalInstances).toHaveLength(0);
   });
 
+  // A lost record belongs to an app-server that is gone. Treating it as live
+  // would offer the user a terminal with no process behind it.
+  it("does not list managed processes the app-server can no longer account for", async () => {
+    listManagedProcesses.mockResolvedValue({
+      processes: [
+        {
+          ...runningProcess,
+          status: "lost",
+          loss_reason: "host_restarted",
+          recovery_cleanup: "terminated",
+          stopped_at: "2026-07-18T08:01:00Z",
+        },
+      ],
+    });
+
+    await render(
+      <WorkspaceTerminalPanel activeContext={worktreeContext} thread={threadWithLiveRun} />,
+    );
+
+    await vi.waitFor(() => expect(listManagedProcesses).toHaveBeenCalledWith("thread-1"));
+    expect(container.querySelector(".workspace-terminal-navigation")?.textContent).not.toContain("npm run dev");
+    expect(terminalInstances).toHaveLength(0);
+  });
+
   it("resizes the terminal list from the separator", async () => {
     await render(<WorkspaceTerminalPanel activeContext={worktreeContext} />);
     const separator = container.querySelector<HTMLElement>('[role="separator"]');

--- a/desktop/src/renderer/WorkspaceTerminalPanel.tsx
+++ b/desktop/src/renderer/WorkspaceTerminalPanel.tsx
@@ -1,7 +1,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XtermTerminal, type ITerminalOptions, type ITheme } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
-import { CheckCircle2, Clock3, Plus, Square, SquareTerminal, Terminal, X, XCircle } from "lucide-react";
+import { CheckCircle2, Clock3, HelpCircle, Plus, Square, SquareTerminal, Terminal, X, XCircle } from "lucide-react";
 import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -547,6 +547,11 @@ function RunStatusIcon({
 }): JSX.Element {
   if (process ? process.status === "failed" : run.status === "failed") {
     return <XCircle className="icon failed" />;
+  }
+  // A lost record outlived the app-server that started it, so nothing here saw
+  // how it ended. It is neither live nor a confirmed completion.
+  if (process?.status === "lost") {
+    return <HelpCircle className="icon lost" />;
   }
   if (run.execution === "managed" && (!process || isManagedProcessLive(process))) {
     return <Clock3 className="icon live" />;

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -400,6 +400,15 @@ func (s *Server) settleOnBoot() {
 	if s == nil || s.rt == nil {
 		return
 	}
+	// Only the boot owner reaches this, and it still holds exclusive app-server
+	// presence. That is what makes retiring another host's command records
+	// safe: a differing host generation alone would also match a peer that is
+	// still alive and still owns its processes.
+	if s.rt.ProcessManager != nil {
+		if err := s.rt.ProcessManager.ReconcileAbandonedRecords(); err != nil {
+			providers.DebugLogf("settleOnBoot (abandoned command records): %v", err)
+		}
+	}
 	now := time.Now().UTC()
 	if s.rt.InferenceJournalRuntime != nil {
 		recoveries, recoverErr := s.rt.InferenceJournalRuntime.ReconcileOrphans(now)

--- a/internal/process/lost_record_test.go
+++ b/internal/process/lost_record_test.go
@@ -1,0 +1,199 @@
+package process
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeLeftoverRecord plants a registry row as if a previous app-server had
+// started it and then died without settling it.
+func writeLeftoverRecord(t *testing.T, registryDir string, p Process) {
+	t.Helper()
+	if err := os.MkdirAll(registryDir, 0o755); err != nil {
+		t.Fatalf("mkdir registry: %v", err)
+	}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(registryDir, p.ID+".json"), raw, 0o644); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+}
+
+func recordByID(t *testing.T, m *Manager, id string) Process {
+	t.Helper()
+	list, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, p := range list {
+		if p.ID == id {
+			return p
+		}
+	}
+	t.Fatalf("record %q not found in %+v", id, list)
+	return Process{}
+}
+
+// A session command left behind by a crashed app-server used to sit at
+// "running" forever: unreachable, but never settled.
+func TestStartupRetiresLeftoverSessionRecordAsLost(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	registryDir := filepath.Join(runtimeDir, "processes")
+	writeLeftoverRecord(t, registryDir, Process{
+		ID:               "leftover-1",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		RootThreadID:     "thread-1",
+		HostGenerationID: "host-from-a-previous-run",
+		Lifecycle:        LifecycleSession,
+		Status:           StatusRunning,
+		PID:              -1,
+		Command:          "sleep 600",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now().Add(-time.Hour),
+	})
+
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+
+	got := recordByID(t, m, "leftover-1")
+	if got.Status != StatusLost {
+		t.Fatalf("Status = %q, want lost", got.Status)
+	}
+	// The command may have exited cleanly, been killed, or still be detached.
+	// Claiming a terminal cause would assert an exit nobody observed.
+	if got.TerminalCause != "" {
+		t.Fatalf("a lost record must not claim a terminal cause, got %q", got.TerminalCause)
+	}
+	if got.LossReason == "" || got.RecoveryCleanup == "" {
+		t.Fatalf("a lost record must explain itself: %+v", got)
+	}
+}
+
+// The correction on the previous step: several managers share one host
+// lifetime. A sibling manager's live record is still controllable by the host
+// and must survive startup untouched.
+func TestStartupLeavesSameHostGenerationRecordsAlone(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	first, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = first.CleanupSession() })
+
+	writeLeftoverRecord(t, filepath.Join(runtimeDir, "processes"), Process{
+		ID:               "sibling-1",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		HostGenerationID: first.HostGenerationID(),
+		Lifecycle:        LifecycleSession,
+		Status:           StatusRunning,
+		PID:              -1,
+		Command:          "sleep 600",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now(),
+	})
+
+	sibling, err := NewManagerWithHostGeneration(t.TempDir(), first.HostGenerationID(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManagerWithHostGeneration: %v", err)
+	}
+	t.Cleanup(func() { _ = sibling.CleanupSession() })
+
+	if got := recordByID(t, sibling, "sibling-1"); got.Status != StatusRunning {
+		t.Fatalf("Status = %q, want running: a sibling manager in the same host must not retire it", got.Status)
+	}
+}
+
+// Managed re-adoption across restarts is still in force. Retiring it belongs to
+// a later step, so this reconciliation must not touch those records.
+func TestStartupDoesNotRetireLeftoverManagedRecords(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	writeLeftoverRecord(t, filepath.Join(runtimeDir, "processes"), Process{
+		ID:               "managed-1",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		HostGenerationID: "host-from-a-previous-run",
+		Lifecycle:        LifecycleManaged,
+		Status:           StatusRunning,
+		PID:              -1,
+		Command:          "sleep 600",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now().Add(-time.Hour),
+	})
+
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+
+	if got := recordByID(t, m, "managed-1"); got.Status == StatusLost {
+		t.Fatalf("managed records are still re-adopted at startup; got %+v", got)
+	}
+}
+
+// Cleanup is best effort and its outcome is reported separately from the loss
+// reason. A live leftover whose identity checks out gets its tree terminated.
+func TestStartupTerminatesVerifiedLeftoverProcessTree(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	cmd := exec.Command("sleep", "600")
+	// Isolate the helper into its own process group. Without this the recorded
+	// group is the test runner's own, and cleanup would kill the test process.
+	PrepareCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	identity, _, _, err := readProcessIdentity(pid)
+	if err != nil {
+		t.Skipf("process identity unavailable on this platform: %v", err)
+	}
+	writeLeftoverRecord(t, filepath.Join(runtimeDir, "processes"), Process{
+		ID:               "leftover-live",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		HostGenerationID: "host-from-a-previous-run",
+		Lifecycle:        LifecycleSession,
+		Status:           StatusRunning,
+		PID:              pid,
+		PGID:             ProcessTreeForPID(pid).ID(),
+		ProcessStartTime: identity,
+		Command:          "sleep 600",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now().Add(-time.Hour),
+	})
+
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+
+	got := recordByID(t, m, "leftover-live")
+	if got.Status != StatusLost {
+		t.Fatalf("Status = %q, want lost", got.Status)
+	}
+	if got.RecoveryCleanup != RecoveryTerminated {
+		t.Fatalf("RecoveryCleanup = %q, want terminated", got.RecoveryCleanup)
+	}
+	// Cleanup succeeding does not tell this host how the command originally
+	// ended, so the record stays lost rather than becoming a normal stop.
+	if got.LossReason != LossHostRestarted {
+		t.Fatalf("LossReason = %q, want host_restarted", got.LossReason)
+	}
+}

--- a/internal/process/lost_record_test.go
+++ b/internal/process/lost_record_test.go
@@ -64,6 +64,11 @@ func TestStartupRetiresLeftoverSessionRecordAsLost(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	t.Cleanup(func() { _ = m.CleanupSession() })
+	// Construction must not touch other hosts' records; reconciliation is an
+	// explicit call the boot owner makes under exclusive presence.
+	if err := m.ReconcileAbandonedRecords(); err != nil {
+		t.Fatalf("ReconcileAbandonedRecords: %v", err)
+	}
 
 	got := recordByID(t, m, "leftover-1")
 	if got.Status != StatusLost {
@@ -108,6 +113,9 @@ func TestStartupLeavesSameHostGenerationRecordsAlone(t *testing.T) {
 		t.Fatalf("NewManagerWithHostGeneration: %v", err)
 	}
 	t.Cleanup(func() { _ = sibling.CleanupSession() })
+	if err := sibling.ReconcileAbandonedRecords(); err != nil {
+		t.Fatalf("ReconcileAbandonedRecords: %v", err)
+	}
 
 	if got := recordByID(t, sibling, "sibling-1"); got.Status != StatusRunning {
 		t.Fatalf("Status = %q, want running: a sibling manager in the same host must not retire it", got.Status)
@@ -136,6 +144,11 @@ func TestStartupDoesNotRetireLeftoverManagedRecords(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	t.Cleanup(func() { _ = m.CleanupSession() })
+	// Construction must not touch other hosts' records; reconciliation is an
+	// explicit call the boot owner makes under exclusive presence.
+	if err := m.ReconcileAbandonedRecords(); err != nil {
+		t.Fatalf("ReconcileAbandonedRecords: %v", err)
+	}
 
 	if got := recordByID(t, m, "managed-1"); got.Status == StatusLost {
 		t.Fatalf("managed records are still re-adopted at startup; got %+v", got)
@@ -154,10 +167,11 @@ func TestStartupTerminatesVerifiedLeftoverProcessTree(t *testing.T) {
 		t.Skipf("cannot start helper process: %v", err)
 	}
 	pid := cmd.Process.Pid
-	t.Cleanup(func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	})
+	// Reap the helper as it exits. A real leftover is re-parented to init and
+	// reaped there; an unreaped child would linger as a zombie, which still
+	// answers a group-liveness probe and would look like failed cleanup.
+	go func() { _ = cmd.Wait() }()
+	t.Cleanup(func() { _ = killProcessGroup(ProcessTreeForPID(pid).ID()) })
 
 	identity, _, _, err := readProcessIdentity(pid)
 	if err != nil {
@@ -183,6 +197,11 @@ func TestStartupTerminatesVerifiedLeftoverProcessTree(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	t.Cleanup(func() { _ = m.CleanupSession() })
+	// Construction must not touch other hosts' records; reconciliation is an
+	// explicit call the boot owner makes under exclusive presence.
+	if err := m.ReconcileAbandonedRecords(); err != nil {
+		t.Fatalf("ReconcileAbandonedRecords: %v", err)
+	}
 
 	got := recordByID(t, m, "leftover-live")
 	if got.Status != StatusLost {
@@ -195,5 +214,136 @@ func TestStartupTerminatesVerifiedLeftoverProcessTree(t *testing.T) {
 	// ended, so the record stays lost rather than becoming a normal stop.
 	if got.LossReason != LossHostRestarted {
 		t.Fatalf("LossReason = %q, want host_restarted", got.LossReason)
+	}
+}
+
+// Constructing a manager must never retire another host's records. Wuu allows a
+// successor app-server to start while an earlier host is still alive, so the
+// decision needs proof of exclusive ownership that only the boot owner has.
+func TestNewManagerDoesNotRetireForeignRecords(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	writeLeftoverRecord(t, filepath.Join(runtimeDir, "processes"), Process{
+		ID:               "peer-owned",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		HostGenerationID: "host-still-alive-elsewhere",
+		Lifecycle:        LifecycleSession,
+		Status:           StatusRunning,
+		PID:              -1,
+		Command:          "sleep 600",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now(),
+	})
+
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+
+	if got := recordByID(t, m, "peer-owned"); got.Status != StatusRunning {
+		t.Fatalf("Status = %q, want running: construction must not judge another host's records", got.Status)
+	}
+}
+
+// A leader that exits while a descendant keeps running must not read as a
+// clean stop. Probing only the recorded pid would report success and leave the
+// rest of the tree alive.
+func TestLeftoverCleanupKillsDescendantsAfterLeaderExits(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	// The leader exits immediately; the grandchild outlives it inside the same
+	// process group.
+	cmd := exec.Command("sh", "-c", "sleep 600 & exit 0")
+	PrepareCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	pgid := ProcessTreeForPID(pid).ID()
+	identity, _, _, err := readProcessIdentity(pid)
+	if err != nil {
+		t.Skipf("process identity unavailable on this platform: %v", err)
+	}
+	_ = cmd.Wait()
+	t.Cleanup(func() { _ = killProcessGroup(pgid) })
+
+	if !processGroupExists(pgid) {
+		t.Skip("descendant did not outlive its leader on this platform")
+	}
+	writeLeftoverRecord(t, filepath.Join(runtimeDir, "processes"), Process{
+		ID:               "leftover-descendant",
+		OwnerKind:        OwnerMainAgent,
+		OwnerID:          "main",
+		HostGenerationID: "host-from-a-previous-run",
+		Lifecycle:        LifecycleSession,
+		Status:           StatusRunning,
+		PID:              pid,
+		PGID:             pgid,
+		ProcessStartTime: identity,
+		Command:          "sh -c 'sleep 600 & exit 0'",
+		CWD:              t.TempDir(),
+		StartedAt:        time.Now().Add(-time.Hour),
+	})
+
+	if err := terminateLeftoverProcessTree(pgid, 2*time.Second); err != nil {
+		t.Fatalf("terminateLeftoverProcessTree: %v", err)
+	}
+	if processGroupExists(pgid) {
+		t.Fatal("descendant survived cleanup: the leader's exit was mistaken for the tree stopping")
+	}
+}
+
+// The sweep must settle every abandoned record, not stop at the first one.
+// Reconciliation is also no longer part of manager construction, so a failure
+// here cannot block the managed re-adoption that runs there.
+func TestReconcileSettlesEveryAbandonedRecord(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	registryDir := filepath.Join(runtimeDir, "processes")
+	for _, id := range []string{"leftover-a", "leftover-b", "leftover-c"} {
+		writeLeftoverRecord(t, registryDir, Process{
+			ID:               id,
+			OwnerKind:        OwnerMainAgent,
+			OwnerID:          "main",
+			HostGenerationID: "host-from-a-previous-run",
+			Lifecycle:        LifecycleSession,
+			Status:           StatusRunning,
+			PID:              -1,
+			Command:          "sleep 600",
+			CWD:              t.TempDir(),
+			StartedAt:        time.Now().Add(-time.Hour),
+		})
+	}
+
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+	if err := m.ReconcileAbandonedRecords(); err != nil {
+		t.Fatalf("ReconcileAbandonedRecords: %v", err)
+	}
+
+	for _, id := range []string{"leftover-a", "leftover-b", "leftover-c"} {
+		if got := recordByID(t, m, id); got.Status != StatusLost {
+			t.Fatalf("record %s status = %q, want lost: the sweep stopped early", id, got.Status)
+		}
+	}
+}
+
+// Failing to enumerate the registry at all is different from one bad record:
+// the sweep cannot know what it skipped, so it reports the failure.
+func TestReconcileReportsRegistryEnumerationFailure(t *testing.T) {
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	m, err := NewManager(t.TempDir(), runtimeDir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.CleanupSession() })
+
+	if err := os.WriteFile(filepath.Join(runtimeDir, "processes", "corrupt.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt record: %v", err)
+	}
+	if err := m.ReconcileAbandonedRecords(); err == nil {
+		t.Fatal("ReconcileAbandonedRecords() = nil, want an error when the registry cannot be read")
 	}
 }

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -1128,22 +1128,33 @@ const persistedProcessWatchInterval = 250 * time.Millisecond
 // resumePersistedManagedProcesses restores exit observation for managed
 // processes that outlived the manager which started them. PTY/stdin handles
 // cannot be reconstructed, but terminal state and completion delivery can.
-// reconcileForeignHostRecords retires records this host cannot account for.
+// ReconcileAbandonedRecords retires command records no live host can still own,
+// and best-effort cleans up their process trees.
 //
-// Until now only managed records were revisited at startup, so a session
-// command left behind by a crashed app-server sat at "running" forever: the
-// process was unreachable and the row never settled. Any non-terminal record
-// from another host generation is now marked lost, and its process tree is
-// cleaned up on a best-effort basis after an identity check.
+// It is destructive and MUST only be called by an app-server that has proven it
+// is the sole live host — in practice from the boot-owner section while the
+// exclusive app-server presence lock is held. A differing host generation is a
+// fencing label, not a liveness lease: Wuu supports a successor app-server
+// starting while an earlier host is still alive, and in that case the earlier
+// host's session commands are legitimately still owned. Deciding from the
+// generation alone would kill them. Exclusive presence is what proves nobody
+// else can own these records; the generation only says which ones are not ours.
 //
-// Records from this host's own generation are left alone. They belong to a
+// Records from this host's own generation are left alone: they belong to a
 // sibling manager in the same app-server, which still holds their handles.
 //
-// Managed records are also left alone here. The existing resume path
-// deliberately re-adopts and re-observes them across a restart; retiring that
-// re-adoption is a separate step of the lifecycle work, and killing them now
-// would break a contract that is still in force.
-func (m *Manager) reconcileForeignHostRecords() error {
+// Managed records are also left alone. The existing resume path deliberately
+// re-adopts and re-observes them across a restart; retiring that re-adoption is
+// a separate step of the lifecycle work.
+//
+// A per-record failure is reported and skipped rather than aborting the sweep:
+// one unreadable or unkillable leftover must not stop the remaining records
+// from settling, nor block the managed re-adoption that runs after it. Only a
+// failure to enumerate the registry at all is returned.
+func (m *Manager) ReconcileAbandonedRecords() error {
+	if m == nil {
+		return nil
+	}
 	processes, err := m.List()
 	if err != nil {
 		return err
@@ -1153,7 +1164,7 @@ func (m *Manager) reconcileForeignHostRecords() error {
 			continue
 		}
 		if _, err := m.markRecordLost(p.ID); err != nil {
-			return err
+			log.Printf("wuu: could not retire abandoned command record %s: %v", p.ID, err)
 		}
 	}
 	return nil
@@ -1162,24 +1173,95 @@ func (m *Manager) reconcileForeignHostRecords() error {
 // terminateLeftoverProcessTree stops a process group left behind by an earlier
 // host. It asks politely first and escalates, because nothing in this process
 // is waiting on the group to observe a graceful exit.
+// leftoverProcessGroupPollInterval paces the group-liveness probe while waiting
+// for a signalled tree to drain.
+const leftoverProcessGroupPollInterval = 25 * time.Millisecond
+
+// terminateLeftoverProcessTree stops a tree left behind by an earlier host,
+// mirroring CommandHandle.Stop: terminate, allow a grace period, force-kill,
+// and only then report failure.
+//
+// Liveness is probed on the whole group rather than the recorded leader. A
+// leader that exits while descendants keep running would otherwise look like a
+// clean stop and leave the rest of the tree alive.
+//
 // Falling back to the pid when no group was recorded would signal whatever
 // group happens to carry that id — possibly Wuu's own — so a record without a
-// usable group is reported as un-cleanable instead.
-func terminateLeftoverProcessTree(p *Process) error {
-	tree := ProcessTreeFromID(p.PGID)
-	if err := tree.Terminate(); err != nil {
-		return err
+// usable group is reported as un-cleanable by ProcessTree's own guard.
+func terminateLeftoverProcessTree(pgid int, grace time.Duration) error {
+	if grace <= 0 {
+		grace = DefaultStopGracePeriod
 	}
-	if !processExists(p.PID) {
-		return nil
+	tree := ProcessTreeFromID(pgid)
+	terminateErr := tree.Terminate()
+	if terminateErr != nil {
+		return terminateErr
 	}
-	return tree.Kill()
+	drained := waitForProcessGroupExit(tree.ID(), grace)
+	killErr := tree.Kill()
+	if !drained && !waitForProcessGroupExit(tree.ID(), grace) {
+		return errors.Join(killErr, fmt.Errorf("process group %d did not stop after force-kill", tree.ID()))
+	}
+	return killErr
 }
 
-// markRecordLost settles one unaccountable record. Cleanup is attempted only
-// when the recorded PID still names the same process; otherwise the signal
-// would land on whatever reused that PID.
+func waitForProcessGroupExit(pgid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if !processGroupExists(pgid) {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(leftoverProcessGroupPollInterval)
+	}
+}
+
+// markRecordLost settles one unaccountable record.
+//
+// Identity inspection and signalling happen outside m.mu: both make OS calls,
+// and the force-kill path can block for the full grace period. Holding the
+// manager lock across that would stall every other manager operation for the
+// duration of startup recovery. The record is re-read and re-checked under the
+// lock afterwards, so a record that settled meanwhile is left alone.
 func (m *Manager) markRecordLost(id string) (*Process, error) {
+	m.mu.Lock()
+	snapshot, err := m.load(id)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	if !isLiveStatus(snapshot.Status) {
+		m.mu.Unlock()
+		return snapshot, nil
+	}
+	probe := *snapshot
+	m.mu.Unlock()
+
+	reason := LossHostRestarted
+	cleanup := RecoveryNotNeeded
+	detail := ""
+	matched, matchErr := processMatchesRecord(&probe)
+	switch {
+	case matchErr != nil:
+		// The identity could not be established, so the pid is not safe to
+		// signal even if something is still running under it.
+		reason = LossIdentityMismatch
+		detail = fmt.Sprintf("left over from an earlier app-server; identity could not be verified: %v", matchErr)
+	case !matched:
+		cleanup = RecoveryNotFound
+		detail = "left over from an earlier app-server; the recorded process was already gone"
+	default:
+		if err := terminateLeftoverProcessTree(probe.PGID, DefaultStopGracePeriod); err != nil {
+			cleanup = RecoveryFailed
+			detail = fmt.Sprintf("left over from an earlier app-server; cleanup failed: %v", err)
+		} else {
+			cleanup = RecoveryTerminated
+			detail = "left over from an earlier app-server; this host terminated the leftover process tree"
+		}
+	}
+
 	m.mu.Lock()
 	p, err := m.load(id)
 	if err != nil {
@@ -1187,33 +1269,15 @@ func (m *Manager) markRecordLost(id string) (*Process, error) {
 		return nil, err
 	}
 	if !isLiveStatus(p.Status) {
+		// Something settled the record while the signals were in flight; that
+		// outcome was observed and this one was not, so it wins.
 		m.mu.Unlock()
 		return p, nil
 	}
-
 	p.Status = StatusLost
-	p.LossReason = LossHostRestarted
-	matched, matchErr := processMatchesRecord(p)
-	switch {
-	case matchErr != nil:
-		// The identity could not be established, so the PID is not safe to
-		// signal even if something is still running under it.
-		p.LossReason = LossIdentityMismatch
-		p.RecoveryCleanup = RecoveryNotNeeded
-		p.LastError = fmt.Sprintf("left over from an earlier app-server; identity could not be verified: %v", matchErr)
-	case !matched:
-		p.RecoveryCleanup = RecoveryNotFound
-		p.LastError = "left over from an earlier app-server; the recorded process was already gone"
-	default:
-		if err := terminateLeftoverProcessTree(p); err != nil {
-			p.RecoveryCleanup = RecoveryFailed
-			p.LastError = fmt.Sprintf("left over from an earlier app-server; cleanup failed: %v", err)
-		} else {
-			p.RecoveryCleanup = RecoveryTerminated
-			p.LastError = "left over from an earlier app-server; this host terminated the leftover process tree"
-		}
-	}
-
+	p.LossReason = reason
+	p.RecoveryCleanup = cleanup
+	p.LastError = detail
 	// Deliberately no TerminalCause and no ExitCode: this host never observed
 	// how the command ended, and cleaning up afterwards does not tell it.
 	p.StoppedAt = time.Now()
@@ -1222,15 +1286,13 @@ func (m *Manager) markRecordLost(id string) (*Process, error) {
 		m.mu.Unlock()
 		return p, err
 	}
+	settled := *p
 	m.mu.Unlock()
-	m.publish(Event{Type: EventCleanedUp, Process: *p})
-	return p, nil
+	m.publish(Event{Type: EventCleanedUp, Process: settled})
+	return &settled, nil
 }
 
 func (m *Manager) resumePersistedManagedProcesses() error {
-	if err := m.reconcileForeignHostRecords(); err != nil {
-		return err
-	}
 	processes, err := m.List()
 	if err != nil {
 		return err

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -60,7 +60,38 @@ const (
 	StatusStopping Status = "stopping"
 	StatusStopped  Status = "stopped"
 	StatusFailed   Status = "failed"
+	// StatusLost marks a record this host cannot account for. It is not a
+	// terminal cause: the command may have exited cleanly, been killed, or
+	// still be running detached. Claiming "stopped" would assert an exit this
+	// host never observed, so the uncertainty is recorded instead.
+	StatusLost Status = "lost"
+
+	// LossHostRestarted is the ordinary case: the record belongs to an earlier
+	// app-server lifetime, so its stdin, PTY, and exit watcher are gone.
+	LossHostRestarted LossReason = "host_restarted"
+	// LossIdentityMismatch means the recorded PID now belongs to something
+	// else. Signalling it would hit an unrelated process.
+	LossIdentityMismatch LossReason = "identity_mismatch"
+
+	// RecoveryNotNeeded means nothing was running to clean up.
+	RecoveryNotNeeded RecoveryCleanup = "not_needed"
+	// RecoveryNotFound means the recorded process was already gone.
+	RecoveryNotFound RecoveryCleanup = "not_found"
+	// RecoveryTerminated means this host killed the leftover process tree.
+	RecoveryTerminated RecoveryCleanup = "terminated"
+	// RecoveryFailed means cleanup was attempted and did not succeed. The
+	// record stays lost; it must not be dressed up as a normal stop.
+	RecoveryFailed RecoveryCleanup = "failed"
 )
+
+// LossReason explains why a record became unaccountable.
+type LossReason string
+
+// RecoveryCleanup records what startup managed to do about a lost record's
+// process tree. It is deliberately separate from the loss reason: succeeding at
+// cleanup does not retroactively tell this host how the command originally
+// ended.
+type RecoveryCleanup string
 
 type Process struct {
 	Action    string    `json:"action,omitempty"`
@@ -77,6 +108,13 @@ type Process struct {
 	// running process still has an in-memory control handle. Records written
 	// before this field existed have it empty.
 	HostGenerationID string `json:"host_generation_id,omitempty"`
+	// LossReason is set with StatusLost and explains why the record became
+	// unaccountable. RecoveryCleanup separately records what this host managed
+	// to do about the leftover process tree; a successful cleanup never
+	// rewrites the status into a normal stop, because that would claim an exit
+	// nobody observed.
+	LossReason      LossReason      `json:"loss_reason,omitempty"`
+	RecoveryCleanup RecoveryCleanup `json:"recovery_cleanup,omitempty"`
 	// Deprecated: Lifecycle is being retired with the managed process class.
 	// It still parses and round-trips so existing registry records keep
 	// loading; new behavior must not branch on it.
@@ -1090,7 +1128,109 @@ const persistedProcessWatchInterval = 250 * time.Millisecond
 // resumePersistedManagedProcesses restores exit observation for managed
 // processes that outlived the manager which started them. PTY/stdin handles
 // cannot be reconstructed, but terminal state and completion delivery can.
+// reconcileForeignHostRecords retires records this host cannot account for.
+//
+// Until now only managed records were revisited at startup, so a session
+// command left behind by a crashed app-server sat at "running" forever: the
+// process was unreachable and the row never settled. Any non-terminal record
+// from another host generation is now marked lost, and its process tree is
+// cleaned up on a best-effort basis after an identity check.
+//
+// Records from this host's own generation are left alone. They belong to a
+// sibling manager in the same app-server, which still holds their handles.
+//
+// Managed records are also left alone here. The existing resume path
+// deliberately re-adopts and re-observes them across a restart; retiring that
+// re-adoption is a separate step of the lifecycle work, and killing them now
+// would break a contract that is still in force.
+func (m *Manager) reconcileForeignHostRecords() error {
+	processes, err := m.List()
+	if err != nil {
+		return err
+	}
+	for _, p := range processes {
+		if p.Lifecycle == LifecycleManaged || !isLiveStatus(p.Status) || p.HostGenerationID == m.hostGenerationID {
+			continue
+		}
+		if _, err := m.markRecordLost(p.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// terminateLeftoverProcessTree stops a process group left behind by an earlier
+// host. It asks politely first and escalates, because nothing in this process
+// is waiting on the group to observe a graceful exit.
+// Falling back to the pid when no group was recorded would signal whatever
+// group happens to carry that id — possibly Wuu's own — so a record without a
+// usable group is reported as un-cleanable instead.
+func terminateLeftoverProcessTree(p *Process) error {
+	tree := ProcessTreeFromID(p.PGID)
+	if err := tree.Terminate(); err != nil {
+		return err
+	}
+	if !processExists(p.PID) {
+		return nil
+	}
+	return tree.Kill()
+}
+
+// markRecordLost settles one unaccountable record. Cleanup is attempted only
+// when the recorded PID still names the same process; otherwise the signal
+// would land on whatever reused that PID.
+func (m *Manager) markRecordLost(id string) (*Process, error) {
+	m.mu.Lock()
+	p, err := m.load(id)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	if !isLiveStatus(p.Status) {
+		m.mu.Unlock()
+		return p, nil
+	}
+
+	p.Status = StatusLost
+	p.LossReason = LossHostRestarted
+	matched, matchErr := processMatchesRecord(p)
+	switch {
+	case matchErr != nil:
+		// The identity could not be established, so the PID is not safe to
+		// signal even if something is still running under it.
+		p.LossReason = LossIdentityMismatch
+		p.RecoveryCleanup = RecoveryNotNeeded
+		p.LastError = fmt.Sprintf("left over from an earlier app-server; identity could not be verified: %v", matchErr)
+	case !matched:
+		p.RecoveryCleanup = RecoveryNotFound
+		p.LastError = "left over from an earlier app-server; the recorded process was already gone"
+	default:
+		if err := terminateLeftoverProcessTree(p); err != nil {
+			p.RecoveryCleanup = RecoveryFailed
+			p.LastError = fmt.Sprintf("left over from an earlier app-server; cleanup failed: %v", err)
+		} else {
+			p.RecoveryCleanup = RecoveryTerminated
+			p.LastError = "left over from an earlier app-server; this host terminated the leftover process tree"
+		}
+	}
+
+	// Deliberately no TerminalCause and no ExitCode: this host never observed
+	// how the command ended, and cleaning up afterwards does not tell it.
+	p.StoppedAt = time.Now()
+	p.UpdatedAt = p.StoppedAt
+	if err := m.save(p); err != nil {
+		m.mu.Unlock()
+		return p, err
+	}
+	m.mu.Unlock()
+	m.publish(Event{Type: EventCleanedUp, Process: *p})
+	return p, nil
+}
+
 func (m *Manager) resumePersistedManagedProcesses() error {
+	if err := m.reconcileForeignHostRecords(); err != nil {
+		return err
+	}
 	processes, err := m.List()
 	if err != nil {
 		return err

--- a/internal/process/manager_unix.go
+++ b/internal/process/manager_unix.go
@@ -82,3 +82,14 @@ func processExists(pid int) bool {
 	err := syscall.Kill(pid, 0)
 	return err == nil || errors.Is(err, syscall.EPERM)
 }
+
+// processGroupExists reports whether any process remains in the group. Probing
+// the group rather than the leader matters when the leader exits first and
+// leaves descendants behind: the tree is still alive and still needs killing.
+func processGroupExists(pgid int) bool {
+	if pgid <= 1 {
+		return false
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/process/manager_windows.go
+++ b/internal/process/manager_windows.go
@@ -58,6 +58,13 @@ func killProcessGroup(pid int) error {
 	return taskkillTree(pid, true)
 }
 
+// processGroupExists reports whether the tree is still alive. Windows has no
+// process group to probe; taskkill /T walks descendants from the root, so the
+// root's liveness is the tree's liveness for signalling purposes.
+func processGroupExists(pgid int) bool {
+	return processExists(pgid)
+}
+
 func taskkillTree(pid int, force bool) error {
 	if pid <= 1 {
 		return nil

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1174,7 +1174,11 @@ export type ManagedProcessStatus =
   | "running"
   | "stopping"
   | "stopped"
-  | "failed";
+  | "failed"
+  // The app-server cannot account for this command: it belongs to an earlier
+  // host lifetime, so nothing here observed how it ended. Distinct from
+  // "stopped", which asserts an exit this host actually saw.
+  | "lost";
 
 export type ManagedProcessSummary = {
   id: string;
@@ -1192,6 +1196,11 @@ export type ManagedProcessSummary = {
   exit_code?: number;
   last_error?: string;
   input_available?: boolean;
+  // Set with status "lost": why the record became unaccountable, and what the
+  // current host managed to do about the leftover process tree. Cleanup
+  // succeeding does not turn the record back into a normal stop.
+  loss_reason?: string;
+  recovery_cleanup?: string;
 };
 
 export type ManagedProcessListResult = {


### PR DESCRIPTION
## Summary

Second step of #157, building on #195. Fixes the concrete symptom the issue opens with: *"app 崩溃后，遗留 `session` 进程可能仍在运行，但 registry 永久停在 running"*.

## Changes

- **Startup reconciles records it cannot account for.** `resumePersistedManagedProcesses` only ever revisited `managed` records, so a session command orphaned by a crashed app-server stayed `running` forever — unreachable, never settled, still rendered as live. Any non-terminal record from a foreign host generation is now retired.
- **`lost` is a distinct status, not `stopped`.** This host never observed how the command ended. It may have exited cleanly, been killed, or still be detached. `stopped` would assert an exit nobody saw, so the record carries `loss_reason` and, separately, `recovery_cleanup`. **A successful cleanup never rewrites the status** — killing a leftover afterwards still tells nobody how it originally ended. That separation is the issue's own rule (`recovery_cleanup=terminated`, not "stopped").
- **Cleanup is identity-checked and group-scoped.** It runs only when the recorded process identity still matches, and only through the recorded process group via the existing `ProcessTree` guard. Falling back to the pid when no group was recorded would signal whatever group carries that id — possibly Wuu's own — so such a record is reported as un-cleanable instead.
- **Protocol and desktop follow.** `ManagedProcessStatus` gains `lost` with the two optional reason fields; the terminal workspace renders it distinctly rather than as a neutral pending clock, and no longer offers a terminal for a process that is gone.

### Two boundaries I held, deliberately

1. **`managed` records keep their existing re-adoption path.** My first attempt retired them too and broke `TestNewManagerReconcilesPersistedManagedProcessExit` — correctly, because re-adoption is still a live contract. The issue retires it as part of removing the managed class, which is a later step. Killing them here would have been a behavior change smuggled past its own design step.
2. **`stopped`/`failed` are not collapsed into `terminal` yet.** That is the breaking half of the status vocabulary: `WorkspaceTerminalPanel` branches on `"stopped"` and on the three live values, and the union is hand-mirrored in `packages/protocol`. Adding `lost` is additive; collapsing the rest deserves its own PR so the cross-stack change is reviewable on its own.

This also applies the correction from #195: records from **this** host's generation are left untouched, because several managers share one host lifetime and a sibling still holds their handles. There is a test for exactly that.

## Test plan

- [x] Added or updated unit tests for the change
- [x] `go test ./...` passes
- [x] `cd desktop && npm test` passes
- [ ] Manually verified the behavior in the desktop shell (if applicable)

Four Go tests: a leftover session record retired as `lost` without inventing a terminal cause; same-host-generation records left alone; managed records left to their existing path; and a live leftover with verified identity getting its tree terminated and reported as `recovery_cleanup=terminated` while staying `lost`. One desktop test: a `lost` process is not listed as live and gets no terminal. `make check` passes.

While writing the identity test I killed the test runner itself — the helper process inherited the runner's process group, so cleanup signalled it. That is the same footgun the production fallback would have had; both are fixed, and the test now isolates the helper with `PrepareCommand`.

One unrelated pre-existing failure: `TestGoalPauseResumeClearRuntimeGoal` in `internal/appserver` ("goal resume should kick one continuation turn, got 2") fails identically on a clean `main`, verified by stashing.

Not verified in the desktop shell — I could not launch Electron in this environment. The desktop half is covered by the unit test above.

## Risk and rollback

- Risk level: medium — startup now terminates leftover process trees. Scoped by generation, lifecycle, identity match, and the existing process-group guard.
- Rollback: revert the commit. Orphaned records return to sitting at `running`.

## Linked issues / docs

Refs #157. Still open: status vocabulary collapse, owner-close cascade, execution convergence.
