### PR TITLE
修复 Windows SQLite 路径 URI

### DIFF
--- a/internal/channels/store.go
+++ b/internal/channels/store.go
@@ -1190,7 +1190,11 @@ func (s *Service) WakeState(ctx context.Context, agentID string) (WakeState, err
 }
 
 func sqliteDSN(path string) string {
-	u := url.URL{Scheme: "file", Path: path}
+	slashed := filepath.ToSlash(path)
+	if filepath.VolumeName(path) != "" && !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	u := url.URL{Scheme: "file", Path: slashed}
 	query := u.Query()
 	query.Add("_pragma", "busy_timeout(5000)")
 	query.Add("_pragma", "foreign_keys(1)")

--- a/internal/channels/store_test.go
+++ b/internal/channels/store_test.go
@@ -5,15 +5,37 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"unicode/utf8"
 )
+
+func TestSQLiteDSNNormalizesWindowsPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path normalization")
+	}
+	dsn := sqliteDSN(`C:\Users\wuu\AppData\Local\channels.sqlite3`)
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse sqlite DSN %q: %v", dsn, err)
+	}
+	if parsed.Scheme != "file" {
+		t.Fatalf("sqlite DSN scheme = %q, want file", parsed.Scheme)
+	}
+	if parsed.Host != "" {
+		t.Fatalf("sqlite DSN host = %q, want empty", parsed.Host)
+	}
+	if parsed.Path != "/C:/Users/wuu/AppData/Local/channels.sqlite3" {
+		t.Fatalf("sqlite DSN path = %q, want normalized absolute Windows path", parsed.Path)
+	}
+}
 
 type recordingWakeSink struct {
 	mu        sync.Mutex

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -785,7 +785,17 @@ func storeTableExists(db *sql.DB, name string) (bool, error) {
 }
 
 func sqliteDSN(path string) string {
-	u := url.URL{Scheme: "file", Path: path}
+	// url.URL percent-encodes backslashes and treats a path without a leading
+	// slash as opaque, so a Windows path like C:\dir\db turns into
+	// file:C:%5Cdir%5Cdb, which the sqlite driver rejects with "invalid uri
+	// authority". Normalize to forward slashes and ensure a leading slash so
+	// Windows paths yield a valid file:///... URI while relative POSIX paths
+	// retain their existing semantics.
+	slashed := filepath.ToSlash(path)
+	if filepath.VolumeName(path) != "" && !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	u := url.URL{Scheme: "file", Path: slashed}
 	q := u.Query()
 	q.Add("_pragma", "busy_timeout(5000)")
 	q.Add("_pragma", "foreign_keys(1)")

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4,8 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -13,6 +15,26 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/statepath"
 )
+
+func TestSQLiteDSNNormalizesWindowsPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path normalization")
+	}
+	dsn := sqliteDSN(`C:\Users\wuu\AppData\Local\sessions.sqlite3`)
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parse sqlite DSN %q: %v", dsn, err)
+	}
+	if parsed.Scheme != "file" {
+		t.Fatalf("sqlite DSN scheme = %q, want file", parsed.Scheme)
+	}
+	if parsed.Host != "" {
+		t.Fatalf("sqlite DSN host = %q, want empty", parsed.Host)
+	}
+	if parsed.Path != "/C:/Users/wuu/AppData/Local/sessions.sqlite3" {
+		t.Fatalf("sqlite DSN path = %q, want normalized absolute Windows path", parsed.Path)
+	}
+}
 
 func TestCreateAndList(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## 修改内容

- 将 Windows SQLite 路径转换为合法的 `file:///` URI。
- 为 session 和 channel 数据库增加 Windows 路径测试。

## 修复问题

Windows 反斜杠路径经过 `url.URL` 后会被错误编码，SQLite 驱动报 `invalid uri authority`，可能导致 Wuu Core 无法启动。

## 测试

`go test ./internal/channels ./internal/session -run '^TestSQLiteDSNNormalizesWindowsPath$' -count=1`
