### PR TITLE
feat(desktop): render sandboxed frontend previews inline in turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ## [Unreleased]
 
+### Added
+
+- Added capability-gated, sandboxed HTML, CSS, and JavaScript previews to
+  desktop conversation answers.
+
 ## [0.15.0] - 2026-08-05
 
 ### Added

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' wuu-plugin:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https: wuu-file: wuu-plugin:; connect-src 'self' wuu-file: wuu-plugin:; frame-src wuu-file:;"
+      content="default-src 'self'; script-src 'self' wuu-plugin:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http: https: wuu-file: wuu-plugin:; connect-src 'self' wuu-file: wuu-plugin:; frame-src 'self' wuu-file:;"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>wuu</title>

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1313,6 +1313,9 @@ app.whenReady().then(async () => {
       client: { name: "wuu-desktop", version: DESKTOP_BUILD_INFO.version },
       capabilities: {
         reverse_rpc: { methods: [...BROWSER_REVERSE_RPC_METHODS] },
+        presentations: {
+          frontend_preview_versions: [1],
+        },
       },
     });
     if (result.core) {

--- a/desktop/src/renderer/AssistantTurnDisplay.test.tsx
+++ b/desktop/src/renderer/AssistantTurnDisplay.test.tsx
@@ -34,6 +34,18 @@ function makeReasoning(): ThreadItem {
   };
 }
 
+function makeFrontendPreview(status: "completed" | "failed" = "completed"): ThreadItem {
+  return {
+    id: nextID("frontend-preview"),
+    type: "tool_call",
+    status,
+    name: "render_frontend_preview",
+    arguments: JSON.stringify({ version: 1, title: "Button", html: "<button>Save</button>" }),
+    result: status === "completed" ? "Frontend preview ready." : undefined,
+    error: status === "failed" ? "invalid frontend preview" : undefined,
+  };
+}
+
 function makeToolCall(): ThreadItem {
   return {
     id: nextID("tool"),
@@ -119,5 +131,40 @@ describe("buildAssistantTurnDisplay generated queries", () => {
       ]),
     );
     expect(display.entries.map((entry) => entry.kind)).toEqual(["commentary"]);
+  });
+});
+
+describe("buildAssistantTurnDisplay frontend previews", () => {
+  it("keeps a successful preview as standalone answer content between activities", () => {
+    const preview = makeFrontendPreview();
+    const display = build(makeTurn("completed", [makeToolCall(), preview, makeToolCall()]));
+    expect(display.entries.map((entry) => entry.kind)).toEqual([
+      "activity",
+      "presentation",
+      "activity",
+    ]);
+    expect(display.entries[1]).toMatchObject({
+      item: preview,
+      position: "answer",
+      settled: true,
+      streaming: false,
+    });
+    expect(display.entries[1].items).toBeUndefined();
+    expect(display.hasAnswer).toBe(true);
+    expect(display.missingReplyMessage).toBeUndefined();
+  });
+
+  it("treats a preview-only completed turn as an answered turn", () => {
+    const display = build(makeTurn("completed", [makeFrontendPreview()]));
+    expect(display.hasAnswer).toBe(true);
+    expect(display.entries.map((entry) => entry.kind)).toEqual(["presentation"]);
+    expect(display.missingReplyMessage).toBeUndefined();
+  });
+
+  it("leaves failed previews in ordinary process activity", () => {
+    const display = build(makeTurn("failed", [makeFrontendPreview("failed")]));
+    expect(display.entries).toHaveLength(1);
+    expect(display.entries[0]).toMatchObject({ kind: "activity", position: "process" });
+    expect(display.hasAnswer).toBe(false);
   });
 });

--- a/desktop/src/renderer/AssistantTurnDisplay.tsx
+++ b/desktop/src/renderer/AssistantTurnDisplay.tsx
@@ -2,6 +2,7 @@ import { type JSX } from "react";
 import type { ThreadItem, Turn } from "../shared/protocol";
 import { streamFieldValue } from "./ThreadItemText";
 import { readableToolActivityCommand } from "./ToolActivityHelpers";
+import { isSuccessfulFrontendPreviewToolCall } from "./FrontendPreviewSpec";
 import { isCancellationMessage } from "./UserFacingErrors";
 import { translateCurrent } from "./i18n";
 
