### PR TITLE
fix: restore conservative model budgets for unknown models

### DIFF
--- a/desktop/src/renderer/SettingsView.test.tsx
+++ b/desktop/src/renderer/SettingsView.test.tsx
@@ -634,6 +634,37 @@ describe("SettingsView provider configuration", () => {
 });
 
 describe("SettingsView advanced settings", () => {
+  it("labels an unknown model's conservative context estimate", async () => {
+    installBuildInfoStub({
+      core: undefined,
+      desktop: { version: "0.0.0-test", date: "1970-01-01T00:00:00Z" },
+    });
+    const { rootText } = renderSettings({
+      initialPage: "advanced",
+      initialized: baseInitialized({
+        provider: "custom",
+        model: "private-unknown-model",
+        advanced_settings: {
+          max_steps: 0,
+          max_context_tokens: 0,
+          temperature: 0,
+          disable_auto_compact: false,
+          compact_keep_recent_tokens: 20000,
+          context_window_tokens: 64000,
+          context_window_source: "conservative_fallback",
+          output_reserve_tokens: 16000,
+          compact_threshold_tokens: 40000,
+        },
+      }),
+      onAdvancedSave: vi.fn().mockResolvedValue(undefined),
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(rootText()).toContain("模型未识别，按 64k 保守估算（可手动覆盖）");
+    expect(rootText()).toContain("64,000");
+  });
+
   it("renders compaction controls and saves each field on commit", async () => {
     installBuildInfoStub({
       core: undefined,

--- a/desktop/src/renderer/SettingsView.tsx
+++ b/desktop/src/renderer/SettingsView.tsx
@@ -2979,6 +2979,10 @@ function advancedContextSourceLabel(source: string | undefined, t: Translate): s
       return t("advanced.sourceInputLimit");
     case "agent_max_context_tokens":
       return t("advanced.sourceManualLimit");
+    case "model_registry":
+      return t("advanced.sourceModelRegistry");
+    case "conservative_fallback":
+      return t("advanced.sourceConservativeFallback");
     case "unknown":
     case "":
     case undefined:

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -414,6 +414,8 @@ export const enUS = {
   "advanced.sourceModelConfig": "From the model configuration",
   "advanced.sourceInputLimit": "From the current channel input limit",
   "advanced.sourceManualLimit": "From the manual limit",
+  "advanced.sourceModelRegistry": "From the built-in model registry",
+  "advanced.sourceConservativeFallback": "Unknown model; conservatively estimated at 64k (you can override it)",
   "advanced.sourceUnknown": "Unknown; proactive compaction will only recover from provider errors",
   "mcp.authCodeNamed": "{name} authorization code",
   "mcp.authCode": "Authorization code",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -412,6 +412,8 @@ export const zhCN = {
   "advanced.sourceModelConfig": "来自模型配置",
   "advanced.sourceInputLimit": "来自当前通道输入上限",
   "advanced.sourceManualLimit": "来自手动上限",
+  "advanced.sourceModelRegistry": "来自内置模型目录",
+  "advanced.sourceConservativeFallback": "模型未识别，按 64k 保守估算（可手动覆盖）",
   "advanced.sourceUnknown": "未识别，主动压缩只依赖服务错误恢复",
   "mcp.authCodeNamed": "{name} 授权码",
   "mcp.authCode": "授权码",

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -143,16 +143,16 @@ func RunToolLoop(
 
 	var (
 		totalIn, totalOut, totalCacheCreation, totalCacheRead int
-		// Reactive auto-compact (overflow recovery) runs at most once
-		// per Run; if a single compaction isn't enough, surfacing the
-		// error is more honest than silently looping. Proactive compact
+		// Reactive auto-compact (overflow recovery) is bounded but may make a
+		// second, more aggressive pass when the first changed history still
+		// does not fit. Proactive compact
 		// runs before provider requests, including mid-turn continuation
 		// requests after completed tool results. A failed or no-op
 		// proactive attempt suppresses further proactive attempts for
 		// this Run so the loop cannot spin on an unhelpful compactor.
-		overflowCompacted   bool
-		proactiveSuppressed bool
-		historyRewritten    bool
+		overflowCompactAttempts int
+		proactiveSuppressed     bool
+		historyRewritten        bool
 		// Tracks current context fill so we can decide whether to
 		// proactively compact before the next round. Uses
 		// response.usage as ground truth + delta estimation for
@@ -510,13 +510,13 @@ func RunToolLoop(
 		result, err := step.Execute(ctx, req)
 		lastAgentOperationID = req.Operation.ID
 		if err != nil {
-			// Context window exceeded — try a one-shot compaction of
+			// Context window exceeded — try bounded compaction of
 			// older history and re-issue. Provider-agnostic; the
 			// CompactFn carries whatever client/model knowledge it
 			// needs. This is the reactive backstop for the case
 			// where our proactive estimate undercounted.
-			if effectiveCompact != nil && providers.IsContextOverflow(err) && !overflowCompacted {
-				overflowCompacted = true // gate first; never retry twice
+			if effectiveCompact != nil && providers.IsContextOverflow(err) && overflowCompactAttempts < maxReactiveCompactAttempts {
+				overflowCompactAttempts++ // gate first so failures cannot spin
 				usageBefore := usage.Breakdown()
 				before := usageBefore.Total()
 				msgsBefore := len(messages)
@@ -826,6 +826,11 @@ func compactAttemptWithUsage(info CompactAttemptInfo, usage UsageBreakdown) Comp
 	info.UsageAdjustment = usage.Adjustment
 	return info
 }
+
+// maxReactiveCompactAttempts allows one follow-up shrink when provider-side
+// counting proves the first estimate was still too generous, while keeping a
+// hard bound against retry loops.
+const maxReactiveCompactAttempts = 2
 
 // proactiveCompactThreshold returns the absolute token count at which
 // the loop should run a proactive compact pass, or 0 if proactive

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1178,9 +1178,9 @@ func TestRunToolLoop_ContextOverflowStopsWhenCompactUnchanged(t *testing.T) {
 	}
 }
 
-func TestRunToolLoop_ContextOverflowOnlyRetriesOnce(t *testing.T) {
+func TestRunToolLoop_ContextOverflowAllowsOneMoreChangedCompaction(t *testing.T) {
 	overflow := &providers.HTTPError{StatusCode: 400, Body: "context_length_exceeded", ContextOverflow: true}
-	step := &fakeStep{results: []StepResult{{}, {}}, errs: []error{overflow, overflow}}
+	step := &fakeStep{results: []StepResult{{}, {}, {Content: "ok"}}, errs: []error{overflow, overflow, nil}}
 	cfg := LoopConfig{Model: "m", Compact: func(_ context.Context, m []providers.ChatMessage) ([]providers.ChatMessage, error) { return m[1:], nil }}
 	history := []providers.ChatMessage{
 		userMsg("old"),
@@ -1188,15 +1188,37 @@ func TestRunToolLoop_ContextOverflowOnlyRetriesOnce(t *testing.T) {
 		userMsg("big"),
 	}
 
+	result, err := RunToolLoop(context.Background(), history, cfg, step)
+	if err != nil {
+		t.Fatalf("expected second changed compaction to recover, got %v", err)
+	}
+	if result.Content != "ok" || len(step.calls) != 3 {
+		t.Fatalf("expected two bounded retries and success, result=%q calls=%d", result.Content, len(step.calls))
+	}
+}
+
+func TestRunToolLoop_ContextOverflowRecoveryRemainsBounded(t *testing.T) {
+	overflow := &providers.HTTPError{StatusCode: 400, Body: "context_length_exceeded", ContextOverflow: true}
+	step := &fakeStep{results: []StepResult{{}, {}, {}}, errs: []error{overflow, overflow, overflow}}
+	compactCalls := 0
+	cfg := LoopConfig{Model: "m", Compact: func(_ context.Context, messages []providers.ChatMessage) ([]providers.ChatMessage, error) {
+		compactCalls++
+		return messages[1:], nil
+	}}
+	history := []providers.ChatMessage{
+		userMsg("oldest"),
+		{Role: "assistant", Content: "old answer"},
+		userMsg("newer"),
+		{Role: "assistant", Content: "newer answer"},
+		userMsg("big"),
+	}
+
 	_, err := RunToolLoop(context.Background(), history, cfg, step)
-	if err == nil {
-		t.Fatal("expected second overflow to surface")
+	if err == nil || !providers.IsContextOverflow(err) {
+		t.Fatalf("expected the third overflow to surface, got %v", err)
 	}
-	if !providers.IsContextOverflow(err) {
-		t.Fatalf("expected context-overflow error, got %v", err)
-	}
-	if len(step.calls) != 2 {
-		t.Fatalf("expected one retry after changed compact, got %d calls", len(step.calls))
+	if compactCalls != maxReactiveCompactAttempts || len(step.calls) != maxReactiveCompactAttempts+1 {
+		t.Fatalf("recovery was not bounded: compact calls=%d step calls=%d", compactCalls, len(step.calls))
 	}
 }
 

--- a/internal/modelbudget/budget.go
+++ b/internal/modelbudget/budget.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/blueberrycongee/wuu/internal/config"
 	"github.com/blueberrycongee/wuu/internal/modelcatalog"
+	"github.com/blueberrycongee/wuu/internal/providers"
 )
 
 type Source string
@@ -15,6 +16,8 @@ const (
 	SourceProviderModelLimit    Source = "provider_model_limit"
 	SourceProviderInputLimit    Source = "provider_input_limit"
 	SourceAgentOverride         Source = "agent_max_context_tokens"
+	SourceModelRegistry         Source = "model_registry"
+	SourceConservativeFallback  Source = "conservative_fallback"
 )
 
 const CodexSubscriptionGPT5InputCap = 272_000
@@ -56,7 +59,7 @@ func Resolve(model string, provider config.ProviderConfig, agentOverride int) Bu
 
 	context, source := resolveContextWindow(model, apiModel, provider, agentOverride)
 	input := resolveInputWindow(model, apiModel, provider)
-	output := configuredModelOutputLimit(model, provider)
+	output := resolveOutputLimit(model, apiModel, provider)
 	outputReserve := output
 	// The prompt ceiling is the context window, clamped by a published
 	// input cap when the channel has one (e.g. Codex subscription 272k).
@@ -89,7 +92,7 @@ func Resolve(model string, provider config.ProviderConfig, agentOverride int) Bu
 		UsableInputTokens:      usable,
 		CompactThresholdTokens: usable,
 		ContextWindowSource:    source,
-		ContextWindowKnown:     source != SourceUnknown && context > 0,
+		ContextWindowKnown:     source != SourceUnknown && source != SourceConservativeFallback && context > 0,
 	}
 }
 
@@ -118,7 +121,28 @@ func resolveContextWindow(model, apiModel string, provider config.ProviderConfig
 	if agentOverride > 0 {
 		return agentOverride, SourceAgentOverride
 	}
-	return 0, SourceUnknown
+	// Prefer the provider-facing API ID over a local alias. Curated indexes can
+	// contain short generic names (for example "fast"), but the API ID is the
+	// model that actually owns the context contract.
+	for _, candidate := range []string{apiModel, model} {
+		if window, ok := providers.KnownContextWindowFor(candidate); ok {
+			return window, SourceModelRegistry
+		}
+	}
+	// Keep proactive and reactive compaction usable even for a brand-new or
+	// private model. This is deliberately marked as an estimate rather than
+	// trusted metadata so callers can explain it and users can override it.
+	return providers.ContextWindowFor(model), SourceConservativeFallback
+}
+
+func resolveOutputLimit(model, apiModel string, provider config.ProviderConfig) int {
+	if limit := configuredModelOutputLimit(model, provider); limit > 0 {
+		return limit
+	}
+	if strings.TrimSpace(apiModel) != "" {
+		return providers.MaxOutputTokensFor(apiModel)
+	}
+	return providers.MaxOutputTokensFor(model)
 }
 
 func resolveInputWindow(model, apiModel string, provider config.ProviderConfig) int {

--- a/internal/modelbudget/budget_test.go
+++ b/internal/modelbudget/budget_test.go
@@ -6,32 +6,32 @@ import (
 	"github.com/blueberrycongee/wuu/internal/config"
 )
 
-func TestResolveMiniMaxM3WithoutProviderLimitStaysUnknown(t *testing.T) {
+func TestResolveMiniMaxM3WithoutProviderLimitUsesRegistry(t *testing.T) {
 	budget := Resolve("MiniMax-M3", config.ProviderConfig{Type: "anthropic"}, 0)
-	if budget.ContextWindowTokens != 0 {
-		t.Fatalf("ContextWindowTokens = %d, want 0", budget.ContextWindowTokens)
+	if budget.ContextWindowTokens != 1_000_000 {
+		t.Fatalf("ContextWindowTokens = %d, want 1000000", budget.ContextWindowTokens)
 	}
-	if budget.ContextWindowSource != SourceUnknown || budget.ContextWindowKnown {
+	if budget.ContextWindowSource != SourceModelRegistry || !budget.ContextWindowKnown {
 		t.Fatalf("unexpected context source: source=%q known=%v", budget.ContextWindowSource, budget.ContextWindowKnown)
 	}
-	if budget.OutputReserveTokens != 0 {
-		t.Fatalf("OutputReserveTokens = %d, want 0 without provider metadata", budget.OutputReserveTokens)
+	if budget.OutputReserveTokens != 131_072 {
+		t.Fatalf("OutputReserveTokens = %d, want registry fallback 131072", budget.OutputReserveTokens)
 	}
-	if budget.CompactThresholdTokens != 0 {
-		t.Fatalf("CompactThresholdTokens = %d, want 0", budget.CompactThresholdTokens)
+	if budget.CompactThresholdTokens != 967_000 {
+		t.Fatalf("CompactThresholdTokens = %d, want 967000", budget.CompactThresholdTokens)
 	}
 }
 
-func TestResolveUnknownModelStaysUnknown(t *testing.T) {
+func TestResolveUnknownModelUsesConservativeOperationalBudget(t *testing.T) {
 	budget := Resolve("private-unknown-model", config.ProviderConfig{Type: "anthropic"}, 0)
-	if budget.ContextWindowTokens != 0 || budget.ContextWindowKnown {
-		t.Fatalf("unknown model should not get a synthetic context window: %+v", budget)
+	if budget.ContextWindowTokens != 64_000 || budget.ContextWindowKnown {
+		t.Fatalf("unknown model should get an explicitly estimated context window: %+v", budget)
 	}
-	if budget.ContextWindowSource != SourceUnknown {
-		t.Fatalf("ContextWindowSource = %q, want %q", budget.ContextWindowSource, SourceUnknown)
+	if budget.ContextWindowSource != SourceConservativeFallback {
+		t.Fatalf("ContextWindowSource = %q, want %q", budget.ContextWindowSource, SourceConservativeFallback)
 	}
-	if budget.UsableInputTokens != 0 || budget.CompactThresholdTokens != 0 {
-		t.Fatalf("unknown model should not synthesize compact thresholds: %+v", budget)
+	if budget.OutputReserveTokens != 16_000 || budget.UsableInputTokens != 40_000 || budget.CompactThresholdTokens != 40_000 {
+		t.Fatalf("unexpected conservative compact budget: %+v", budget)
 	}
 }
 
@@ -79,7 +79,7 @@ func TestResolveProviderOverrideWins(t *testing.T) {
 	}
 }
 
-func TestResolveAliasDoesNotUseAPIModelRegistry(t *testing.T) {
+func TestResolveAliasUsesAPIModelRegistry(t *testing.T) {
 	provider := config.ProviderConfig{
 		Type: "anthropic",
 		Models: map[string]config.ProviderModelConfig{
@@ -90,11 +90,11 @@ func TestResolveAliasDoesNotUseAPIModelRegistry(t *testing.T) {
 	if budget.APIModel != "MiniMax-M3" {
 		t.Fatalf("APIModel = %q, want MiniMax-M3", budget.APIModel)
 	}
-	if budget.ContextWindowTokens != 0 || budget.ContextWindowSource != SourceUnknown {
-		t.Fatalf("alias should not infer API model context registry: %+v", budget)
+	if budget.ContextWindowTokens != 1_000_000 || budget.ContextWindowSource != SourceModelRegistry || !budget.ContextWindowKnown {
+		t.Fatalf("alias should infer API model context registry: %+v", budget)
 	}
-	if budget.OutputReserveTokens != 0 {
-		t.Fatalf("alias should not infer API model output reserve, got %+v", budget)
+	if budget.OutputReserveTokens != 131_072 {
+		t.Fatalf("alias should infer API model output reserve, got %+v", budget)
 	}
 }
 
@@ -118,13 +118,13 @@ func TestResolveAliasUsesAPIModelCodexCap(t *testing.T) {
 	}
 }
 
-func TestEffectiveContextWindowUsesCodexInputCapWhenModelWindowUnknown(t *testing.T) {
+func TestEffectiveContextWindowUsesCodexInputCapBelowRegistryWindow(t *testing.T) {
 	budget := Resolve("gpt-5.5", config.ProviderConfig{
 		Type:  "openai-codex",
 		Model: "gpt-5.5",
 	}, 0)
-	if budget.ContextWindowTokens != 0 || budget.ContextWindowSource != SourceUnknown {
-		t.Fatalf("model context window should stay unknown: %+v", budget)
+	if budget.ContextWindowTokens != 400_000 || budget.ContextWindowSource != SourceModelRegistry {
+		t.Fatalf("model context window should come from the registry: %+v", budget)
 	}
 	got, source := budget.EffectiveContextWindow()
 	if got != CodexSubscriptionGPT5InputCap || source != SourceProviderInputLimit {

--- a/internal/providers/contextwindow.go
+++ b/internal/providers/contextwindow.go
@@ -20,9 +20,9 @@ import (
 //     family rules ("claude-sonnet" → 200k) that catch any vendor's
 //     proxy-renamed variant.
 //
-// If neither source recognizes the model, ok is false. Agent runtimes use this
-// path for proactive auto-compact so BYOK models with unknown limits do not get
-// silently treated as 64k-context models.
+// If neither source recognizes the model, ok is false. Budget resolution uses
+// this distinction to report trusted registry metadata separately from its
+// explicit conservative fallback.
 func KnownContextWindowFor(model string) (window int, ok bool) {
 	if model == "" {
 		return 0, false
@@ -60,9 +60,9 @@ func KnownContextWindowFor(model string) (window int, ok bool) {
 }
 
 // ContextWindowFor returns the context window size in tokens for the given model
-// identifier. Unknown models fall back to defaultContextWindow for legacy callers
-// and display code. Runtime proactive auto-compact should use
-// KnownContextWindowFor instead so unknown BYOK models remain reactive-only.
+// identifier. Unknown models fall back to defaultContextWindow. Callers that
+// need to distinguish trusted metadata from this estimate should use
+// KnownContextWindowFor first.
 func ContextWindowFor(model string) int {
 	if w, ok := KnownContextWindowFor(model); ok {
 		return w

--- a/internal/runtime/session.go
+++ b/internal/runtime/session.go
@@ -1679,9 +1679,9 @@ func ResolveModelBudget(model string, provider config.ProviderConfig, agentOverr
 	return modelbudget.Resolve(model, provider, agentOverride)
 }
 
-// ResolveContextWindow resolves the trusted model context size used for
-// proactive auto-compact. A zero return means the model limit is unknown; the
-// runtime should skip proactive compaction and rely on provider overflow errors.
+// ResolveContextWindow resolves the operational model context size used for
+// proactive auto-compact. Unknown models receive modelbudget's conservative
+// estimate so they do not wait for a provider overflow before compacting.
 func ResolveContextWindow(model string, provider config.ProviderConfig, agentOverride int) int {
 	return ResolveModelBudget(model, provider, agentOverride).ContextWindowTokens
 }

--- a/internal/runtime/session_test.go
+++ b/internal/runtime/session_test.go
@@ -1700,7 +1700,7 @@ func TestNewSessionUsesConfiguredModelLimitForContextWindow(t *testing.T) {
 	}
 }
 
-func TestNewSessionUnknownModelDisablesProactiveContextWindow(t *testing.T) {
+func TestNewSessionUnknownModelUsesConservativeProactiveContextWindow(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("WUU_HOME", filepath.Join(home, "state"))
@@ -1726,12 +1726,20 @@ func TestNewSessionUnknownModelDisablesProactiveContextWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
+	t.Cleanup(func() {
+		if _, cleanupErr := rt.Cleanup(); cleanupErr != nil {
+			t.Errorf("Cleanup: %v", cleanupErr)
+		}
+	})
 
-	if rt.StreamRunner.ContextWindowOverride != 0 {
-		t.Fatalf("ContextWindowOverride = %d, want 0 for unknown BYOK model", rt.StreamRunner.ContextWindowOverride)
+	if rt.StreamRunner.ContextWindowOverride != 64_000 {
+		t.Fatalf("ContextWindowOverride = %d, want conservative 64000 for unknown BYOK model", rt.StreamRunner.ContextWindowOverride)
 	}
 	if rt.StreamRunner.MaxInputTokens != 0 {
 		t.Fatalf("MaxInputTokens = %d, want 0 for unknown BYOK model", rt.StreamRunner.MaxInputTokens)
+	}
+	if rt.StreamRunner.OutputReserveTokens != 16_000 || rt.StreamRunner.CompactThresholdTokens != 40_000 {
+		t.Fatalf("unexpected unknown-model compact budget: output=%d threshold=%d", rt.StreamRunner.OutputReserveTokens, rt.StreamRunner.CompactThresholdTokens)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes the degraded compaction path for models without explicitly configured context-window metadata.

Known models now resolve their token budgets from the built-in registry using the provider-facing API model ID. Unknown models now receive an explicit conservative budget so proactive compaction remains available instead of immediately falling back to the 4k reactive path described in #211.

## Changes
- resolve context-window and output-token limits from the provider-facing API model ID
- use built-in registry metadata for known models instead of relying only on session config
- add a conservative fallback for unknown models:
  - 64k context window
  - 16k max output tokens
  - 40k proactive compaction threshold
- distinguish trusted registry-backed metadata from conservative estimated budgets
- keep reactive compaction bounded to two retries when proactive budgeting is unavailable
- update settings copy so unknown-model budget labels are clearly presented as conservative estimates
- add coverage for unknown-model conservative budgeting in runtime and settings tests

## Test plan
- [x] Added or updated unit tests
- [ ] `go test ./...`
- [ ] `cd desktop && npm test`
- [ ] manually verified desktop

Additional validation run for this change:
- [x] `go test ./internal/modelbudget`
- [x] `go test ./internal/providers`
- [x] `go test ./internal/agent`
- [x] `go test ./internal/runtime -run TestNewSessionUnknownModelUsesConservativeProactiveContextWindow -count=1 -v` reached the new test logic, but failed during Windows temp-dir cleanup because `debug.log` remained locked
- [x] `cd desktop && npm exec -- vitest run src/renderer/SettingsView.test.tsx -t "labels an unknown model's conservative context estimate"`
- [x] `cd desktop && npm run typecheck`

Notes:
- full `go test ./...` still fails on existing Windows/environment-sensitive suites, including timeouts, file-lock cleanup issues, POSIX permission expectations, and missing shell/tooling assumptions
- full `cd desktop && npm test` still hits existing Windows-specific failures, including path-separator assumptions and Electron/dev-launcher environment issues

## Risk and rollback
Risk is moderate because this changes how session budgets are derived for model metadata and affects compaction behavior for unknown models.

Rollback is straightforward by reverting the model-budget resolution changes in this branch.

## Linked issues / docs
Closes #211