### PR TITLE
fix(sqlite): normalize Windows file DSN paths

### DIFF
--- a/internal/channels/store.go
+++ b/internal/channels/store.go
@@ -1190,7 +1190,13 @@ func (s *Service) WakeState(ctx context.Context, agentID string) (WakeState, err
 }
 
 func sqliteDSN(path string) string {
-	u := url.URL{Scheme: "file", Path: path}
+	// Normalize Windows paths for file URI: C:\Users\... → /C:/Users/...
+	// On Unix filepath.ToSlash is a no-op and paths already start with /.
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := url.URL{Scheme: "file", Path: p}
 	query := u.Query()
 	query.Add("_pragma", "busy_timeout(5000)")
 	query.Add("_pragma", "foreign_keys(1)")

--- a/internal/channels/store_test.go
+++ b/internal/channels/store_test.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -63,6 +65,43 @@ func openTestService(t *testing.T, wake WakeSink) *Service {
 		}
 	})
 	return service
+}
+
+func TestSQLiteDSNNormalizesPaths(t *testing.T) {
+	const suffix = "?_pragma=busy_timeout%285000%29&_pragma=foreign_keys%281%29&_txlock=immediate"
+
+	t.Run("unix absolute", func(t *testing.T) {
+		got := sqliteDSN("/Users/name/.wuu/workspaces/abc/channels.sqlite3")
+		want := "file:///Users/name/.wuu/workspaces/abc/channels.sqlite3" + suffix
+		if got != want {
+			t.Fatalf("sqliteDSN() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("windows drive absolute", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.ToSlash only normalizes Windows separators on Windows")
+		}
+		got := sqliteDSN(`C:\Users\name\.wuu\workspaces\abc\channels.sqlite3`)
+		want := "file:///C:/Users/name/.wuu/workspaces/abc/channels.sqlite3" + suffix
+		if got != want {
+			t.Fatalf("sqliteDSN() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("url parse round trip", func(t *testing.T) {
+		// Whatever platform we are on, url.Parse must succeed and the path
+		// component must not be reinterpreted as authority — this is the exact
+		// failure that triggered "invalid uri authority" in production.
+		dsn := sqliteDSN(`C:\Users\wsmdm\.wuu\workspaces\abc\channels.sqlite3`)
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			t.Fatalf("url.Parse(%q) error = %v", dsn, err)
+		}
+		if parsed.Host != "" {
+			t.Fatalf("DSN %q has non-empty host/authority %q", dsn, parsed.Host)
+		}
+	})
 }
 
 func createTestAgent(t *testing.T, service *Service, name string) AgentCredential {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -785,7 +785,13 @@ func storeTableExists(db *sql.DB, name string) (bool, error) {
 }
 
 func sqliteDSN(path string) string {
-	u := url.URL{Scheme: "file", Path: path}
+	// Normalize Windows paths for file URI: C:\Users\... → /C:/Users/...
+	// On Unix filepath.ToSlash is a no-op and paths already start with /.
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	u := url.URL{Scheme: "file", Path: p}
 	q := u.Query()
 	q.Add("_pragma", "busy_timeout(5000)")
 	q.Add("_pragma", "foreign_keys(1)")

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4,8 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -48,6 +50,43 @@ func TestDirUsesUserHome(t *testing.T) {
 	if got := Dir(""); got != want {
 		t.Fatalf("Dir(empty) = %q, want %q", got, want)
 	}
+}
+
+func TestSQLiteDSNNormalizesPaths(t *testing.T) {
+	const suffix = "?_pragma=busy_timeout%285000%29&_pragma=foreign_keys%281%29&_txlock=immediate"
+
+	t.Run("unix absolute", func(t *testing.T) {
+		got := sqliteDSN("/Users/name/.wuu/sessions/sessions.sqlite3")
+		want := "file:///Users/name/.wuu/sessions/sessions.sqlite3" + suffix
+		if got != want {
+			t.Fatalf("sqliteDSN() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("windows drive absolute", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("filepath.ToSlash only normalizes Windows separators on Windows")
+		}
+		got := sqliteDSN(`C:\Users\name\.wuu\sessions\sessions.sqlite3`)
+		want := "file:///C:/Users/name/.wuu/sessions/sessions.sqlite3" + suffix
+		if got != want {
+			t.Fatalf("sqliteDSN() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("url parse round trip", func(t *testing.T) {
+		// Whatever platform we are on, url.Parse must succeed and the path
+		// component must not be reinterpreted as authority — this is the exact
+		// failure that triggered "invalid uri authority" in production.
+		dsn := sqliteDSN(`C:\Users\wsmdm\.wuu\sessions\sessions.sqlite3`)
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			t.Fatalf("url.Parse(%q) error = %v", dsn, err)
+		}
+		if parsed.Host != "" {
+			t.Fatalf("DSN %q has non-empty host/authority %q", dsn, parsed.Host)
+		}
+	})
 }
 
 func TestSetRuntimeSelectionPersists(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix SQLite file DSN generation on Windows so absolute paths like `C:\Users\...` are encoded as `file:///C:/Users/...` instead of being parsed as a URI authority.

This prevents `modernc.org/sqlite` from rejecting Windows database paths with `invalid uri authority`.

## Changes

- Normalize SQLite database paths with `filepath.ToSlash`.
- Ensure file URI paths always start with `/`, so Windows drive letters stay in the URI path component.
- Apply the fix to both session storage and channel storage SQLite DSNs.
- Add unit coverage for:
  - Unix absolute paths
  - Windows drive-letter paths
  - `url.Parse` round-trip behavior ensuring the DSN has no authority/host

## Test plan

- [x] Added unit tests for the DSN normalization behavior
- [x] `go test ./internal/channels ./internal/session -run TestSQLiteDSNNormalizesPaths -count=1 -v` passes on Windows
- [x] `go test ./cmd/... ./internal/... ./prompts/... -count=1` passes in WSL
- [ ] `cd desktop && npm test` passes
  - Not run; this change is limited to Go SQLite DSN construction.

## Risk and rollback

- Risk level: low
- Rollback: revert this PR. The change only affects how local SQLite file DSNs are constructed before opening existing session/channel databases.

## Linked issues / docs

N/A
