### PR TITLE
Fix Cron workspace binding and global model inheritance

### DIFF
--- a/internal/appserver/channels_store_test.go
+++ b/internal/appserver/channels_store_test.go
@@ -372,6 +372,7 @@ func TestNonAutostartNamedAgentWakeLoadsExistingPersistedSession(t *testing.T) {
 	server.mu.Unlock()
 	releaseDetachedThreadRuntime(detachedThreadRuntime{runtime: thread.execRuntime})
 	thread.execRuntime = nil
+	rt.Model = "new-global-model"
 
 	server.channelService.SetWakeSink(nil)
 	room := createAppserverTestRoom(t, server.channelService, credential.Agent)
@@ -386,6 +387,13 @@ func TestNonAutostartNamedAgentWakeLoadsExistingPersistedSession(t *testing.T) {
 	loaded := server.thread(thread.ID)
 	if loaded == nil || loaded.NamedAgentID != credential.Agent.ID || loaded.Source != namedAgentSessionSource+credential.Agent.ID {
 		t.Fatalf("loaded persisted non-autostart thread = %#v", loaded)
+	}
+	if loaded.Model != "new-global-model" {
+		t.Fatalf("loaded named agent model = %q, want current global model", loaded.Model)
+	}
+	metadata, found, err := session.Find(rt.SessionDir, thread.ID)
+	if err != nil || !found || metadata.Model != "new-global-model" {
+		t.Fatalf("persisted named agent model = %q, found %v, err %v", metadata.Model, found, err)
 	}
 }
 

--- a/internal/appserver/named_agent_wake.go
+++ b/internal/appserver/named_agent_wake.go
@@ -88,19 +88,24 @@ func (s *Server) ensureNamedAgentThreadLocked(agent channels.NamedAgent) (*threa
 		th.Source = namedAgentSessionSource + agent.ID
 		th.CWD = filepath.Dir(agent.MemoryDir)
 		if needsNamedAgentRuntime {
-			selection := runtime.ThreadModelSelection{
-				Provider: th.ModelProvider, Model: th.Model, Variant: th.ModelVariant,
-				Effort: th.ModelEffort, PermissionMode: th.PermissionMode,
-			}
+			selection := s.currentSessionRuntimeSelection()
 			selection.Provider, selection.Model, selection.Effort = namedAgentModelSelection(
 				selection.Provider, selection.Model, selection.Effort, agent,
 			)
-			threadRuntime, err := s.newNamedAgentRuntime(threadID, agent, selection)
+			threadRuntime, err := s.newNamedAgentRuntime(threadID, agent, runtime.ThreadModelSelection{
+				Provider: selection.Provider, Model: selection.Model, Variant: selection.Variant,
+				Effort: selection.Effort, PermissionMode: selection.PermissionMode,
+			})
 			if err != nil {
+				return nil, err
+			}
+			if _, err := session.SetRuntimeSelection(s.rt.SessionDir, threadID, selection); err != nil {
+				releaseDetachedThreadRuntime(detachedThreadRuntime{runtime: threadRuntime})
 				return nil, err
 			}
 			staleRuntime := th.execRuntime
 			th.execRuntime = threadRuntime
+			applyThreadRuntimeSelection(th, selection)
 			if len(th.History) > 0 && strings.EqualFold(strings.TrimSpace(th.History[0].Role), "system") {
 				th.History[0].Content = threadRuntime.StreamRunner.SystemPrompt
 			}
@@ -139,6 +144,11 @@ func (s *Server) ensureNamedAgentThreadLocked(agent channels.NamedAgent) (*threa
 			releaseDetachedThreadRuntime(detachedThreadRuntime{runtime: threadRuntime})
 			return nil, err
 		}
+		if _, err := session.SetRuntimeSelection(s.rt.SessionDir, threadID, selection); err != nil {
+			releaseDetachedThreadRuntime(detachedThreadRuntime{runtime: threadRuntime})
+			return nil, err
+		}
+		applyThreadRuntimeSelection(th, selection)
 	} else {
 		if _, err := session.CreateWithMetadata(s.rt.SessionDir, threadID, agentHome); err != nil {
 			releaseDetachedThreadRuntime(detachedThreadRuntime{runtime: threadRuntime})

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -458,6 +458,7 @@ func NewSession(opts Options) (*Session, error) {
 			return nil, newErr
 		}
 		kit.SetStateDir(workspaceStateDir)
+		kit.SetWorkspaceID(workspaceID)
 		kit.SetAutomationManager(automationManager)
 		kit.SetProcessManager(processMgr)
 		kit.SetSkills(discoveredSkills)

--- a/internal/tools/cron.go
+++ b/internal/tools/cron.go
@@ -126,6 +126,8 @@ func (t *CronTool) executeAdd(title, cronExpr, timezone, prompt, mode, heartbeat
 		Mode:              automation.Mode(strings.TrimSpace(mode)),
 		CreatorThreadID:   strings.TrimSpace(t.env.SessionID),
 		HeartbeatThreadID: heartbeatThreadID,
+		WorkspaceID:       strings.TrimSpace(t.env.WorkspaceID),
+		WorkspacePath:     strings.TrimSpace(t.env.RootDir),
 		Recurring:         recurring,
 		Durable:           durable,
 	})

--- a/internal/tools/cron_test.go
+++ b/internal/tools/cron_test.go
@@ -54,6 +54,28 @@ func TestScheduleCronTool_DefaultsToSessionOnly(t *testing.T) {
 	}
 }
 
+func TestScheduleCronTool_BindsTaskToWorkspace(t *testing.T) {
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, "state")
+	env := newCronToolTestEnv(rootDir, stateDir, "thread-1")
+	env.WorkspaceID = "workspace-1"
+	tool := NewCronTool(env)
+
+	if _, err := tool.Execute(context.Background(), `{"action":"add","cron":"*/5 * * * *","prompt":"check workspace"}`); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	tasks, err := cron.NewSessionTaskStore(stateDir).List()
+	if err != nil {
+		t.Fatalf("session store list: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 session task, got %d", len(tasks))
+	}
+	if tasks[0].WorkspaceID != "workspace-1" || tasks[0].WorkspacePath != rootDir {
+		t.Fatalf("workspace = %q, %q", tasks[0].WorkspaceID, tasks[0].WorkspacePath)
+	}
+}
+
 func TestScheduleCronTool_DurablePersistsToDisk(t *testing.T) {
 	dir := t.TempDir()
 	stateDir := filepath.Join(dir, "state")

--- a/internal/tools/env.go
+++ b/internal/tools/env.go
@@ -202,8 +202,9 @@ func (s *webEvidenceState) snapshot() []webEvidenceEntry {
 // construction time. It replaces the old approach of making every
 // handler a method on *Toolkit.
 type Env struct {
-	RootDir  string
-	StateDir string
+	RootDir     string
+	WorkspaceID string
+	StateDir    string
 	// Unconfined is the explicit escape hatch for lifting path confinement.
 	// Default false means file tools stay inside FileScopeRoots/RootDir.
 	Unconfined bool

--- a/internal/tools/toolkit.go
+++ b/internal/tools/toolkit.go
@@ -163,6 +163,7 @@ func (t *Toolkit) CloneForRoot(rootDir string) (*Toolkit, error) {
 	// owns independent mutable state, matching the original intent.
 	env := Env{
 		RootDir:                     abs,
+		WorkspaceID:                 t.env.WorkspaceID,
 		StateDir:                    t.env.StateDir,
 		Unconfined:                  t.env.Unconfined,
 		AllowMutations:              t.env.AllowMutations,
@@ -717,6 +718,14 @@ func (t *Toolkit) RootDir() string {
 		return ""
 	}
 	return t.env.RootDir
+}
+
+// SetWorkspaceID binds tools to the stable identity of their workspace.
+func (t *Toolkit) SetWorkspaceID(workspaceID string) {
+	if t == nil || t.env == nil {
+		return
+	}
+	t.env.WorkspaceID = strings.TrimSpace(workspaceID)
 }
 
 // SetFileScopeRoots installs (or clears, with an empty slice) the file-tool


### PR DESCRIPTION
## What changed

- Persist the workspace ID and path when an agent creates a Cron task.
- Make named agents configured to inherit the global model resolve the current global selection whenever an existing session is restored.
- Persist the refreshed model selection back to the named-agent session.
- Add focused regression coverage for both fixes.

## Why

Cron tasks created through an agent previously lost their workspace context because the tool environment did not carry the workspace identity into task creation.

Named agents with no explicit model override could also keep using the model stored in an older session after the global model changed. They now follow the current global model while explicit agent overrides still take precedence.

## Validation

- `go test ./internal/tools -run '^TestScheduleCronTool' -count=1`
- `go test ./internal/appserver -run '^$' -count=1`
- The focused named-agent regression passes on the Windows SQLite compatibility branch. On this branch, executing it on Windows is blocked by the separately reported SQLite file-URI issue covered by PR #205.