### PR TITLE
fix: harden Windows desktop workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,46 @@ jobs:
       - name: Check, test, and build
         run: make theme-surface-matrix-check check-desktop test-desktop build-desktop
 
+  windows-desktop-check:
+    name: Windows desktop check
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Test and typecheck
+        run: |
+          npm test
+          npm run typecheck
+
+      - name: Package Windows app
+        run: npm run pack:win
+
+      - name: Verify packaged app
+        shell: pwsh
+        run: |
+          $app = Get-ChildItem release -Recurse -Filter wuu.exe | Select-Object -First 1
+          $core = Get-ChildItem release -Recurse -Filter wuu-core.exe | Select-Object -First 1
+          if (-not $app) { throw "Packaged wuu.exe is missing" }
+          if (-not $core) { throw "Packaged wuu-core.exe is missing" }
+          & $core.FullName --version
+
   clients-check:
     name: Clients check
     runs-on: ubuntu-latest

--- a/desktop/scripts/dev.cjs
+++ b/desktop/scripts/dev.cjs
@@ -10,6 +10,7 @@ const {
 const { ensureDevSigningIdentity } = require("./dev-signing.cjs");
 
 const desktopRoot = resolve(__dirname, "..");
+const repoRoot = resolve(desktopRoot, "..");
 const buildHelper = join(__dirname, "build-cua-mac.cjs");
 const buildSpeechHelper = join(__dirname, "build-speech-mac.cjs");
 const buildPluginHelpers = join(__dirname, "build-core.cjs");
@@ -50,6 +51,13 @@ if (pluginHelperBuild.status !== 0) {
 }
 
 const env = { ...process.env };
+// electron-vite launches Electron directly on Windows and Linux. Unlike the
+// macOS LaunchServices wrapper below, that path does not inject the source
+// checkout or opt in to `go run`, so the main process would otherwise fail
+// immediately with "wuu desktop core is missing". Keep local development on
+// the source-owned core on every platform.
+env.WUU_DESKTOP_USE_GO_RUN = "1";
+env.WUU_SOURCE_ROOT = repoRoot;
 if (env.WUU_ENABLE_BROWSER === "1") {
   env.VITE_ENABLE_BROWSER = "true";
 }

--- a/desktop/scripts/env-run.cjs
+++ b/desktop/scripts/env-run.cjs
@@ -25,8 +25,13 @@ if (!command) {
 const child = spawn(command, args.slice(index + 1), {
   stdio: "inherit",
   env,
-  // Windows tool shims are .cmd batch files; only a shell can start those.
-  shell: process.platform === "win32",
+  // Windows tool shims and bare npm-script commands may resolve to .cmd
+  // files, which require cmd.exe. Native .exe/.com programs must be spawned
+  // directly so arguments such as `node -e "..."` are not re-parsed or
+  // corrupted by an extra shell (and do not trigger Node's shell+args warning).
+  shell:
+    process.platform === "win32" &&
+    !/\.(?:exe|com)$/i.test(command),
 });
 child.on("error", (error) => {
   console.error(`env-run: ${error.message}`);

--- a/desktop/scripts/prepare-dev-electron-app.cjs
+++ b/desktop/scripts/prepare-dev-electron-app.cjs
@@ -208,6 +208,7 @@ function installElectronBinary() {
 function ensureSourceElectronApp({
   sourceAppExists = () => existsSync(sourceApp),
   installElectron = installElectronBinary,
+  installerPath = electronInstallerPath,
   electronVersion = installedElectronVersion(),
 } = {}) {
   if (sourceAppExists()) return true;
@@ -219,7 +220,7 @@ function ensureSourceElectronApp({
   if (result.status !== 0) {
     throw new Error(
       `Electron ${electronVersion} install failed with status ${result.status ?? "unknown"}. `
-      + `Run the local installer directly to see the full error: node ${electronInstallerPath()}`,
+      + `Run the local installer directly to see the full error: node ${installerPath()}`,
     );
   }
   if (!sourceAppExists()) {

--- a/desktop/scripts/test-dev-launcher.cjs
+++ b/desktop/scripts/test-dev-launcher.cjs
@@ -1,6 +1,6 @@
 const assert = require("node:assert/strict");
 const { readFileSync } = require("node:fs");
-const { resolve } = require("node:path");
+const { join, resolve } = require("node:path");
 const packageJSON = require("../package.json");
 const {
   launchEnvironment,
@@ -71,15 +71,33 @@ assert.equal(
 );
 assert.equal(
   helperPathForApp("/repo/desktop/build/dev-host/Wuu Dev.app"),
-  "/repo/desktop/build/dev-host/Wuu Dev.app/Contents/Resources/bin/wuu-cua-mac",
+  join(
+    "/repo/desktop/build/dev-host/Wuu Dev.app",
+    "Contents",
+    "Resources",
+    "bin",
+    "wuu-cua-mac",
+  ),
 );
 assert.equal(
   pipHelperPathForApp("/repo/desktop/build/dev-host/Wuu Dev.app"),
-  "/repo/desktop/build/dev-host/Wuu Dev.app/Contents/Resources/bin/wuu-cua-mac-pip",
+  join(
+    "/repo/desktop/build/dev-host/Wuu Dev.app",
+    "Contents",
+    "Resources",
+    "bin",
+    "wuu-cua-mac-pip",
+  ),
 );
 assert.equal(
   speechHelperPathForApp("/repo/desktop/build/dev-host/Wuu Dev.app"),
-  "/repo/desktop/build/dev-host/Wuu Dev.app/Contents/Resources/bin/wuu-speech-mac",
+  join(
+    "/repo/desktop/build/dev-host/Wuu Dev.app",
+    "Contents",
+    "Resources",
+    "bin",
+    "wuu-speech-mac",
+  ),
 );
 assert.equal(
   sourceHashFromBuildInfo({ sourceHash: "a".repeat(64) }, () => "fallback"),
@@ -101,6 +119,8 @@ const devLauncherSource = readFileSync(resolve(__dirname, "dev.cjs"), "utf8");
 assert.doesNotMatch(devLauncherSource, /env\.WUU_ENABLE_CUA_MAC\s*=\s*["']1["']/);
 assert.match(devLauncherSource, /build-core\.cjs/);
 assert.match(devLauncherSource, /--plugins-only/);
+assert.match(devLauncherSource, /WUU_DESKTOP_USE_GO_RUN\s*=\s*["']1["']/);
+assert.match(devLauncherSource, /WUU_SOURCE_ROOT\s*=\s*repoRoot/);
 assert.equal(packageJSON.scripts["build:core"], "node scripts/build-core.cjs");
 assert.equal(
   packageJSON.scripts["build:core:win"],
@@ -228,6 +248,7 @@ assert.throws(
   () => ensureSourceElectronApp({
     sourceAppExists: () => false,
     installElectron: () => ({ status: 1 }),
+    installerPath: () => "/repo/desktop/node_modules/electron/install.js",
     electronVersion: "42.3.0",
   }),
   /status 1/,

--- a/desktop/src/main/appServerClients.test.ts
+++ b/desktop/src/main/appServerClients.test.ts
@@ -115,14 +115,14 @@ describe("appServerExitMessage", () => {
 
 describe("appServerHelperEnvironment", () => {
   it("injects packaged first-party plugin helpers and the signed macOS helper", () => {
-    const packagedBin = "/Applications/wuu.app/Contents/Resources/bin";
+    const packagedBin = join("/Applications/wuu.app/Contents/Resources", "bin");
     const available = new Set([
-      `${packagedBin}/wuu-subagent-plugin`,
-      `${packagedBin}/wuu-automation-plugin`,
-      `${packagedBin}/wuu-memory-plugin`,
-      `${packagedBin}/wuu-dream-plugin`,
-      `${packagedBin}/wuu-todo-plugin`,
-      `${packagedBin}/wuu-cua-mac`,
+      join(packagedBin, "wuu-subagent-plugin"),
+      join(packagedBin, "wuu-automation-plugin"),
+      join(packagedBin, "wuu-memory-plugin"),
+      join(packagedBin, "wuu-dream-plugin"),
+      join(packagedBin, "wuu-todo-plugin"),
+      join(packagedBin, "wuu-cua-mac"),
     ]);
     const result = appServerHelperEnvironment(
       { HOME: "/Users/test" },
@@ -131,24 +131,25 @@ describe("appServerHelperEnvironment", () => {
       "darwin",
       (path) => available.has(path),
     );
-    expect(result.WUU_SUBAGENT_PLUGIN_HELPER).toBe(`${packagedBin}/wuu-subagent-plugin`);
-    expect(result.WUU_AUTOMATION_PLUGIN_HELPER).toBe(`${packagedBin}/wuu-automation-plugin`);
-    expect(result.WUU_MEMORY_PLUGIN_HELPER).toBe(`${packagedBin}/wuu-memory-plugin`);
-    expect(result.WUU_DREAM_PLUGIN_HELPER).toBe(`${packagedBin}/wuu-dream-plugin`);
-    expect(result.WUU_TODO_PLUGIN_HELPER).toBe(`${packagedBin}/wuu-todo-plugin`);
+    expect(result.WUU_SUBAGENT_PLUGIN_HELPER).toBe(join(packagedBin, "wuu-subagent-plugin"));
+    expect(result.WUU_AUTOMATION_PLUGIN_HELPER).toBe(join(packagedBin, "wuu-automation-plugin"));
+    expect(result.WUU_MEMORY_PLUGIN_HELPER).toBe(join(packagedBin, "wuu-memory-plugin"));
+    expect(result.WUU_DREAM_PLUGIN_HELPER).toBe(join(packagedBin, "wuu-dream-plugin"));
+    expect(result.WUU_TODO_PLUGIN_HELPER).toBe(join(packagedBin, "wuu-todo-plugin"));
     expect(result.WUU_CUA_MAC_HELPER).toBe(
-      `${packagedBin}/wuu-cua-mac`,
+      join(packagedBin, "wuu-cua-mac"),
     );
   });
 
   it("uses development plugin helpers without replacing explicit overrides", () => {
+    const developmentBin = join("/source", "desktop", "build", "bin");
     const available = new Set([
-      "/source/desktop/build/bin/wuu-subagent-plugin",
-      "/source/desktop/build/bin/wuu-automation-plugin",
-      "/source/desktop/build/bin/wuu-memory-plugin",
-      "/source/desktop/build/bin/wuu-dream-plugin",
-      "/source/desktop/build/bin/wuu-todo-plugin",
-      "/source/desktop/build/bin/wuu-cua-mac",
+      join(developmentBin, "wuu-subagent-plugin"),
+      join(developmentBin, "wuu-automation-plugin"),
+      join(developmentBin, "wuu-memory-plugin"),
+      join(developmentBin, "wuu-dream-plugin"),
+      join(developmentBin, "wuu-todo-plugin"),
+      join(developmentBin, "wuu-cua-mac"),
     ]);
     const discovered = appServerHelperEnvironment(
       {},
@@ -158,10 +159,10 @@ describe("appServerHelperEnvironment", () => {
       (path) => available.has(path),
     );
     expect(discovered.WUU_TODO_PLUGIN_HELPER).toBe(
-      "/source/desktop/build/bin/wuu-todo-plugin",
+      join(developmentBin, "wuu-todo-plugin"),
     );
     expect(discovered.WUU_CUA_MAC_HELPER).toBe(
-      "/source/desktop/build/bin/wuu-cua-mac",
+      join(developmentBin, "wuu-cua-mac"),
     );
     const overridden = appServerHelperEnvironment(
       {

--- a/desktop/src/main/cuaFrameStreams.test.ts
+++ b/desktop/src/main/cuaFrameStreams.test.ts
@@ -84,8 +84,8 @@ describe("cuaFrameHelperCandidates", () => {
       "/app",
       ["/repo"],
     )).toEqual([
-      "/app/bin/wuu-cua-mac-pip",
-      "/repo/desktop/build/bin/wuu-cua-mac-pip",
+      join("/app", "bin", "wuu-cua-mac-pip"),
+      join("/repo", "desktop", "build", "bin", "wuu-cua-mac-pip"),
     ]);
   });
 
@@ -97,7 +97,7 @@ describe("cuaFrameHelperCandidates", () => {
       },
       undefined,
       [],
-    )).toEqual(["/app/bin/wuu-cua-mac-pip"]);
+    )).toEqual([join("/app", "bin", "wuu-cua-mac-pip")]);
   });
 
   it("detects aliases that resolve to the same executable file", () => {
@@ -108,11 +108,17 @@ describe("cuaFrameHelperCandidates", () => {
       const hardlink = join(root, "wuu-cua-mac-pip-hardlink");
       const copy = join(root, "wuu-cua-mac-pip-copy");
       writeFileSync(mcp, "signed helper bytes");
-      symlinkSync(mcp, symlink);
+      if (process.platform !== "win32") {
+        // Creating symlinks on Windows requires Developer Mode or elevation;
+        // hard links below exercise the same file-identity branch there.
+        symlinkSync(mcp, symlink);
+      }
       linkSync(mcp, hardlink);
       writeFileSync(copy, "signed helper bytes");
 
-      expect(isSameExecutableFile(symlink, mcp)).toBe(true);
+      if (process.platform !== "win32") {
+        expect(isSameExecutableFile(symlink, mcp)).toBe(true);
+      }
       expect(isSameExecutableFile(hardlink, mcp)).toBe(true);
       expect(isSameExecutableFile(copy, mcp)).toBe(false);
     } finally {

--- a/desktop/src/main/gitService.test.ts
+++ b/desktop/src/main/gitService.test.ts
@@ -216,6 +216,21 @@ describe("GitService commit message generation", () => {
 });
 
 describe("GitService worktree roots", () => {
+  it.skipIf(process.platform !== "win32")(
+    "accepts a known Windows worktree path with different casing",
+    () => {
+      const root = makeRepository();
+      const differentlyCasedRoot = root.toUpperCase();
+
+      expect(
+        serviceFor(root, [], [differentlyCasedRoot]).status(
+          {},
+          differentlyCasedRoot,
+        ).is_repo,
+      ).toBe(true);
+    },
+  );
+
   it("returns the same root for sibling directories in one working tree", () => {
     const root = makeRepository();
     const frontend = join(root, "frontend");
@@ -245,19 +260,22 @@ describe("GitService worktree roots", () => {
     expect(gitWorkingTreeBusy(root, [])).toBe(true);
   });
 
-  it("matches symlinked sibling paths to the same working tree", () => {
-    const root = makeRepository();
-    const frontend = join(root, "frontend");
-    const backend = join(root, "backend");
-    const alias = mkdtempSync(join(tmpdir(), "wuu-git-alias-"));
-    rmSync(alias, { recursive: true, force: true });
-    roots.push(alias);
-    mkdirSync(frontend);
-    mkdirSync(backend);
-    symlinkSync(root, alias, "dir");
+  it.skipIf(process.platform === "win32")(
+    "matches symlinked sibling paths to the same working tree",
+    () => {
+      const root = makeRepository();
+      const frontend = join(root, "frontend");
+      const backend = join(root, "backend");
+      const alias = mkdtempSync(join(tmpdir(), "wuu-git-alias-"));
+      rmSync(alias, { recursive: true, force: true });
+      roots.push(alias);
+      mkdirSync(frontend);
+      mkdirSync(backend);
+      symlinkSync(root, alias, "dir");
 
-    expect(gitWorkingTreeBusy(frontend, [join(alias, "backend")])).toBe(true);
-  });
+      expect(gitWorkingTreeBusy(frontend, [join(alias, "backend")])).toBe(true);
+    },
+  );
 
   it("allows a running thread in an independent linked worktree", () => {
     const root = makeRepository();

--- a/desktop/src/main/gitService.ts
+++ b/desktop/src/main/gitService.ts
@@ -113,7 +113,7 @@ export class GitService {
     }
     const normalizedRoot = resolve(requestedRoot);
     const allowedRoots = [context.cwd, ...this.getKnownThreadCwds()].map((cwd) => resolve(cwd));
-    if (!allowedRoots.includes(normalizedRoot)) {
+    if (!allowedRoots.some((allowedRoot) => sameGitWorktreeRoot(normalizedRoot, allowedRoot))) {
       throw new Error("Git working directory is not associated with the current project");
     }
     return { ...context, cwd: normalizedRoot };

--- a/desktop/src/main/legacyCliLink.test.ts
+++ b/desktop/src/main/legacyCliLink.test.ts
@@ -18,27 +18,33 @@ afterEach(async () => {
 });
 
 describe("removeLegacyDesktopCliLink", () => {
-  it("removes a link to the core bundled by an older desktop app", async () => {
-    const source = "/Applications/wuu.app/Contents/Resources/bin/wuu";
-    await symlink(source, join(installDir, "wuu"));
+  it.skipIf(process.platform === "win32")(
+    "removes a link to the core bundled by an older desktop app",
+    async () => {
+      const source = "/Applications/wuu.app/Contents/Resources/bin/wuu";
+      await symlink(source, join(installDir, "wuu"));
 
-    await expect(
-      removeLegacyDesktopCliLink({ homeDir: home, platform: "darwin" }),
-    ).resolves.toBe(true);
-    await expect(readlink(join(installDir, "wuu"))).rejects.toThrow();
-  });
+      await expect(
+        removeLegacyDesktopCliLink({ homeDir: home, platform: "darwin" }),
+      ).resolves.toBe(true);
+      await expect(readlink(join(installDir, "wuu"))).rejects.toThrow();
+    },
+  );
 
-  it("preserves an independently installed CLI link", async () => {
-    const source = join(home, "go", "bin", "wuu");
-    await mkdir(join(home, "go", "bin"), { recursive: true });
-    await writeFile(source, "independent cli");
-    await symlink(source, join(installDir, "wuu"));
+  it.skipIf(process.platform === "win32")(
+    "preserves an independently installed CLI link",
+    async () => {
+      const source = join(home, "go", "bin", "wuu");
+      await mkdir(join(home, "go", "bin"), { recursive: true });
+      await writeFile(source, "independent cli");
+      await symlink(source, join(installDir, "wuu"));
 
-    await expect(
-      removeLegacyDesktopCliLink({ homeDir: home, platform: "darwin" }),
-    ).resolves.toBe(false);
-    await expect(readlink(join(installDir, "wuu"))).resolves.toBe(source);
-  });
+      await expect(
+        removeLegacyDesktopCliLink({ homeDir: home, platform: "darwin" }),
+      ).resolves.toBe(false);
+      await expect(readlink(join(installDir, "wuu"))).resolves.toBe(source);
+    },
+  );
 
   it("preserves a real CLI binary", async () => {
     await writeFile(join(installDir, "wuu"), "independent cli");

--- a/desktop/src/main/projects.test.ts
+++ b/desktop/src/main/projects.test.ts
@@ -242,6 +242,20 @@ describe("ProjectManager project store migration", () => {
 });
 
 describe("ProjectManager runtime context availability", () => {
+  it.skipIf(process.platform !== "win32")(
+    "deduplicates Windows project paths case-insensitively",
+    async () => {
+      const projectPath = await createProjectDir("case-insensitive");
+      const manager = new ProjectManager();
+
+      const first = manager.add(projectPath);
+      const second = manager.add(projectPath.toUpperCase());
+
+      expect(second.projects).toHaveLength(1);
+      expect(second.projects[0]?.id).toBe(first.projects[0]?.id);
+    },
+  );
+
   it("registers a workspace without changing the active runtime context", async () => {
     const activePath = await createProjectDir("active");
     const addedPath = await createProjectDir("added");

--- a/desktop/src/main/projects.ts
+++ b/desktop/src/main/projects.ts
@@ -115,7 +115,7 @@ export class ProjectManager {
     // folder (via relocate, not re-add) keeps the same identity and its
     // workspace state + conversation history stay connected.
     const existingIndex = this.store.projects.findIndex(
-      (project) => resolve(project.path) === resolvedPath,
+      (project) => sameProjectPath(project.path, resolvedPath),
     );
     const existing =
       existingIndex >= 0 ? this.store.projects[existingIndex] : undefined;
@@ -219,6 +219,14 @@ export class ProjectManager {
   private save(): void {
     writeProjectStoreFile(projectStorePath(), this.store);
   }
+}
+
+function sameProjectPath(left: string, right: string): boolean {
+  const resolvedLeft = resolve(left);
+  const resolvedRight = resolve(right);
+  return process.platform === "win32"
+    ? resolvedLeft.toLowerCase() === resolvedRight.toLowerCase()
+    : resolvedLeft === resolvedRight;
 }
 
 function projectStorePath(): string {

--- a/desktop/src/main/speechRecognition.test.ts
+++ b/desktop/src/main/speechRecognition.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SpeechRecognitionService } from "./speechRecognition";
 
@@ -129,7 +130,7 @@ describe("SpeechRecognitionService", () => {
 
     await expect(status).resolves.toBe("denied");
     expect(spawnHelper).toHaveBeenCalledWith(
-      "/resources/bin/wuu-speech-mac",
+      join("/resources", "bin", "wuu-speech-mac"),
       ["--authorization-status"],
     );
   });

--- a/desktop/src/main/terminalSessions.test.ts
+++ b/desktop/src/main/terminalSessions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { resolve } from "node:path";
 import type {
   RuntimeContext,
   TerminalSessionEvent,
@@ -50,16 +51,12 @@ describe("resolveTerminalCwd", () => {
     const params: TerminalSessionStartParams = {
       cwd: "/repo/worktrees/fork-1/project",
     };
-    expect(resolveTerminalCwd(context, params)).toBe(
-      "/repo/worktrees/fork-1/project",
-    );
+    expect(resolveTerminalCwd(context, params)).toBe(resolve(params.cwd!));
   });
 
   it("normalizes a relative override to an absolute path", () => {
     const params: TerminalSessionStartParams = { cwd: "relative/worktree" };
-    const resolved = resolveTerminalCwd(context, params);
-    expect(resolved.endsWith("/relative/worktree")).toBe(true);
-    expect(resolved.startsWith("/")).toBe(true);
+    expect(resolveTerminalCwd(context, params)).toBe(resolve(params.cwd!));
   });
 
   it("ignores an empty-string override and falls back to the runtime context", () => {

--- a/desktop/src/main/wuuCommand.test.ts
+++ b/desktop/src/main/wuuCommand.test.ts
@@ -46,7 +46,8 @@ describe("resolveWuuCommand (issue #8: never run a workspace-local core)", () =>
 
   it("prefers the packaged app-owned binary over PATH", () => {
     const resourcesPath = mkdtempSync(join(tmpdir(), "wuu-resources-"));
-    const binary = join(resourcesPath, "bin", "wuu-core");
+    const binaryName = process.platform === "win32" ? "wuu-core.exe" : "wuu-core";
+    const binary = join(resourcesPath, "bin", binaryName);
     mkdirSync(join(resourcesPath, "bin"), { recursive: true });
     writeFileSync(binary, "#!/bin/sh\n");
     expect(resolveWuuCommand({}, "/repo/wuu", undefined, resourcesPath)).toEqual({
@@ -54,6 +55,23 @@ describe("resolveWuuCommand (issue #8: never run a workspace-local core)", () =>
       args: [],
       cwd: "/repo/wuu",
     });
+  });
+
+  it("only selects a core binary for the current platform", () => {
+    const resourcesPath = mkdtempSync(join(tmpdir(), "wuu-resources-platform-"));
+    const bin = join(resourcesPath, "bin");
+    mkdirSync(bin, { recursive: true });
+    const unixBinary = join(bin, "wuu-core");
+    const windowsBinary = join(bin, "wuu-core.exe");
+    writeFileSync(unixBinary, "unix");
+    writeFileSync(windowsBinary, "windows");
+
+    expect(
+      resolveWuuCommand({}, "/repo/wuu", undefined, resourcesPath, "win32"),
+    ).toMatchObject({ command: windowsBinary });
+    expect(
+      resolveWuuCommand({}, "/repo/wuu", undefined, resourcesPath, "linux"),
+    ).toMatchObject({ command: unixBinary });
   });
 
   it("prefers the explicit desktop-core override over go run", () => {

--- a/desktop/src/main/wuuCommand.ts
+++ b/desktop/src/main/wuuCommand.ts
@@ -31,6 +31,7 @@ export function resolveWuuCommand(
   workdir: string,
   sourceRoot: string | undefined,
   resourcesPath?: string,
+  platform: NodeJS.Platform = process.platform,
 ): WuuCommand {
   if (env.WUU_DESKTOP_CORE) {
     return { command: env.WUU_DESKTOP_CORE, args: [], cwd: workdir };
@@ -38,24 +39,21 @@ export function resolveWuuCommand(
   if (sourceRoot && env.WUU_DESKTOP_USE_GO_RUN === "1") {
     return { command: "go", args: ["run", "./cmd/wuu"], cwd: sourceRoot };
   }
-  const packaged = resolvePackagedWuuCore(resourcesPath);
+  const packaged = resolvePackagedWuuCore(resourcesPath, platform);
   if (packaged) {
     return { command: packaged, args: [], cwd: workdir };
   }
   throw new Error("wuu desktop core is missing; reinstall the desktop app");
 }
 
-function resolvePackagedWuuCore(resourcesPath: string | undefined): string | undefined {
+function resolvePackagedWuuCore(
+  resourcesPath: string | undefined,
+  platform: NodeJS.Platform,
+): string | undefined {
   if (!resourcesPath) {
     return undefined;
   }
-  for (const candidate of [
-    join(resourcesPath, "bin", "wuu-core"),
-    join(resourcesPath, "bin", "wuu-core.exe"),
-  ]) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return undefined;
+  const binary = platform === "win32" ? "wuu-core.exe" : "wuu-core";
+  const candidate = join(resourcesPath, "bin", binary);
+  return existsSync(candidate) ? candidate : undefined;
 }

--- a/desktop/src/renderer/ui/layers/ProductionUILayers.test.ts
+++ b/desktop/src/renderer/ui/layers/ProductionUILayers.test.ts
@@ -84,7 +84,7 @@ describe("production UI layer ownership", () => {
   it("limits direct React portals to specialized rendering boundaries", () => {
     const owners = rendererSources(RENDERER_ROOT)
       .filter((path) => readFileSync(path, "utf8").includes("createPortal"))
-      .map((path) => relative(RENDERER_ROOT, path))
+      .map((path) => relative(RENDERER_ROOT, path).replaceAll("\\", "/"))
       .sort();
 
     expect(owners).toEqual([...INTENTIONAL_DIRECT_PORTAL_OWNERS].sort());


### PR DESCRIPTION
## Summary

Harden the Windows desktop development, testing, and packaging workflows. This change fixes several Windows-specific issues around process launching, executable resolution, path handling, and test behavior, and adds a dedicated Windows CI check for the desktop app.

## Changes

- add a Windows desktop CI job that:
  - runs desktop tests and type checking
  - builds the Windows desktop package
  - verifies `wuu.exe` and `wuu-core.exe` are present
  - checks the packaged core executable can run successfully
- make local desktop development consistently use the source-owned Go core on Windows
- avoid routing native Windows executables through `cmd.exe`, reducing argument parsing issues and shell warnings
- resolve the correct packaged core binary by platform, including `wuu-core.exe` on Windows
- treat Windows project and Git worktree paths case-insensitively where appropriate
- update desktop tests and mocks to handle Windows path separators, executable names, and filesystem behavior

## Test plan

- [x] Added or updated unit tests
- [ ] `go test ./...`
- [ ] `cd desktop && npm test`
- [ ] `cd desktop && npm run typecheck`
- [ ] `cd desktop && npm run pack:win`

## Risk and rollback

- Risk level: medium
- This PR touches desktop process launching, Windows path handling, and packaging behavior.
- Cross-platform branches are preserved, but the change affects a few core desktop execution paths on Windows.
- Rollback by reverting this PR.

## Linked issues / docs

N/A