@@ -40,6 +41,7 @@ export type TurnEntry = {
 export type TurnEntryKind =
   | "commentary"
   | "answer"
+  | "presentation"
   | "activity"
   | "process"
   | "process_group";
@@ -163,11 +165,24 @@ export function buildAssistantTurnDisplay(
     }
 
     if (item.type === "tool_call") {
+      if (isSuccessfulFrontendPreviewToolCall(item)) {
+        hasAnswer = true;
+        entries.push({
+          key: `${item.id}-presentation`,
+          item,
+          position: "answer",
+          settled: true,
+          streaming: false,
+          kind: "presentation",
+        });
+        continue;
+      }
       const group: ThreadItem[] = [item];
       let nextIndex = index + 1;
       while (
         nextIndex < turn.items.length &&
-        turn.items[nextIndex].type === "tool_call"
+        turn.items[nextIndex].type === "tool_call" &&
+        !isSuccessfulFrontendPreviewToolCall(turn.items[nextIndex])
       ) {
         group.push(turn.items[nextIndex]);
         nextIndex++;

--- a/desktop/src/renderer/AssistantTurnShell.tsx
+++ b/desktop/src/renderer/AssistantTurnShell.tsx
@@ -32,6 +32,7 @@ import { ProcessSurface } from "./ProcessSurface";
 import { turnProgressContent } from "./TurnViewHelpers";
 import { collectTurnSources } from "./ToolActivityHelpers";
 import { TurnSourcesRow } from "./TurnSourcesRow";
+import { FrontendPreviewCard } from "./FrontendPreviewCard";
 import {
   AUTO_FOLLOW_NESTED_SCROLL_ATTR,
   useAutoFollowScrollContainer,
@@ -128,8 +129,9 @@ export function AssistantTurnShell({
   const hasAnswer = answerEntries.length > 0;
   const answerHandoffRequested = answerEntries.some(
     (entry) =>
-      entry.item.type === "agent_message" &&
-      streamFieldValue(turn.id, entry.item, "text").trim().length > 0,
+      entry.kind === "presentation" ||
+      (entry.item.type === "agent_message" &&
+        streamFieldValue(turn.id, entry.item, "text").trim().length > 0),
   );
   const processCollapseRequested = answerHandoffRequested;
   const className = [
@@ -469,6 +471,9 @@ function EntryRenderer({
   onOpenRuns?: () => void;
 }): JSX.Element | null {
   const { item, kind, streaming } = entry;
+  if (kind === "presentation") {
+    return <FrontendPreviewCard item={item} />;
+  }
   if (kind === "activity" || kind === "process_group") {
     return (
       <ProcessSurface

--- a/desktop/src/renderer/FrontendPreviewCard.test.tsx
+++ b/desktop/src/renderer/FrontendPreviewCard.test.tsx
@@ -1,0 +1,98 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ThreadItem } from "../shared/protocol";
+import { FrontendPreviewCard } from "./FrontendPreviewCard";
+import { buildFrontendPreviewDocument, parseFrontendPreviewSpec } from "./FrontendPreviewSpec";
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+function previewItem(argumentsJSON: string): ThreadItem {
+  return {
+    id: "preview-1",
+    type: "tool_call",
+    status: "completed",
+    name: "render_frontend_preview",
+    arguments: argumentsJSON,
+    result: "Frontend preview ready.",
+  };
+}
+
+function renderCard(item: ThreadItem): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(<FrontendPreviewCard item={item} />));
+  return container;
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe("FrontendPreviewCard", () => {
+  const valid = JSON.stringify({
+    version: 1,
+    title: "Loading button",
+    html: '<button id="save">Save</button>',
+    css: "button:hover { transform: scale(1.05); }",
+    javascript: "document.querySelector('#save').textContent = 'Ready';",
+    viewport: { height: 280 },
+  });
+
+  it("stays collapsed by default and destroys the runtime when collapsed or viewing source", () => {
+    const view = renderCard(previewItem(valid));
+    expect(view.querySelector("iframe")).toBeNull();
+
+    act(() => view.querySelector<HTMLButtonElement>(".frontend-preview-summary")?.click());
+    const frame = view.querySelector<HTMLIFrameElement>("iframe");
+    expect(frame).not.toBeNull();
+    expect(frame?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(frame?.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(frame?.srcdoc).toContain("default-src 'none'");
+    expect(frame?.srcdoc).toContain("connect-src 'none'");
+    expect(frame?.style.height).toBe("280px");
+
+    const sourceTab = view.querySelectorAll<HTMLButtonElement>('[role="tab"]')[1];
+    act(() => sourceTab?.click());
+    expect(view.querySelector("iframe")).toBeNull();
+    expect(view.querySelector("pre")?.textContent).toContain("<button");
+
+    act(() => view.querySelector<HTMLButtonElement>(".frontend-preview-summary")?.click());
+    expect(view.querySelector("iframe")).toBeNull();
+  });
+
+  it("shows an inert error instead of mounting invalid history", () => {
+    const view = renderCard(previewItem('{"version":1,"title":"Unsafe","html":"<script>alert(1)</script>"}'));
+    act(() => view.querySelector<HTMLButtonElement>(".frontend-preview-summary")?.click());
+    expect(view.querySelector("iframe")).toBeNull();
+    expect(view.querySelector('[role="alert"]')).not.toBeNull();
+  });
+});
+
+describe("frontend preview document", () => {
+  it("rejects unknown fields and external-resource markup", () => {
+    expect(parseFrontendPreviewSpec('{"version":1,"title":"x","html":"","extra":true}').error).toContain("unknown");
+    expect(parseFrontendPreviewSpec('{"version":1,"title":"x","html":"<img src=\\"https://example.com/x.png\\">"}').error).toContain("attribute");
+  });
+
+  it("escapes style and script terminators while installing runtime guards", () => {
+    const parsed = parseFrontendPreviewSpec(JSON.stringify({
+      version: 1,
+      title: "Safe",
+      html: "<button>ok</button>",
+      css: "/* </style> */ button { color: red; }",
+      javascript: "const marker = '</script>';",
+    }));
+    expect(parsed.error).toBeUndefined();
+    const document = buildFrontendPreviewDocument(parsed.spec!);
+    expect(document).toContain("<\\/style>");
+    expect(document).toContain("<\\/script>");
+    expect(document).toContain('Object.defineProperty(globalThis, name');
+    expect(document).toContain("form-action 'none'");
+  });
+});

--- a/desktop/src/renderer/FrontendPreviewCard.tsx
+++ b/desktop/src/renderer/FrontendPreviewCard.tsx
@@ -1,0 +1,110 @@
+import { ChevronRight, Code2, Play } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ThreadItem } from "../shared/protocol";
+import {
+  buildFrontendPreviewDocument,
+  parseFrontendPreviewSpec,
+  type FrontendPreviewSpec,
+} from "./FrontendPreviewSpec";
+import { useI18n } from "./i18n";
+
+export function FrontendPreviewCard({ item }: { item: ThreadItem }): JSX.Element {
+  const { t } = useI18n();
+  const parsed = useMemo(() => parseFrontendPreviewSpec(item.arguments), [item.arguments]);
+  const spec = parsed.spec;
+  const [expanded, setExpanded] = useState(false);
+  const [tab, setTab] = useState<"preview" | "source">("preview");
+  const title = parsed.spec?.title ?? t("frontendPreview.invalidTitle");
+
+  return (
+    <section className={`frontend-preview-card${parsed.error ? " is-invalid" : ""}`}>
+      <button
+        type="button"
+        className="frontend-preview-summary"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <Play className="icon-sm frontend-preview-kind-icon" aria-hidden />
+        <span className="frontend-preview-summary-copy">
+          <span className="frontend-preview-title">{title}</span>
+          <span className="frontend-preview-kind">{t("frontendPreview.kind")}</span>
+        </span>
+        <ChevronRight className="icon-sm frontend-preview-chevron" aria-hidden />
+      </button>
+      {expanded ? (
+        <div className="frontend-preview-body">
+          {parsed.error || !spec ? (
+            <div className="frontend-preview-error" role="alert">
+              {t("frontendPreview.invalidDetail", {
+                detail: parsed.error ?? t("frontendPreview.invalidTitle"),
+              })}
+            </div>
+          ) : (
+            <>
+              <div className="frontend-preview-tabs" role="tablist" aria-label={t("frontendPreview.tabsLabel")}>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === "preview"}
+                  className={tab === "preview" ? "is-active" : ""}
+                  onClick={() => setTab("preview")}
+                >
+                  <Play className="icon-xs" aria-hidden />
+                  {t("frontendPreview.previewTab")}
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === "source"}
+                  className={tab === "source" ? "is-active" : ""}
+                  onClick={() => setTab("source")}
+                >
+                  <Code2 className="icon-xs" aria-hidden />
+                  {t("frontendPreview.sourceTab")}
+                </button>
+              </div>
+              {tab === "preview" ? (
+                <FrontendPreviewFrame spec={spec} />
+              ) : (
+                <FrontendPreviewSource spec={spec} />
+              )}
+            </>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function FrontendPreviewFrame({ spec }: { spec: FrontendPreviewSpec }): JSX.Element {
+  const source = useMemo(() => buildFrontendPreviewDocument(spec), [spec]);
+  return (
+    <iframe
+      className="frontend-preview-frame"
+      title={spec.title}
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      allow="camera 'none'; microphone 'none'; geolocation 'none'; clipboard-read 'none'; clipboard-write 'none'"
+      srcDoc={source}
+      style={{ height: `${spec.viewport.height}px` }}
+    />
+  );
+}
+
+function FrontendPreviewSource({ spec }: { spec: FrontendPreviewSpec }): JSX.Element {
+  const sections = [
+    ["HTML", spec.html],
+    ["CSS", spec.css],
+    ["JavaScript", spec.javascript],
+  ].filter((entry) => entry[1].trim().length > 0);
+  return (
+    <div className="frontend-preview-source">
+      {sections.map(([label, source]) => (
+        <section key={label}>
+          <h4>{label}</h4>
+          <pre><code>{source}</code></pre>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/renderer/FrontendPreviewSpec.ts
+++ b/desktop/src/renderer/FrontendPreviewSpec.ts
@@ -1,0 +1,236 @@
+import type { ThreadItem } from "../shared/protocol";
+
+export const FRONTEND_PREVIEW_TOOL_NAME = "render_frontend_preview";
+
+const FRONTEND_PREVIEW_VERSION = 1;
+const MAX_PAYLOAD_BYTES = 256 * 1024;
+const MAX_TITLE_BYTES = 80;
+const MAX_HTML_BYTES = 96 * 1024;
+const MAX_CSS_BYTES = 96 * 1024;
+const MAX_JAVASCRIPT_BYTES = 96 * 1024;
+const MAX_HTML_NODES = 500;
+const DEFAULT_HEIGHT = 320;
+const MIN_HEIGHT = 160;
+const MAX_HEIGHT = 720;
+
+export type FrontendPreviewSpec = {
+  version: 1;
+  title: string;
+  html: string;
+  css: string;
+  javascript: string;
+  viewport: {
+    height: number;
+  };
+};
+
+export type FrontendPreviewParseResult =
+  | { spec: FrontendPreviewSpec; error?: never }
+  | { spec?: never; error: string };
+
+export function isSuccessfulFrontendPreviewToolCall(item: ThreadItem): boolean {
+  return (
+    item.type === "tool_call" &&
+    item.name === FRONTEND_PREVIEW_TOOL_NAME &&
+    item.status === "completed" &&
+    item.result_detail?.is_error !== true &&
+    !item.error
+  );
+}
+
+export function parseFrontendPreviewSpec(
+  raw: string | undefined,
+): FrontendPreviewParseResult {
+  if (!raw || utf8ByteLength(raw) > MAX_PAYLOAD_BYTES) {
+    return { error: "Preview payload is missing or too large." };
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return { error: "Preview payload is not valid JSON." };
+  }
+  if (!isRecord(value) || !hasOnlyKeys(value, ["version", "title", "html", "css", "javascript", "viewport"])) {
+    return { error: "Preview payload contains unknown fields." };
+  }
+  if (value.version !== FRONTEND_PREVIEW_VERSION) {
+    return { error: "This preview version is not supported." };
+  }
+  if (typeof value.title !== "string" || value.title.trim().length === 0 || utf8ByteLength(value.title.trim()) > MAX_TITLE_BYTES) {
+    return { error: "Preview title is missing or too large." };
+  }
+  if (typeof value.html !== "string" || utf8ByteLength(value.html) > MAX_HTML_BYTES) {
+    return { error: "Preview HTML is missing or too large." };
+  }
+  const css = value.css === undefined ? "" : value.css;
+  const javascript = value.javascript === undefined ? "" : value.javascript;
+  if (typeof css !== "string" || utf8ByteLength(css) > MAX_CSS_BYTES) {
+    return { error: "Preview CSS is invalid or too large." };
+  }
+  if (typeof javascript !== "string" || utf8ByteLength(javascript) > MAX_JAVASCRIPT_BYTES) {
+    return { error: "Preview JavaScript is invalid or too large." };
+  }
+  let height = DEFAULT_HEIGHT;
+  if (value.viewport !== undefined) {
+    if (!isRecord(value.viewport) || !hasOnlyKeys(value.viewport, ["height"])) {
+      return { error: "Preview viewport contains unknown fields." };
+    }
+    if (value.viewport.height !== undefined) {
+      if (!Number.isInteger(value.viewport.height)) {
+        return { error: "Preview height must be an integer." };
+      }
+      height = value.viewport.height as number;
+    }
+  }
+  if (height < MIN_HEIGHT || height > MAX_HEIGHT) {
+    return { error: `Preview height must be between ${MIN_HEIGHT} and ${MAX_HEIGHT}.` };
+  }
+  const htmlError = validateHTMLFragment(value.html);
+  if (htmlError) return { error: htmlError };
+  const cssError = validateCSS(css);
+  if (cssError) return { error: cssError };
+
+  return {
+    spec: {
+      version: 1,
+      title: value.title.trim(),
+      html: value.html,
+      css,
+      javascript,
+      viewport: { height },
+    },
+  };
+}
+
+const FORBIDDEN_ELEMENTS = new Set([
+  "APPLET", "BASE", "BODY", "EMBED", "FRAME", "FRAMESET", "HEAD", "HTML",
+  "IFRAME", "LINK", "META", "OBJECT", "SCRIPT", "STYLE", "TITLE", "WEBVIEW",
+]);
+
+const FORBIDDEN_ATTRIBUTES = new Set([
+  "action", "background", "cite", "data", "formaction", "href", "longdesc",
+  "manifest", "ping", "poster", "profile", "src", "srcdoc", "srcset", "usemap",
+]);
+
+function validateHTMLFragment(fragment: string): string | undefined {
+  if (/<\/?(?:html|head|body|script|style|iframe|link|meta|base|object|embed|webview)\b/i.test(fragment)) {
+    return "Preview HTML contains a forbidden element.";
+  }
+  if (typeof DOMParser === "undefined") {
+    return "Preview HTML validation is unavailable.";
+  }
+  const document = new DOMParser().parseFromString(`<main>${fragment}</main>`, "text/html");
+  const root = document.body.firstElementChild;
+  if (!root) {
+    return "Preview HTML validation failed.";
+  }
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL);
+  let nodeCount = 0;
+  while (walker.nextNode()) nodeCount++;
+  if (nodeCount > MAX_HTML_NODES) {
+    return `Preview HTML exceeds ${MAX_HTML_NODES} nodes.`;
+  }
+  const elements = Array.from(root.querySelectorAll("*"));
+  for (const element of elements) {
+    if (FORBIDDEN_ELEMENTS.has(element.tagName)) {
+      return `Preview HTML element <${element.tagName.toLowerCase()}> is not allowed.`;
+    }
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase();
+      if (name.startsWith("on") || FORBIDDEN_ATTRIBUTES.has(name)) {
+        return `Preview HTML attribute ${name} is not allowed.`;
+      }
+    }
+  }
+  return undefined;
+}
+
+function validateCSS(css: string): string | undefined {
+  const normalized = css.toLowerCase();
+  for (const token of ["@import", "url(", "expression(", "-moz-binding"]) {
+    if (normalized.includes(token)) {
+      return `Preview CSS contains forbidden ${token}.`;
+    }
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const keys = new Set(allowed);
+  return Object.keys(value).every((key) => keys.has(key));
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function escapeStyleEnd(value: string): string {
+  return value.replace(/<\/style/gi, "<\\/style");
+}
+
+function escapeScriptEnd(value: string): string {
+  return value.replace(/<\/script/gi, "<\\/script");
+}
+
+const PREVIEW_CSP = [
+  "default-src 'none'",
+  "script-src 'unsafe-inline'",
+  "style-src 'unsafe-inline'",
+  "img-src data:",
+  "connect-src 'none'",
+  "font-src 'none'",
+  "media-src 'none'",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "worker-src 'none'",
+  "form-action 'none'",
+  "base-uri 'none'",
+  "navigate-to 'none'",
+].join("; ");
+
+const PREVIEW_RUNTIME_GUARD = `
+(() => {
+  const blocked = (name) => () => { throw new Error(name + " is disabled in Wuu previews"); };
+  for (const name of ["fetch", "XMLHttpRequest", "WebSocket", "EventSource", "Worker", "SharedWorker", "open"]) {
+    try {
+      Object.defineProperty(globalThis, name, { value: blocked(name), writable: false, configurable: false });
+    } catch {}
+  }
+  try {
+    Object.defineProperty(navigator, "sendBeacon", { value: blocked("sendBeacon"), writable: false, configurable: false });
+  } catch {}
+  document.addEventListener("submit", (event) => event.preventDefault(), true);
+  document.addEventListener("click", (event) => {
+    if (event.target instanceof Element && event.target.closest("a")) event.preventDefault();
+  }, true);
+})();`;
+
+export function buildFrontendPreviewDocument(spec: FrontendPreviewSpec): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+:root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+* { box-sizing: border-box; }
+html, body { min-height: 100%; margin: 0; }
+body { padding: 20px; background: #ffffff; color: #202124; }
+button, input, select, textarea { font: inherit; }
+@media (prefers-color-scheme: dark) { body { background: #171918; color: #f1f3f2; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; } }
+</style>
+<style>${escapeStyleEnd(spec.css)}</style>
+</head>
+<body>
+${spec.html}
+<script>${PREVIEW_RUNTIME_GUARD}</script>
+<script>${escapeScriptEnd(spec.javascript)}</script>
+</body>
+</html>`;
+}

--- a/desktop/src/renderer/ToolActivityHelpers.ts
+++ b/desktop/src/renderer/ToolActivityHelpers.ts
@@ -323,6 +323,8 @@ function displaySectionKey(kind: string | undefined): string | undefined {
       return "command";
     case "user_interaction":
       return "interaction";
+    case "presentation":
+      return "interaction";
     default:
       return undefined;
   }

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -1,6 +1,12 @@
 import type { TranslationKey } from "./zh-CN";
 
 export const enUS = {
+  "frontendPreview.invalidTitle": "Unavailable preview",
+  "frontendPreview.kind": "Interactive preview",
+  "frontendPreview.invalidDetail": "This saved preview cannot be opened: {{detail}}",
+  "frontendPreview.tabsLabel": "Preview views",
+  "frontendPreview.previewTab": "Preview",
+  "frontendPreview.sourceTab": "Source",
   "common.system": "Use system language",
   "common.chinese": "简体中文",
   "common.english": "English",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -1,4 +1,10 @@
 export const zhCN = {
+  "frontendPreview.invalidTitle": "无法打开的预览",
+  "frontendPreview.kind": "交互式预览",
+  "frontendPreview.invalidDetail": "这个历史预览无法安全打开：{{detail}}",
+  "frontendPreview.tabsLabel": "预览视图",
+  "frontendPreview.previewTab": "预览",
+  "frontendPreview.sourceTab": "源码",
   "common.system": "跟随系统",
   "common.chinese": "简体中文",
   "common.english": "English",

--- a/desktop/src/renderer/rendererCsp.test.ts
+++ b/desktop/src/renderer/rendererCsp.test.ts
@@ -8,4 +8,10 @@ describe("renderer content security policy", () => {
   it("allows PDF.js to fetch documents through the renderable file scheme", () => {
     expect(rendererHtml).toMatch(/connect-src\s+'self'\s+wuu-file:/);
   });
+
+  it("allows same-origin srcdoc previews without allowing network frames", () => {
+    const frameDirective = rendererHtml.match(/frame-src\s+([^;]+);/)?.[1] ?? "";
+    expect(frameDirective.split(/\s+/)).toEqual(["'self'", "wuu-file:"]);
+    expect(frameDirective).not.toMatch(/https?:|data:|blob:/);
+  });
 });

--- a/desktop/src/renderer/styles/turns.css
+++ b/desktop/src/renderer/styles/turns.css
@@ -4757,3 +4757,142 @@ button.turn-sources-pill:focus-visible {
     transform: none;
   }
 }
+
+/* A successful render_frontend_preview call is answer content, not process
+ * chrome. The runtime is mounted only while this card is expanded on Preview. */
+.frontend-preview-card {
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--hairline-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  color: var(--ink);
+}
+
+.frontend-preview-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  padding: 12px 14px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.frontend-preview-summary:hover,
+.frontend-preview-summary:focus-visible {
+  background: var(--surface-2);
+}
+
+.frontend-preview-summary-copy {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.frontend-preview-title {
+  overflow: hidden;
+  font-weight: var(--weight-semibold, 600);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.frontend-preview-kind {
+  color: var(--ink-muted);
+  font-size: 12px;
+}
+
+.frontend-preview-chevron {
+  flex: 0 0 auto;
+  color: var(--ink-muted);
+  transition: transform var(--motion-fast) var(--ease-out);
+}
+
+.frontend-preview-summary[aria-expanded="true"] .frontend-preview-chevron {
+  transform: rotate(90deg);
+}
+
+.frontend-preview-body {
+  border-top: 1px solid var(--hairline-soft);
+  background: var(--paper);
+}
+
+.frontend-preview-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--hairline-soft);
+  background: var(--surface-1);
+}
+
+.frontend-preview-tabs button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.frontend-preview-tabs button:hover,
+.frontend-preview-tabs button:focus-visible,
+.frontend-preview-tabs button.is-active {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+
+.frontend-preview-frame {
+  display: block;
+  width: 100%;
+  min-height: 160px;
+  border: 0;
+  background: #fff;
+}
+
+.frontend-preview-source {
+  max-height: 520px;
+  overflow: auto;
+  padding: 12px;
+}
+
+.frontend-preview-source section + section {
+  margin-top: 14px;
+}
+
+.frontend-preview-source h4 {
+  margin: 0 0 6px;
+  color: var(--ink-muted);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.frontend-preview-source pre {
+  margin: 0;
+  overflow: auto;
+  padding: 10px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  white-space: pre;
+}
+
+.frontend-preview-error {
+  padding: 14px;
+  color: var(--danger, #b42318);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .frontend-preview-chevron {
+    transition: none;
+  }
+}

--- a/internal/appserver/config_handlers.go
+++ b/internal/appserver/config_handlers.go
@@ -43,6 +43,8 @@ func (s *Server) handleInitialize(req Request) error {
 		return s.writeResponse(req.ID, nil, fmt.Errorf("unsupported protocol version %q (server uses %q)", params.ProtocolVersion, ProtocolVersion))
 	}
 	s.setClientMethods(params.Capabilities.ReverseRPC.Methods)
+	frontendPreview := supportsPresentationVersion(params.Capabilities.Presentations.FrontendPreviewVersions, 1)
+	s.rt.Toolkit.SetFrontendPreviewEnabled(frontendPreview)
 	s.pinLegacyRuntimeSelections()
 	core := version.Info()
 	runtimeHost := s.rt.HostInfo()
@@ -83,8 +85,21 @@ func (s *Server) handleInitialize(req Request) error {
 		Providers:          s.providerSummaries(),
 		AdvancedSettings:   s.currentAdvancedSettingsSummary(),
 		GeneralSettings:    s.currentGeneralSettingsSummary(),
-		Features:           FeatureFlags{Browser: s.supportsBrowserClient(), SafeMode: s.rt.SafeMode},
+		Features: FeatureFlags{
+			Browser:         s.supportsBrowserClient(),
+			FrontendPreview: frontendPreview,
+			SafeMode:        s.rt.SafeMode,
+		},
 	}, nil)
+}
+
+func supportsPresentationVersion(versions []int, want int) bool {
+	for _, version := range versions {
+		if version == want {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) handleConfigRead(req Request) error {

--- a/internal/appserver/frontend_preview_test.go
+++ b/internal/appserver/frontend_preview_test.go
@@ -1,0 +1,40 @@
+package appserver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestServerInitializeNegotiatesFrontendPreviewTool(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	request := `{"id":"1","method":"initialize","params":{"protocol_version":"wuu-app-server/v0.1","capabilities":{"presentations":{"frontend_preview_versions":[1]}}}}`
+
+	if err := srv.handleLine(context.Background(), []byte(request)); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	result := remarshal[InitializeResult](t, responseByID(t, parseOutput(t, out.String()), "1")["result"])
+	if !result.Features.FrontendPreview {
+		t.Fatalf("frontend preview feature not negotiated: %+v", result.Features)
+	}
+	if !toolDefinitionNames(rt.Toolkit.Definitions())["render_frontend_preview"] {
+		t.Fatal("negotiated runtime did not expose render_frontend_preview")
+	}
+}
+
+func TestServerInitializeKeepsFrontendPreviewDisabledWithoutCapability(t *testing.T) {
+	rt := newTestRuntime(t, &fakeClient{})
+	out := &lockedBuffer{}
+	srv := New(rt, out)
+	if err := srv.handleLine(context.Background(), []byte(`{"id":"1","method":"initialize","params":{}}`)); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	result := remarshal[InitializeResult](t, responseByID(t, parseOutput(t, out.String()), "1")["result"])
+	if result.Features.FrontendPreview {
+		t.Fatalf("unexpected frontend preview negotiation: %+v", result.Features)
+	}
+	if toolDefinitionNames(rt.Toolkit.Definitions())["render_frontend_preview"] {
+		t.Fatal("unsupported shell must not expose render_frontend_preview")
+	}
+}

--- a/internal/appserver/protocol.go
+++ b/internal/appserver/protocol.go
@@ -234,11 +234,16 @@ type ClientInfo struct {
 }
 
 type ClientCapabilities struct {
-	ReverseRPC ReverseRPCCapabilities `json:"reverse_rpc,omitempty"`
+	ReverseRPC    ReverseRPCCapabilities   `json:"reverse_rpc,omitempty"`
+	Presentations PresentationCapabilities `json:"presentations,omitempty"`
 }
 
 type ReverseRPCCapabilities struct {
 	Methods []string `json:"methods,omitempty"`
+}
+
+type PresentationCapabilities struct {
+	FrontendPreviewVersions []int `json:"frontend_preview_versions,omitempty"`
 }
 
 type InitializeResult struct {
@@ -271,6 +276,8 @@ type FeatureFlags struct {
 	// backend (hidden WebContentsView + CDP bridge). Mirrored by
 	// desktop/src/shared/protocol.ts. Filled by config_handlers.handleInitialize.
 	Browser bool `json:"browser"`
+	// FrontendPreview reports successful v1 presentation negotiation.
+	FrontendPreview bool `json:"frontend_preview,omitempty"`
 	// SafeMode reports that plugin manifests are visible for recovery, but no
 	// plugin-owned runtime or desktop contribution is active.
 	SafeMode bool `json:"safe_mode,omitempty"`

--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -75,6 +75,10 @@ const (
 	// so permission routing and telemetry can reason about browser control
 	// independently of the general web fetch/search surface.
 	CapabilityBrowser Capability = "browser"
+
+	// A validated immutable frontend snapshot rendered only by compatible
+	// conversation shells. The core records it but never executes its code.
+	CapabilityPresentationFrontend Capability = "presentation.frontend-preview"
 )
 
 // All returns the full closed set of capabilities. The list is
@@ -102,6 +106,7 @@ func All() []Capability {
 		CapabilityMCP,
 		CapabilityDiscovery,
 		CapabilityBrowser,
+		CapabilityPresentationFrontend,
 	}
 }
 

--- a/internal/modelprofile/compiler.go
+++ b/internal/modelprofile/compiler.go
@@ -65,6 +65,10 @@ func (k SurfaceKind) includesChat() bool {
 	return k == SurfaceNamedAgent
 }
 
+func (k SurfaceKind) includesPresentation() bool {
+	return k == SurfaceMain
+}
+
 // Compiler compiles a model profile into a built-in tool surface. Plugin-owned
 // product tools are not part of this compiler.
 type Compiler interface {
@@ -95,6 +99,9 @@ func (DefaultCompiler) Compile(p Profile, kind SurfaceKind) capability.Surface {
 	}
 	if kind.includesChat() {
 		addChatTools(b)
+	}
+	if kind.includesPresentation() {
+		addPresentationTools(b)
 	}
 	b.sortCaps()
 	return b.surface
@@ -309,6 +316,9 @@ func addExtensionTools(b *surfaceBuilder) {
 	b.addDeferredCapability(capability.CapabilityMCP)
 }
 
+func addPresentationTools(b *surfaceBuilder) {
+	b.addVisible("render_frontend_preview", capability.CapabilityPresentationFrontend)
+}
 func addOpenAICodexEditTools(b *surfaceBuilder) {
 	b.addVisible(openaiPatchEditTool, capability.CapabilityFileEdit)
 }

--- a/internal/modelprofile/compiler_test.go
+++ b/internal/modelprofile/compiler_test.go
@@ -87,6 +87,11 @@ func TestNamedAgentSurfaceAddsChatToolsToCompleteMainSurface(t *testing.T) {
 		named := c.Compile(profile, SurfaceNamedAgent)
 		chatTools := []string{"chat_check", "chat_draft", "chat_read", "chat_remind", "chat_send", "chat_task"}
 		for name, capabilityName := range main.Tools {
+			// Presentations require the desktop turn renderer and are intentionally
+			// absent from named-agent/channel surfaces.
+			if name == "render_frontend_preview" {
+				continue
+			}
 			if named.Tools[name] != capabilityName {
 				t.Errorf("%s/%s named-agent surface lost main tool %s", tt.provider, tt.model, name)
 			}
@@ -96,7 +101,8 @@ func TestNamedAgentSurfaceAddsChatToolsToCompleteMainSurface(t *testing.T) {
 				t.Errorf("%s/%s named-agent surface must expose %s as chat capability", tt.provider, tt.model, name)
 			}
 		}
-		wantTools := append(sortedKeys(main.Tools), chatTools...)
+		mainTools := slices.DeleteFunc(sortedKeys(main.Tools), func(name string) bool { return name == "render_frontend_preview" })
+		wantTools := append(mainTools, chatTools...)
 		slices.Sort(wantTools)
 		if got := sortedKeys(named.Tools); !slices.Equal(got, wantTools) {
 			t.Errorf("%s/%s named-agent tools = %v, want main + chat %v", tt.provider, tt.model, got, wantTools)

--- a/internal/modelprofile/frontend_preview_test.go
+++ b/internal/modelprofile/frontend_preview_test.go
@@ -1,0 +1,23 @@
+package modelprofile
+
+import (
+	"testing"
+
+	"github.com/blueberrycongee/wuu/internal/capability"
+)
+
+func TestFrontendPreviewCapabilityIsMainConversationOnly(t *testing.T) {
+	profile := Resolve("openai", "gpt-5-codex")
+	main := DefaultCompiler{}.Compile(profile, SurfaceMain)
+	if got := main.Tools["render_frontend_preview"]; got != capability.CapabilityPresentationFrontend {
+		t.Fatalf("main frontend preview capability = %q", got)
+	}
+	for name, surface := range map[string]capability.Surface{
+		"worker":      DefaultCompiler{}.Compile(profile, SurfaceWorker),
+		"named-agent": DefaultCompiler{}.Compile(profile, SurfaceNamedAgent),
+	} {
+		if _, ok := surface.Tools["render_frontend_preview"]; ok {
+			t.Fatalf("%s surface must not expose render_frontend_preview", name)
+		}
+	}
+}

--- a/internal/tools/tool_display.go
+++ b/internal/tools/tool_display.go
@@ -75,6 +75,8 @@ func displayCapabilityForKnownToolName(name string) string {
 		return "web.fetch"
 	case "web_search":
 		return "web.search"
+	case frontendPreviewToolName:
+		return "presentation.frontend-preview"
 	}
 	return ""
 }
@@ -136,6 +138,12 @@ func builtInToolDisplay(call providers.ToolCall) providers.ToolCallDisplay {
 			return toolDisplay("agent", "创建长期 Agent")
 		}
 		return toolDisplay("agent", "创建长期 Agent "+displayTruncate(profile, 70))
+	case frontendPreviewToolName:
+		title := displayString(args, "title")
+		if title == "" {
+			return toolDisplay("presentation", "准备交互式预览")
+		}
+		return toolDisplay("presentation", "准备交互式预览 "+displayTruncate(title, 80))
 	default:
 		return providers.ToolCallDisplay{
 			Kind: displayKindForTool(name),

--- a/internal/tools/tool_frontend_preview.go
+++ b/internal/tools/tool_frontend_preview.go
@@ -1,0 +1,263 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/blueberrycongee/wuu/internal/providers"
+	"github.com/blueberrycongee/wuu/internal/toolresult"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+const (
+	frontendPreviewToolName        = "render_frontend_preview"
+	frontendPreviewVersion         = 1
+	frontendPreviewMaxPayloadBytes = 256 * 1024
+	frontendPreviewMaxTitleBytes   = 80
+	frontendPreviewMaxHTMLBytes    = 96 * 1024
+	frontendPreviewMaxCSSBytes     = 96 * 1024
+	frontendPreviewMaxJSBytes      = 96 * 1024
+	frontendPreviewMaxHTMLNodes    = 500
+	frontendPreviewDefaultHeight   = 320
+	frontendPreviewMinHeight       = 160
+	frontendPreviewMaxHeight       = 720
+)
+
+type frontendPreviewViewport struct {
+	Height int `json:"height,omitempty"`
+}
+
+type frontendPreviewSpec struct {
+	Version    int                     `json:"version"`
+	Title      string                  `json:"title"`
+	HTML       string                  `json:"html"`
+	CSS        string                  `json:"css,omitempty"`
+	JavaScript string                  `json:"javascript,omitempty"`
+	Viewport   frontendPreviewViewport `json:"viewport,omitempty"`
+}
+
+// FrontendPreviewTool validates and records an immutable HTML/CSS/JavaScript
+// snapshot. Rendering belongs to a shell that explicitly negotiated support;
+// the Go core never evaluates model-generated frontend code.
+type FrontendPreviewTool struct{}
+
+func NewFrontendPreviewTool() *FrontendPreviewTool { return &FrontendPreviewTool{} }
+
+func (t *FrontendPreviewTool) Name() string { return frontendPreviewToolName }
+
+func (t *FrontendPreviewTool) Definition() providers.ToolDefinition {
+	return providers.ToolDefinition{
+		Name: frontendPreviewToolName,
+		Description: "Render a self-contained HTML, CSS, and JavaScript prototype as a collapsed interactive card inside the current desktop conversation turn. " +
+			"Use this for small frontend studies such as buttons, cards, forms, menus, toasts, and animations. The preview has no network, filesystem, Electron, Node.js, package installation, or workspace-project access. " +
+			"Provide a short textual conclusion after the tool call.",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"version": map[string]any{
+					"type":        "integer",
+					"const":       frontendPreviewVersion,
+					"description": "Required schema version. Use 1.",
+				},
+				"title": map[string]any{
+					"type":      "string",
+					"minLength": 1,
+					"maxLength": frontendPreviewMaxTitleBytes,
+				},
+				"html": map[string]any{
+					"type":        "string",
+					"description": "An HTML body fragment. Do not include html, head, body, script, style, iframe, link, meta, or external-resource elements.",
+				},
+				"css": map[string]any{
+					"type":        "string",
+					"description": "Optional self-contained CSS. External imports and url() resources are not allowed.",
+				},
+				"javascript": map[string]any{
+					"type":        "string",
+					"description": "Optional browser JavaScript. Network, navigation, popup, worker, Electron, Node.js, and host-document access are unavailable.",
+				},
+				"viewport": map[string]any{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]any{
+						"height": map[string]any{
+							"type":    "integer",
+							"minimum": frontendPreviewMinHeight,
+							"maximum": frontendPreviewMaxHeight,
+						},
+					},
+				},
+			},
+			"required": []string{"version", "title", "html"},
+		},
+	}
+}
+
+func (t *FrontendPreviewTool) IsReadOnly() bool        { return true }
+func (t *FrontendPreviewTool) IsConcurrencySafe() bool { return true }
+
+func (t *FrontendPreviewTool) ValidateInput(argsJSON string) error {
+	_, err := parseFrontendPreviewSpec(argsJSON)
+	return err
+}
+
+func (t *FrontendPreviewTool) Execute(_ context.Context, argsJSON string) (string, error) {
+	result, err := t.ExecuteResult(context.Background(), argsJSON)
+	return result.TextProjection(), err
+}
+
+func (t *FrontendPreviewTool) ExecuteResult(_ context.Context, argsJSON string) (toolresult.Result, error) {
+	if _, err := parseFrontendPreviewSpec(argsJSON); err != nil {
+		return toolresult.Result{}, err
+	}
+	digestBytes := sha256.Sum256([]byte(argsJSON))
+	meta, err := json.Marshal(map[string]any{
+		"presentation": map[string]any{
+			"kind":    "frontend_preview",
+			"version": frontendPreviewVersion,
+			"digest":  "sha256:" + hex.EncodeToString(digestBytes[:]),
+		},
+	})
+	if err != nil {
+		return toolresult.Result{}, fmt.Errorf("encode frontend preview acknowledgement: %w", err)
+	}
+	return toolresult.Result{
+		Content: []toolresult.ContentPart{{Type: toolresult.ContentTypeText, Text: "Frontend preview ready."}},
+		Meta:    meta,
+	}, nil
+}
+
+func parseFrontendPreviewSpec(argsJSON string) (frontendPreviewSpec, error) {
+	var spec frontendPreviewSpec
+	if len(argsJSON) > frontendPreviewMaxPayloadBytes {
+		return spec, fmt.Errorf("frontend preview payload exceeds %d bytes: error_kind=payload_too_large", frontendPreviewMaxPayloadBytes)
+	}
+	decoder := json.NewDecoder(strings.NewReader(argsJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&spec); err != nil {
+		return spec, fmt.Errorf("invalid frontend preview arguments: %w", err)
+	}
+	if err := ensureFrontendPreviewJSONEOF(decoder); err != nil {
+		return spec, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(argsJSON), &fields); err != nil {
+		return spec, fmt.Errorf("invalid frontend preview arguments: %w", err)
+	}
+	if _, ok := fields["html"]; !ok {
+		return spec, errors.New("frontend preview html is required: error_kind=missing_html")
+	}
+	if spec.Version != frontendPreviewVersion {
+		return spec, fmt.Errorf("unsupported frontend preview version %d: error_kind=unsupported_version", spec.Version)
+	}
+	if title := strings.TrimSpace(spec.Title); title == "" {
+		return spec, errors.New("frontend preview title is required: error_kind=missing_title")
+	} else if len(title) > frontendPreviewMaxTitleBytes {
+		return spec, fmt.Errorf("frontend preview title exceeds %d bytes: error_kind=title_too_large", frontendPreviewMaxTitleBytes)
+	}
+	if len(spec.HTML) > frontendPreviewMaxHTMLBytes {
+		return spec, fmt.Errorf("frontend preview html exceeds %d bytes: error_kind=html_too_large", frontendPreviewMaxHTMLBytes)
+	}
+	if len(spec.CSS) > frontendPreviewMaxCSSBytes {
+		return spec, fmt.Errorf("frontend preview css exceeds %d bytes: error_kind=css_too_large", frontendPreviewMaxCSSBytes)
+	}
+	if len(spec.JavaScript) > frontendPreviewMaxJSBytes {
+		return spec, fmt.Errorf("frontend preview javascript exceeds %d bytes: error_kind=javascript_too_large", frontendPreviewMaxJSBytes)
+	}
+	if spec.Viewport.Height == 0 {
+		spec.Viewport.Height = frontendPreviewDefaultHeight
+	}
+	if spec.Viewport.Height < frontendPreviewMinHeight || spec.Viewport.Height > frontendPreviewMaxHeight {
+		return spec, fmt.Errorf("frontend preview height must be between %d and %d: error_kind=invalid_viewport", frontendPreviewMinHeight, frontendPreviewMaxHeight)
+	}
+	if err := validateFrontendPreviewHTML(spec.HTML); err != nil {
+		return spec, err
+	}
+	if err := validateFrontendPreviewCSS(spec.CSS); err != nil {
+		return spec, err
+	}
+	return spec, nil
+}
+
+func ensureFrontendPreviewJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); err == io.EOF {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("invalid frontend preview arguments: %w", err)
+	}
+	return errors.New("invalid frontend preview arguments: trailing JSON value")
+}
+
+var frontendPreviewForbiddenElements = map[string]struct{}{
+	"applet": {}, "base": {}, "body": {}, "embed": {}, "frame": {}, "frameset": {},
+	"head": {}, "html": {}, "iframe": {}, "link": {}, "meta": {}, "object": {},
+	"script": {}, "style": {}, "title": {}, "webview": {},
+}
+
+var frontendPreviewForbiddenAttributes = map[string]struct{}{
+	"action": {}, "background": {}, "cite": {}, "data": {}, "formaction": {},
+	"href": {}, "longdesc": {}, "manifest": {}, "ping": {}, "poster": {},
+	"profile": {}, "src": {}, "srcdoc": {}, "srcset": {}, "usemap": {},
+}
+
+func validateFrontendPreviewHTML(fragment string) error {
+	contextNode := &html.Node{Type: html.ElementNode, Data: "div", DataAtom: atom.Div}
+	nodes, err := html.ParseFragment(strings.NewReader(fragment), contextNode)
+	if err != nil {
+		return fmt.Errorf("invalid frontend preview html: %w", err)
+	}
+	count := 0
+	var visit func(*html.Node) error
+	visit = func(node *html.Node) error {
+		count++
+		if count > frontendPreviewMaxHTMLNodes {
+			return fmt.Errorf("frontend preview html exceeds %d nodes: error_kind=too_many_nodes", frontendPreviewMaxHTMLNodes)
+		}
+		if node.Type == html.ElementNode {
+			tag := strings.ToLower(node.Data)
+			if _, forbidden := frontendPreviewForbiddenElements[tag]; forbidden {
+				return fmt.Errorf("frontend preview html element <%s> is not allowed: error_kind=unsafe_html", tag)
+			}
+			for _, attr := range node.Attr {
+				name := strings.ToLower(attr.Key)
+				if strings.HasPrefix(name, "on") {
+					return fmt.Errorf("frontend preview html event attribute %q is not allowed: error_kind=unsafe_html", name)
+				}
+				if _, forbidden := frontendPreviewForbiddenAttributes[name]; forbidden {
+					return fmt.Errorf("frontend preview html attribute %q is not allowed: error_kind=unsafe_html", name)
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			if err := visit(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, node := range nodes {
+		if err := visit(node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFrontendPreviewCSS(css string) error {
+	normalized := strings.ToLower(css)
+	for _, forbidden := range []string{"@import", "url(", "expression(", "-moz-binding"} {
+		if strings.Contains(normalized, forbidden) {
+			return fmt.Errorf("frontend preview css contains forbidden %q: error_kind=unsafe_css", forbidden)
+		}
+	}
+	return nil
+}

--- a/internal/tools/tool_frontend_preview_test.go
+++ b/internal/tools/tool_frontend_preview_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/blueberrycongee/wuu/internal/modelprofile"
+	"github.com/blueberrycongee/wuu/internal/providers"
+)
+
+const validFrontendPreviewArgs = `{"version":1,"title":"Loading button","html":"<button id=\"save\">Save</button>","css":"button:hover { transform: scale(1.05); }","javascript":"document.querySelector('#save').addEventListener('click', () => {});","viewport":{"height":320}}`
+
+func TestFrontendPreviewToolValidatesAndReturnsCompactAcknowledgement(t *testing.T) {
+	tool := NewFrontendPreviewTool()
+	if err := tool.ValidateInput(validFrontendPreviewArgs); err != nil {
+		t.Fatalf("ValidateInput: %v", err)
+	}
+	result, err := tool.ExecuteResult(context.Background(), validFrontendPreviewArgs)
+	if err != nil {
+		t.Fatalf("ExecuteResult: %v", err)
+	}
+	if result.TextProjection() != "Frontend preview ready." {
+		t.Fatalf("unexpected model projection: %q", result.TextProjection())
+	}
+	if strings.Contains(result.JSONProjection(), "Loading button") || strings.Contains(result.JSONProjection(), "querySelector") {
+		t.Fatalf("result must not echo the preview payload: %s", result.JSONProjection())
+	}
+	var meta struct {
+		Presentation struct {
+			Kind    string `json:"kind"`
+			Version int    `json:"version"`
+			Digest  string `json:"digest"`
+		} `json:"presentation"`
+	}
+	if err := json.Unmarshal(result.Meta, &meta); err != nil {
+		t.Fatalf("decode meta: %v", err)
+	}
+	if meta.Presentation.Kind != "frontend_preview" || meta.Presentation.Version != 1 || !strings.HasPrefix(meta.Presentation.Digest, "sha256:") {
+		t.Fatalf("unexpected acknowledgement metadata: %+v", meta.Presentation)
+	}
+}
+
+func TestFrontendPreviewToolRejectsUnsafeOrUnboundedInput(t *testing.T) {
+	tool := NewFrontendPreviewTool()
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{name: "unknown field", args: `{"version":1,"title":"x","html":"","extra":true}`, want: "unknown field"},
+		{name: "missing html", args: `{"version":1,"title":"x"}`, want: "missing_html"},
+		{name: "unsupported version", args: `{"version":2,"title":"x","html":""}`, want: "unsupported_version"},
+		{name: "external image", args: `{"version":1,"title":"x","html":"<img src=\"https://example.com/x.png\">"}`, want: "unsafe_html"},
+		{name: "inline handler", args: `{"version":1,"title":"x","html":"<button onclick=\"alert(1)\">x</button>"}`, want: "unsafe_html"},
+		{name: "script element", args: `{"version":1,"title":"x","html":"<script>alert(1)</script>"}`, want: "unsafe_html"},
+		{name: "css import", args: `{"version":1,"title":"x","html":"","css":"@import 'https://example.com/x.css';"}`, want: "unsafe_css"},
+		{name: "invalid viewport", args: `{"version":1,"title":"x","html":"","viewport":{"height":900}}`, want: "invalid_viewport"},
+		{name: "nested unknown field", args: `{"version":1,"title":"x","html":"","viewport":{"height":320,"width":640}}`, want: "unknown field"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.ValidateInput(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateInput error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestFrontendPreviewToolIsCapabilityGatedAndMainOnly(t *testing.T) {
+	kit, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	kit.SetActiveProfile(modelprofile.Resolve("openai", "gpt-5-codex"), true)
+	if containsProfileDef(kit.Definitions(), frontendPreviewToolName) {
+		t.Fatal("new toolkit must keep frontend preview disabled")
+	}
+	kit.SetFrontendPreviewEnabled(true)
+	if !containsProfileDef(kit.Definitions(), frontendPreviewToolName) {
+		t.Fatalf("enabled main toolkit missing %s", frontendPreviewToolName)
+	}
+
+	worker, err := kit.CloneForRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("CloneForRoot: %v", err)
+	}
+	worker.SetActiveProfile(modelprofile.Resolve("openai", "gpt-5-codex"), false)
+	if containsProfileDef(worker.Definitions(), frontendPreviewToolName) {
+		t.Fatal("worker surface must not expose frontend previews")
+	}
+
+	kit.SetFrontendPreviewEnabled(false)
+	if _, err := kit.Execute(context.Background(), providers.ToolCall{Name: frontendPreviewToolName, Arguments: validFrontendPreviewArgs}); err == nil || !strings.Contains(err.Error(), "disabled in this session") {
+		t.Fatalf("disabled frontend preview execution error = %v", err)
+	}
+}

--- a/internal/tools/toolkit.go
+++ b/internal/tools/toolkit.go
@@ -150,7 +150,7 @@ func New(rootDir string) (*Toolkit, error) {
 	}
 	t := &Toolkit{
 		env:               env,
-		disabledTools:     map[string]struct{}{browserToolName: {}},
+		disabledTools:     map[string]struct{}{browserToolName: {}, frontendPreviewToolName: {}},
 		toolSearchEnabled: true,
 		boundary:          StandardBoundary(),
 	}
@@ -282,6 +282,9 @@ func (t *Toolkit) rebuildRegistry() {
 		// Embedded browser automation (default-disabled in New(); enabled per
 		// session by SetBrowserEnabled off WUU_ENABLE_BROWSER).
 		NewBrowserTool(e),
+		// Content-bearing previews stay disabled until a compatible shell
+		// explicitly negotiates support during app-server initialization.
+		NewFrontendPreviewTool(),
 		// Deferred tool discovery
 		NewToolSearchTool(t),
 	}
@@ -535,6 +538,23 @@ func (t *Toolkit) SetBrowserEnabled(enabled bool) {
 		t.EnableTools(browserToolName)
 	} else {
 		t.DisableTools(browserToolName)
+	}
+	t.activeProfileMu.Lock()
+	t.publishActiveSurfaceLocked()
+	t.activeProfileMu.Unlock()
+}
+
+// SetFrontendPreviewEnabled gates the content-bearing frontend preview tool.
+// New toolkits keep it disabled so CLI/headless shells never advertise a UI
+// surface they cannot render. CloneForRoot copies this gate to thread runtimes.
+func (t *Toolkit) SetFrontendPreviewEnabled(enabled bool) {
+	if t == nil {
+		return
+	}
+	if enabled {
+		t.EnableTools(frontendPreviewToolName)
+	} else {
+		t.DisableTools(frontendPreviewToolName)
 	}
 	t.activeProfileMu.Lock()
 	t.publishActiveSurfaceLocked()

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -75,6 +75,9 @@ export type InitializeParams = {
     reverse_rpc?: {
       methods?: string[];
     };
+    presentations?: {
+      frontend_preview_versions?: number[];
+    };
   };
 };
 
@@ -115,6 +118,8 @@ export type FeatureFlags = {
   // Advertises that this client can host the embedded browser backend
   // (hidden WebContentsView + CDP bridge). Mirrors appserver.FeatureFlags.
   browser?: boolean;
+  // True only when the desktop and core agreed on frontend preview schema v1.
+  frontend_preview?: boolean;
   // Plugin manifests remain visible for recovery, but no plugin contribution
   // is activated in either runtime or desktop planes.
   safe_mode?: boolean;


### PR DESCRIPTION
**Summary**

Implements Slice 1 of [#20](https://github.com/blueberrycongee/wuu/issues/20): a supported desktop conversation can now contain a collapsed, interactive HTML/CSS/JavaScript preview directly in the answer body.

This establishes the end-to-end frontend-preview path from capability negotiation and model tool exposure through persisted turn content and sandboxed rendering. Each call creates an immutable snapshot bound to the turn that produced it. Local interaction stays inside the card, does not wake the agent, and resets when the preview runtime is remounted.

This PR intentionally implements only the frontend-preview slice. It does not add `render_inline_component`, the declarative component registry, charts, data tables, or local state binding planned for later slices of #20.

**Changes**

**The tool is negotiated before it is exposed.** Desktop initialization now advertises frontend preview schema v1 through a presentation capability. The app-server enables `render_frontend_preview` only when the shell declares that version and reports the negotiated result through `features.frontend_preview`. Toolkits keep it disabled by default, so CLI/headless clients and older shells never advertise a content-bearing tool they cannot render.

**Only ordinary main conversations receive the presentation surface.** The model profile compiler maps `render_frontend_preview` to `presentation.frontend-preview` for `SurfaceMain`. Worker and named-Agent/channel surfaces deliberately omit it because those shells do not own the desktop turn renderer that hosts the card.

**The v1 input is strict and bounded.** The Go tool rejects unknown JSON fields, trailing JSON values, missing required fields, unsupported versions, and invalid viewport values. Current limits are:

| Boundary | v1 limit |
| --- | --- |
| Total serialized payload | 256 KiB |
| Title | 80 bytes |
| HTML | 96 KiB |
| CSS | 96 KiB |
| JavaScript | 96 KiB |
| HTML nodes | 500 |
| Preview height | 160–720 px, 320 px default |

HTML validation rejects document-level and active-content elements including `script`, `style`, `iframe`, `meta`, `link`, `base`, `object`, `embed`, and `webview`. It also rejects URL-bearing/navigation attributes and all `on*` event attributes. CSS rejects `@import`, `url(`, `expression(`, and `-moz-binding`.

**The Go core records a snapshot but never evaluates it.** A successful tool call returns only `Frontend preview ready.` plus presentation metadata containing the kind, schema version, and SHA-256 digest. The result does not echo the HTML, CSS, or JavaScript back into model context. The persisted `ThreadItem.arguments` remain the single source used to reconstruct the preview from conversation history.

**Successful presentations leave the process fold.** The desktop turn classifier introduces a standalone `presentation` entry kind. A completed, non-error frontend preview is rendered in the answer body and counts as answer content even when the turn contains no final text. Failed or in-progress preview calls remain ordinary process activity so errors use the existing tool failure path. A presentation also breaks adjacent tool grouping, preserving its position between surrounding activities.

**The card is collapsed and inert by default.** Historical conversations do not execute preview JavaScript merely because the turn is visible. Expanding the card mounts Preview; Source displays the persisted HTML, CSS, and JavaScript without a runtime. Switching to Source or collapsing the card unmounts the iframe. Reopening creates a new iframe and resets local click, input, and animation state.

**Persisted payloads are validated again in the renderer.** The frontend parser mirrors the version, field, byte, viewport, DOM-node, HTML, and CSS checks before building `srcdoc`. This second boundary protects history reloads and future protocol mismatches. Invalid or unsafe history produces an inert error card and never mounts an iframe.

**Generated JavaScript runs in an opaque-origin sandbox.** The iframe uses `sandbox="allow-scripts"` without `allow-same-origin`, carries a no-referrer policy and restrictive Permissions Policy, and has no preload bridge. Generated code therefore receives no Electron API, Node.js API, IPC, filesystem access, host DOM access, host storage, or same-origin relationship with the desktop renderer.

**The preview document starts from `default-src 'none'`.** Its CSP allows only the minimum inline script/style execution needed by the self-contained snapshot and local `data:` images. It disables network connections, nested frames, workers, fonts, media, objects, external forms, base URLs, and navigation. User code is additionally preceded by non-configurable runtime guards for `fetch`, XHR, WebSocket, EventSource, Worker, SharedWorker, `window.open`, and `navigator.sendBeacon`, plus capture-phase prevention for link navigation and form submission.

**The outer renderer CSP stays closed to network frames.** It permits same-origin `srcdoc` presentation frames while retaining the existing `wuu-file:` support. HTTP, HTTPS, data, and blob frames are not added to `frame-src`.

**The UI follows existing conversation conventions.** The card uses the answer-body width, current surface/border/text tokens, compact turn spacing, Preview/Source tabs, Chinese and English strings, and reduced-motion handling. No feature-specific debug control is included in production.

**Security model**

The implementation uses defense in depth rather than relying on a single string filter:

1. The shell must negotiate frontend preview v1 before the model sees the tool.
2. Go strictly decodes and bounds the proposed snapshot.
3. Go parses the HTML fragment and rejects active or external-resource surfaces.
4. The renderer revalidates persisted arguments before mounting history.
5. The iframe has an opaque origin and no host/preload relationship.
6. The inner CSP disables network, navigation, embedding, workers, and external resources.
7. Runtime guards close common browser APIs before generated JavaScript runs.
8. Unmounting the card destroys the runtime and resets local state.

The existing workspace browser webview is not reused: its persistent partition and browser-oriented permissions are intentionally inappropriate for model-generated code.

**One limitation from the issue, worth a look**

The issue calls for resource, payload, and runtime limits. This slice enforces serialized-size, per-field, DOM-node, viewport, network, navigation, and lifecycle limits, but it does not claim that a same-renderer iframe can terminate synchronous JavaScript such as `while (true) {}`. A hard CPU/time budget requires a separately killable process or an equivalent stronger execution boundary. The current preview still executes only after explicit expansion and is destroyed whenever the card unmounts.

The button-animation acceptance fixture is covered through the renderer preview fixture and lifecycle tests rather than a production debug gallery. This keeps the production build free of feature-specific debug controls.

**Validation**

- `go test ./internal/tools -run FrontendPreview -count=1 -v` — passed
  - compact result and digest metadata
  - strict/unsafe input rejection
  - capability enable/disable behavior
  - main-only exposure
- `go test ./internal/modelprofile -run FrontendPreview -count=1 -v` — passed
- Desktop TypeScript typecheck — passed
- Focused renderer suite — 4 files, 62 tests passed
  - presentation classification and grouping boundaries
  - preview-only answer behavior
  - failed-call fallback
  - collapsed-by-default behavior
  - Preview/Source switching
  - iframe teardown and state reset boundary
  - invalid-history inert fallback
  - sandbox/CSP attributes
  - outer renderer frame policy
- Electron main/preload/renderer production build — passed
- Fresh Electron development stack startup — passed through renderer initialization
- `git diff --cached --check` — passed

Native Windows app-server integration is blocked before frontend-preview negotiation by the existing SQLite file-URI problem tracked in [#205](https://github.com/blueberrycongee/wuu/pull/205): the Windows path is encoded as `C:%5C...` and rejected as an invalid URI authority. The same existing platform issue affects unrelated app-server and tool tests. Supported-platform CI still needs to run the app-server integration and complete Go gates.

**Risk and rollback**

Risk level: **medium**. This introduces an explicit untrusted-code surface, but it is default-disabled, version-negotiated, main-surface-only, strictly bounded, revalidated on history load, and rendered in an opaque-origin sandbox with no network or host bridge.

Rollback is a normal revert. Unsupported clients already keep the tool disabled, and no database migration or new persistence format is introduced; historical tool calls remain ordinary recorded tool items if the renderer support is removed.

**Issue scope**

Implements Slice 1 of [#20](https://github.com/blueberrycongee/wuu/issues/20).

This intentionally does not close #20 because the declarative data UI and developer-specific component slices remain outstanding.
