### PR TITLE
fix: preserve PostToolUse context in parallel batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning rules are documented in [the release guide](docs/en/project/release.m
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved `PostToolUse` hook context across concurrent tool batches and
+  isolated request-only context by tool call.
+
 ## [0.15.0] - 2026-08-05
 
 ### Added

--- a/internal/agent/hook_context_integration_test.go
+++ b/internal/agent/hook_context_integration_test.go
@@ -1,0 +1,97 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blueberrycongee/wuu/internal/agent"
+	"github.com/blueberrycongee/wuu/internal/hooks"
+	"github.com/blueberrycongee/wuu/internal/providers"
+)
+
+type hookContextStep struct {
+	results  []agent.StepResult
+	requests []providers.ChatRequest
+	index    int
+}
+
+func (s *hookContextStep) Execute(_ context.Context, request providers.ChatRequest) (agent.StepResult, error) {
+	s.requests = append(s.requests, providers.ChatRequest{
+		Model:    request.Model,
+		Messages: providers.CloneChatMessages(request.Messages),
+	})
+	if s.index >= len(s.results) {
+		return agent.StepResult{}, errors.New("unexpected model request")
+	}
+	result := s.results[s.index]
+	s.index++
+	return result, nil
+}
+
+type concurrentHookTools struct{}
+
+func (concurrentHookTools) Definitions() []providers.ToolDefinition {
+	return []providers.ToolDefinition{{Name: "read_file"}}
+}
+
+func (concurrentHookTools) ToolMetadata(providers.ToolCall) (agent.ToolMetadata, bool) {
+	return agent.ToolMetadata{ReadOnly: true, ConcurrencySafe: true}, true
+}
+
+func (concurrentHookTools) Execute(_ context.Context, call providers.ToolCall) (string, error) {
+	return `{"path":` + call.Arguments + `}`, nil
+}
+
+func TestRunToolLoopPreservesPostToolContextForConcurrentCalls(t *testing.T) {
+	registry := hooks.NewRegistry(map[hooks.Event][]hooks.HookConfig{
+		hooks.PostToolUse: {{
+			Matcher: "read_file",
+			Command: `input=$(cat); case "$input" in *one.txt*) printf '%s' '{"additional_context":"context for one"}';; *) printf '%s' '{"additional_context":"context for two"}';; esac`,
+		}},
+	})
+	executor := hooks.NewHookedExecutor(concurrentHookTools{}, hooks.NewDispatcher(registry), "session", t.TempDir())
+	step := &hookContextStep{results: []agent.StepResult{
+		{ToolCalls: []providers.ToolCall{
+			{ID: "call-one", Name: "read_file", Arguments: `{"path":"one.txt"}`},
+			{ID: "call-two", Name: "read_file", Arguments: `{"path":"two.txt"}`},
+		}},
+		{Content: "done"},
+	}}
+
+	result, err := agent.RunToolLoop(
+		context.Background(),
+		[]providers.ChatMessage{{Role: "user", Content: "compare both files"}},
+		agent.LoopConfig{Model: "test-model", Tools: executor},
+		step,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(step.requests) != 2 {
+		t.Fatalf("model requests = %d, want 2", len(step.requests))
+	}
+	secondRequest := step.requests[1].Messages
+	for _, want := range []string{"context for one", "context for two"} {
+		if countMessageContent(secondRequest, want) != 1 {
+			t.Fatalf("second request should contain %q exactly once: %+v", want, secondRequest)
+		}
+		if countMessageContent(result.NewMessages, want) != 0 {
+			t.Fatalf("durable history must not contain request-only context %q: %+v", want, result.NewMessages)
+		}
+	}
+	if got := countMessageContent(secondRequest, "[ADDITIONAL_CONTEXT]"); got != 2 {
+		t.Fatalf("additional context blocks = %d, want 2: %+v", got, secondRequest)
+	}
+}
+
+func countMessageContent(messages []providers.ChatMessage, needle string) int {
+	count := 0
+	for _, message := range messages {
+		if strings.Contains(message.Content, needle) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -69,6 +69,16 @@ type ToolContextProvider interface {
 	LastAdditionalContext() string
 }
 
+// ToolCallContextProvider exposes request-only context for a specific tool
+// call. Concurrent executors should implement this interface instead of
+// sharing a single "last result" slot, which cannot preserve call ownership
+// when multiple tools finish out of order.
+type ToolCallContextProvider interface {
+	// TakeAdditionalContext returns and clears additional context produced by
+	// the specified tool call.
+	TakeAdditionalContext(call providers.ToolCall) string
+}
+
 // ToolDiscoveryProvider is an optional interface a ToolExecutor can implement
 // to attach provider-native deferred tool schemas to the tool result message
 // that made those tools available.

--- a/internal/agent/tool_runtime.go
+++ b/internal/agent/tool_runtime.go
@@ -581,6 +581,7 @@ func (r *TurnToolRuntime) executeBatch(
 	onResult func(providers.ToolCall, string),
 ) toolBatchResult {
 	ctxProvider, hasCtxProvider := r.executor.(ToolContextProvider)
+	callCtxProvider, hasCallCtxProvider := r.executor.(ToolCallContextProvider)
 	discoveryProvider, hasDiscoveryProvider := r.executor.(ToolDiscoveryProvider)
 
 	if !batch.concurrent || len(batch.calls) == 1 {
@@ -593,12 +594,10 @@ func (r *TurnToolRuntime) executeBatch(
 			}
 			r.notifyResult(call, result, onResult)
 			msgs = append(msgs, toolResultMessage(call, r.invocationIDForCall(call), result, discoveryProvider, hasDiscoveryProvider))
-			if hasCtxProvider {
-				if extra := ctxProvider.LastAdditionalContext(); extra != "" {
-					segment := postToolAdditionalContextSegment(call.Name, extra)
-					if len(segment.Messages) > 0 {
-						requestContext = append(requestContext, segment)
-					}
+			if extra := takeToolAdditionalContext(call, callCtxProvider, hasCallCtxProvider, ctxProvider, hasCtxProvider); extra != "" {
+				segment := postToolAdditionalContextSegment(call.Name, extra)
+				if len(segment.Messages) > 0 {
+					requestContext = append(requestContext, segment)
 				}
 			}
 		}
@@ -615,6 +614,7 @@ func (r *TurnToolRuntime) executeBatch(
 	r.mu.Unlock()
 
 	msgs := make([]providers.ChatMessage, len(batch.calls))
+	requestContext := make([]ContextSegment, 0, len(batch.calls))
 	for i, call := range batch.calls {
 		result, err := r.awaitRunResult(ctx, runs[i])
 		if err != nil {
@@ -622,8 +622,32 @@ func (r *TurnToolRuntime) executeBatch(
 		}
 		r.notifyResult(call, result, onResult)
 		msgs[i] = toolResultMessage(call, runs[i].invocationID, result, discoveryProvider, hasDiscoveryProvider)
+		if hasCallCtxProvider {
+			if extra := callCtxProvider.TakeAdditionalContext(call); extra != "" {
+				segment := postToolAdditionalContextSegment(call.Name, extra)
+				if len(segment.Messages) > 0 {
+					requestContext = append(requestContext, segment)
+				}
+			}
+		}
 	}
-	return toolBatchResult{messages: msgs}
+	return toolBatchResult{messages: msgs, requestContext: requestContext}
+}
+
+func takeToolAdditionalContext(
+	call providers.ToolCall,
+	callProvider ToolCallContextProvider,
+	hasCallProvider bool,
+	legacyProvider ToolContextProvider,
+	hasLegacyProvider bool,
+) string {
+	if hasCallProvider {
+		return callProvider.TakeAdditionalContext(call)
+	}
+	if hasLegacyProvider {
+		return legacyProvider.LastAdditionalContext()
+	}
+	return ""
 }
 
 type toolBatchResult struct {

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/blueberrycongee/wuu/internal/agent"
 	"github.com/blueberrycongee/wuu/internal/providers"
@@ -36,7 +37,9 @@ type HookedExecutor struct {
 	dispatcher        *Dispatcher
 	sessionID         string
 	cwd               string
-	lastAdditionalCtx string // populated by PostToolUse hooks
+	contextMu         sync.Mutex
+	lastAdditionalCtx string            // legacy serial consumer support
+	additionalByCall  map[string]string // populated by PostToolUse hooks
 }
 
 // NewHookedExecutor wraps inner with hook dispatch.
@@ -142,7 +145,7 @@ func (h *HookedExecutor) Execute(ctx context.Context, call providers.ToolCall) (
 // ExecuteResult preserves the canonical rich result while exposing only a
 // deterministic projection to legacy hook payloads.
 func (h *HookedExecutor) ExecuteResult(ctx context.Context, call providers.ToolCall) (toolresult.Result, error) {
-	h.lastAdditionalCtx = "" // reset for this call
+	h.clearAdditionalContext(call)
 	input := &Input{
 		SessionID: h.sessionID,
 		CWD:       h.cwd,
@@ -201,7 +204,7 @@ func (h *HookedExecutor) ExecuteResult(ctx context.Context, call providers.ToolC
 	}
 	postOut, _ := h.dispatcher.Dispatch(ctx, PostToolUse, postInput)
 	if postOut != nil && postOut.Context != "" {
-		h.lastAdditionalCtx = postOut.Context
+		h.storeAdditionalContext(call, postOut.Context)
 	}
 
 	return result, nil
@@ -212,5 +215,54 @@ func (h *HookedExecutor) ExecuteResult(ctx context.Context, call providers.ToolC
 // each Execute call so it can only be consumed once. Implements
 // agent.ToolContextProvider.
 func (h *HookedExecutor) LastAdditionalContext() string {
-	return h.lastAdditionalCtx
+	if h == nil {
+		return ""
+	}
+	h.contextMu.Lock()
+	defer h.contextMu.Unlock()
+	context := h.lastAdditionalCtx
+	h.lastAdditionalCtx = ""
+	return context
+}
+
+// TakeAdditionalContext returns and clears PostToolUse context for one tool
+// call. Keying context by provider call ID keeps concurrent results isolated
+// even when they finish out of order. Implements agent.ToolCallContextProvider.
+func (h *HookedExecutor) TakeAdditionalContext(call providers.ToolCall) string {
+	if h == nil || strings.TrimSpace(call.ID) == "" {
+		return ""
+	}
+	h.contextMu.Lock()
+	defer h.contextMu.Unlock()
+	context := h.additionalByCall[call.ID]
+	delete(h.additionalByCall, call.ID)
+	return context
+}
+
+func (h *HookedExecutor) clearAdditionalContext(call providers.ToolCall) {
+	if h == nil {
+		return
+	}
+	h.contextMu.Lock()
+	defer h.contextMu.Unlock()
+	h.lastAdditionalCtx = ""
+	if strings.TrimSpace(call.ID) != "" {
+		delete(h.additionalByCall, call.ID)
+	}
+}
+
+func (h *HookedExecutor) storeAdditionalContext(call providers.ToolCall, context string) {
+	if h == nil {
+		return
+	}
+	h.contextMu.Lock()
+	defer h.contextMu.Unlock()
+	h.lastAdditionalCtx = context
+	if strings.TrimSpace(call.ID) == "" {
+		return
+	}
+	if h.additionalByCall == nil {
+		h.additionalByCall = make(map[string]string)
+	}
+	h.additionalByCall[call.ID] = context
 }


### PR DESCRIPTION
## Summary

将钩子上下文从全局共享改为按工具调用 ID 独立存储，并在并行批处理中逐项收集，从而确保并发工具的 additional_context 全部送达下一轮模型请求，同时消除数据竞争。

Preserve `PostToolUse.additional_context` when concurrency-safe tools execute in parallel, and remove the data race caused by sharing one unsynchronized “last context” slot across tool calls.

Closes #ISSUE_NUMBER.

## Changes

- Add a call-scoped `ToolCallContextProvider` contract that consumes request-only context by provider tool-call ID.
- Store `PostToolUse` context per call in `HookedExecutor` and protect both the call map and the legacy serial slot with a mutex.
- Collect each completed call's context in the concurrent `TurnToolRuntime.executeBatch` path and attach it to the next model request.
- Keep the existing `ToolContextProvider` fallback for executors that only support the serial contract.
- Add an end-to-end regression test using the real hook dispatcher, two concurrent `read_file` calls, and distinct context values.
- Verify that each context appears exactly once in the follow-up request and does not leak into durable history.

## Test plan

- [x] Added or updated unit/integration tests for the change
- [x] `make ci`
- [x] `go test -race ./internal/hooks ./internal/agent`
- [x] `go test ./internal/hooks ./internal/runtime`
- [x] `go vet ./internal/agent ./internal/hooks ./internal/runtime`
- [x] `go test ./internal/...`
- [x] `cd desktop && npm test` passes as part of `make ci`
- [x] Manually verified the behavior in the desktop shell

Manual before/after result using two batches of two parallel `read_file` calls:

| Signal                                   | Before | After |
| ---------------------------------------- | -----: | ----: |
| Successful hook executions               |      4 |     4 |
| Hook contexts in subsequent model inputs |      0 |     4 |
| Missing contexts                         |      4 |     0 |

After the fix, the model explicitly recognized the hook-provided context. It declined to obey the embedded instruction because it treated the hook text as untrusted context; that is a separate trust-policy decision and confirms that transport is working.

## Risk and rollback

- Risk level: low.
- The change is limited to request-only post-tool context collection and preserves the legacy serial provider fallback.
- Context is keyed by tool-call ID, consumed once, and excluded from durable history.
- Rollback is a normal revert; there is no data, configuration, or protocol migration.

## Linked issues / docs

- Closes #ISSUE_NUMBER.
- Hook contract: `docs/en/customize/hooks.md`