### PR TITLE
feat(desktop): teach first-time long-press clear unread

### DIFF
--- a/desktop/src/renderer/AppModeSwitch.test.tsx
+++ b/desktop/src/renderer/AppModeSwitch.test.tsx
@@ -1,0 +1,219 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WuuDesktopApi } from "../shared/protocol";
+import {
+  AppModeSwitch,
+  CLEAR_UNREAD_HINT_SEEN_KEY,
+} from "./AppModeSwitch";
+import { I18nProvider, setActiveLocale } from "./i18n";
+import { WuuUIRoot } from "./ui/layers/UILayerHost";
+
+type ObserverCallback = IntersectionObserverCallback;
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+
+  readonly callback: ObserverCallback;
+  readonly observed = new Set<Element>();
+
+  constructor(callback: ObserverCallback) {
+    this.callback = callback;
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+
+  disconnect(): void {
+    this.observed.clear();
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  emit(isIntersecting: boolean): void {
+    const entries = [...this.observed].map((target) => ({
+      isIntersecting,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      target,
+    })) as IntersectionObserverEntry[];
+    this.callback(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+let container: HTMLDivElement;
+let root: Root | null = null;
+let originalIntersectionObserver: typeof IntersectionObserver | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setActiveLocale("zh-CN");
+  window.wuu = {
+    initialLanguagePreference: "zh-CN",
+    initialSystemLocale: "zh-CN",
+  } as unknown as WuuDesktopApi;
+  window.localStorage.clear();
+  FakeIntersectionObserver.instances = [];
+  originalIntersectionObserver = window.IntersectionObserver;
+  window.IntersectionObserver =
+    FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container.remove();
+  document
+    .querySelectorAll('[data-wuu-component="sidebar-clear-unread-hint"]')
+    .forEach((node) => node.remove());
+  if (originalIntersectionObserver) {
+    window.IntersectionObserver = originalIntersectionObserver;
+  } else {
+    Reflect.deleteProperty(window, "IntersectionObserver");
+  }
+  delete (window as unknown as { wuu?: unknown }).wuu;
+  setActiveLocale("zh-CN");
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function renderSwitch(
+  props: Partial<React.ComponentProps<typeof AppModeSwitch>> = {},
+): void {
+  act(() => {
+    root ??= createRoot(container);
+    root.render(
+      <WuuUIRoot>
+        <I18nProvider>
+          <AppModeSwitch
+            mode="harness"
+            collaborationEnabled={false}
+            unreadCount={props.unreadCount ?? 0}
+            unreadViewOpen={props.unreadViewOpen}
+            onClearUnread={props.onClearUnread}
+            onToggleUnreadView={props.onToggleUnreadView}
+            {...props}
+          />
+        </I18nProvider>
+      </WuuUIRoot>,
+    );
+  });
+
+  const button = container.querySelector(".sidebar-notifications-button");
+  if (button instanceof HTMLElement) {
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue({
+      x: 240,
+      y: 48,
+      left: 240,
+      top: 48,
+      right: 272,
+      bottom: 80,
+      width: 32,
+      height: 32,
+      toJSON: () => ({}),
+    } as DOMRect);
+  }
+}
+
+function hintLayer(): HTMLElement | null {
+  return document.querySelector('[data-wuu-component="sidebar-clear-unread-hint"]');
+}
+
+function latestObserver(): FakeIntersectionObserver | undefined {
+  return FakeIntersectionObserver.instances.at(-1);
+}
+
+function showBell(visible = true): void {
+  const observer = latestObserver();
+  if (!observer) {
+    throw new Error("expected an IntersectionObserver instance");
+  }
+  act(() => {
+    observer.emit(visible);
+  });
+}
+
+describe("AppModeSwitch clear-unread hint", () => {
+  it("shows a one-time tip when unread first appears and the bell is visible", () => {
+    renderSwitch({ unreadCount: 0 });
+    expect(hintLayer()).toBeNull();
+
+    renderSwitch({ unreadCount: 2 });
+    expect(hintLayer()).toBeNull();
+
+    showBell(true);
+    expect(hintLayer()?.textContent).toContain("长按铃铛，可一次清除全部未读");
+  });
+
+  it("hides the tip while the sidebar bell is off-canvas", () => {
+    renderSwitch({ unreadCount: 1 });
+    showBell(true);
+    expect(hintLayer()).not.toBeNull();
+
+    showBell(false);
+    expect(hintLayer()).toBeNull();
+
+    showBell(true);
+    expect(hintLayer()).not.toBeNull();
+  });
+
+  it("dismisses permanently when the tip close button is pressed", () => {
+    renderSwitch({ unreadCount: 1 });
+    showBell(true);
+    const dismiss = hintLayer()?.querySelector(
+      ".sidebar-clear-unread-hint-dismiss",
+    );
+    expect(dismiss).not.toBeNull();
+
+    act(() => {
+      dismiss?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(hintLayer()).toBeNull();
+    expect(window.localStorage.getItem(CLEAR_UNREAD_HINT_SEEN_KEY)).toBe("true");
+
+    renderSwitch({ unreadCount: 3 });
+    showBell(true);
+    expect(hintLayer()).toBeNull();
+  });
+
+  it("marks the tip seen after a successful long-press clear", () => {
+    const onClearUnread = vi.fn();
+    renderSwitch({ unreadCount: 1, onClearUnread });
+    showBell(true);
+    expect(hintLayer()).not.toBeNull();
+
+    const button = container.querySelector(".sidebar-notifications-button");
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button?.dispatchEvent(
+        new MouseEvent("pointerdown", { bubbles: true, button: 0 }),
+      );
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(onClearUnread).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(CLEAR_UNREAD_HINT_SEEN_KEY)).toBe("true");
+    expect(hintLayer()).toBeNull();
+  });
+
+  it("stays hidden once the tip has already been seen", () => {
+    window.localStorage.setItem(CLEAR_UNREAD_HINT_SEEN_KEY, "true");
+    renderSwitch({ unreadCount: 4 });
+    expect(latestObserver()).toBeUndefined();
+    expect(hintLayer()).toBeNull();
+  });
+});

--- a/desktop/src/renderer/AppModeSwitch.tsx
+++ b/desktop/src/renderer/AppModeSwitch.tsx
@@ -1,15 +1,37 @@
-import { Bell } from "lucide-react";
+import { Bell, X } from "lucide-react";
 import {
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
 import { useI18n } from "./i18n";
+import { UILayerPortal } from "./ui/layers/UILayerHost";
 
 export type AppMode = "harness" | "collaboration";
 const CLEAR_UNREAD_HOLD_MS = 600;
+export const CLEAR_UNREAD_HINT_SEEN_KEY = "wuu.desktop.clearUnreadHintSeen";
+const HINT_VIEWPORT_MARGIN = 8;
+const HINT_TRIGGER_GAP = 8;
+
+function loadClearUnreadHintSeen(): boolean {
+  try {
+    return window.localStorage.getItem(CLEAR_UNREAD_HINT_SEEN_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function persistClearUnreadHintSeen(): void {
+  try {
+    window.localStorage.setItem(CLEAR_UNREAD_HINT_SEEN_KEY, "true");
+  } catch {
+    // A blocked or full localStorage should not keep the tip looping forever.
+  }
+}
 
 export function AppModeSwitch({
   mode,
@@ -34,7 +56,21 @@ export function AppModeSwitch({
   const holdTimerRef = useRef<number | undefined>(undefined);
   const longPressTriggeredRef = useRef(false);
   const keyboardPressRef = useRef<string | undefined>(undefined);
+  const bellButtonRef = useRef<HTMLButtonElement | null>(null);
+  const hintLayerRef = useRef<HTMLDivElement | null>(null);
   const [holding, setHolding] = useState(false);
+  const [clearUnreadHintSeen, setClearUnreadHintSeen] = useState(loadClearUnreadHintSeen);
+  const [bellVisible, setBellVisible] = useState(false);
+  const [hintPosition, setHintPosition] = useState<CSSProperties | null>(null);
+  const hintEligible =
+    !readOnly && mode === "harness" && unreadCount > 0 && !clearUnreadHintSeen;
+  const showClearUnreadHint = hintEligible && bellVisible;
+
+  function markClearUnreadHintSeen(): void {
+    if (clearUnreadHintSeen) return;
+    persistClearUnreadHintSeen();
+    setClearUnreadHintSeen(true);
+  }
 
   function cancelHold(): void {
     if (holdTimerRef.current !== undefined) {
@@ -52,6 +88,7 @@ export function AppModeSwitch({
       holdTimerRef.current = undefined;
       longPressTriggeredRef.current = true;
       setHolding(false);
+      markClearUnreadHintSeen();
       onClearUnread?.();
     }, CLEAR_UNREAD_HOLD_MS);
   }
@@ -61,6 +98,74 @@ export function AppModeSwitch({
       window.clearTimeout(holdTimerRef.current);
     }
   }, []);
+
+  useEffect(() => {
+    if (!hintEligible) {
+      setBellVisible(false);
+      return;
+    }
+
+    const trigger = bellButtonRef.current;
+    const Observer = window.IntersectionObserver;
+    if (!trigger || typeof Observer !== "function") {
+      // Without IntersectionObserver, keep the tip tied to an actually
+      // laid-out bell so a collapsed/off-canvas rail cannot orphan it.
+      const rect = trigger?.getBoundingClientRect();
+      setBellVisible(Boolean(trigger && rect && rect.width > 0 && rect.height > 0));
+      return;
+    }
+
+    const observer = new Observer(
+      ([entry]) => {
+        setBellVisible(Boolean(entry?.isIntersecting && entry.intersectionRatio > 0));
+      },
+      { threshold: [0, 0.01, 1] },
+    );
+    observer.observe(trigger);
+    return () => observer.disconnect();
+  }, [hintEligible]);
+
+  useLayoutEffect(() => {
+    if (!showClearUnreadHint) {
+      setHintPosition(null);
+      return;
+    }
+
+    const updatePosition = (): void => {
+      const trigger = bellButtonRef.current;
+      const layer = hintLayerRef.current;
+      if (!trigger || !layer) return;
+
+      const rect = trigger.getBoundingClientRect();
+      // Wait for a real layout box before anchoring. Visibility itself is
+      // owned by IntersectionObserver so a collapsed sidebar can hide the
+      // tip without this geometry check fighting it.
+      if (rect.width <= 0 || rect.height <= 0) {
+        setHintPosition({ visibility: "hidden" });
+        return;
+      }
+
+      const tip = layer.getBoundingClientRect();
+      const maxLeft = Math.max(
+        HINT_VIEWPORT_MARGIN,
+        window.innerWidth - tip.width - HINT_VIEWPORT_MARGIN,
+      );
+      const preferredLeft = rect.right - tip.width;
+      const left = Math.min(Math.max(preferredLeft, HINT_VIEWPORT_MARGIN), maxLeft);
+      const belowTop = rect.bottom + HINT_TRIGGER_GAP;
+      const aboveTop = rect.top - tip.height - HINT_TRIGGER_GAP;
+      const fitsBelow = belowTop + tip.height <= window.innerHeight - HINT_VIEWPORT_MARGIN;
+      const top = fitsBelow
+        ? belowTop
+        : Math.max(HINT_VIEWPORT_MARGIN, aboveTop);
+
+      setHintPosition({ left, top, visibility: "visible" });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    return () => window.removeEventListener("resize", updatePosition);
+  }, [showClearUnreadHint, t]);
 
   function handleNotificationPointerDown(event: ReactPointerEvent<HTMLButtonElement>): void {
     if (event.button !== 0) return;
@@ -125,40 +230,67 @@ export function AppModeSwitch({
         )}
       </div>
       {!readOnly && mode === "harness" ? (
-        <button
-          className="sidebar-notifications-button"
-          type="button"
-          aria-label={t("sidebar.notificationsHint", { count: unreadCount })}
-          aria-pressed={unreadViewOpen}
-          title={t("sidebar.notificationsHint", { count: unreadCount })}
-          data-has-unread={unreadCount > 0 || undefined}
-          data-holding={holding || undefined}
-          onPointerDown={handleNotificationPointerDown}
-          onPointerUp={cancelHold}
-          onPointerCancel={() => {
-            cancelHold();
-            longPressTriggeredRef.current = false;
-          }}
-          onPointerLeave={handleNotificationPointerLeave}
-          onKeyDown={handleNotificationKeyDown}
-          onKeyUp={handleNotificationKeyUp}
-          onBlur={() => {
-            cancelHold();
-            keyboardPressRef.current = undefined;
-            longPressTriggeredRef.current = false;
-          }}
-          onClick={(event) => {
-            if (longPressTriggeredRef.current) {
-              event.preventDefault();
+        <>
+          <button
+            ref={bellButtonRef}
+            className="sidebar-notifications-button"
+            type="button"
+            aria-label={t("sidebar.notificationsHint", { count: unreadCount })}
+            aria-pressed={unreadViewOpen}
+            title={t("sidebar.notificationsHint", { count: unreadCount })}
+            data-has-unread={unreadCount > 0 || undefined}
+            data-holding={holding || undefined}
+            onPointerDown={handleNotificationPointerDown}
+            onPointerUp={cancelHold}
+            onPointerCancel={() => {
+              cancelHold();
               longPressTriggeredRef.current = false;
-              return;
-            }
-            onToggleUnreadView?.();
-          }}
-        >
-          <Bell aria-hidden="true" />
-          <span className="sidebar-notifications-dot" aria-hidden="true" />
-        </button>
+            }}
+            onPointerLeave={handleNotificationPointerLeave}
+            onKeyDown={handleNotificationKeyDown}
+            onKeyUp={handleNotificationKeyUp}
+            onBlur={() => {
+              cancelHold();
+              keyboardPressRef.current = undefined;
+              longPressTriggeredRef.current = false;
+            }}
+            onClick={(event) => {
+              if (longPressTriggeredRef.current) {
+                event.preventDefault();
+                longPressTriggeredRef.current = false;
+                return;
+              }
+              onToggleUnreadView?.();
+            }}
+          >
+            <Bell aria-hidden="true" />
+            <span className="sidebar-notifications-dot" aria-hidden="true" />
+          </button>
+          {showClearUnreadHint ? (
+            <UILayerPortal layer="popover">
+              <div
+                ref={hintLayerRef}
+                className="sidebar-clear-unread-hint"
+                data-wuu-component="sidebar-clear-unread-hint"
+                data-wuu-layer="popover"
+                role="status"
+                style={hintPosition ?? { visibility: "hidden" }}
+              >
+                <p className="sidebar-clear-unread-hint-copy">
+                  {t("sidebar.clearUnreadHint")}
+                </p>
+                <button
+                  className="sidebar-clear-unread-hint-dismiss"
+                  type="button"
+                  aria-label={t("common.close")}
+                  onClick={markClearUnreadHintSeen}
+                >
+                  <X aria-hidden="true" />
+                </button>
+              </div>
+            </UILayerPortal>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/desktop/src/renderer/AppSidebar.tsx
+++ b/desktop/src/renderer/AppSidebar.tsx
@@ -1609,7 +1609,6 @@ export function AppSidebar({
                 <span>{t("sidebar.attentionEmpty")}</span>
               </div>
             ) : null}
-            <p className="sidebar-unread-hint">{t("sidebar.clearUnreadHint")}</p>
           </section>
         ) : (
           <>

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -347,7 +347,7 @@ export const enUS = {
   "sidebar.unreadConversations": "Unread",
   "sidebar.unreadEmpty": "No unread conversations",
   "sidebar.attentionEmpty": "No conversations need attention",
-  "sidebar.clearUnreadHint": "Press and hold the bell to mark unread conversations as read",
+  "sidebar.clearUnreadHint": "Press and hold the bell to clear all unread",
   "sidebar.collaborationEmpty": "No channels yet",
   "sidebar.conversations": "Conversations",
   "sidebar.settings": "Settings",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -345,7 +345,7 @@ export const zhCN = {
   "sidebar.unreadConversations": "未读",
   "sidebar.unreadEmpty": "没有未读会话",
   "sidebar.attentionEmpty": "没有需要关注的会话",
-  "sidebar.clearUnreadHint": "长按铃铛将未读会话标为已读",
+  "sidebar.clearUnreadHint": "长按铃铛，可一次清除全部未读",
   "sidebar.collaborationEmpty": "还没有频道",
   "sidebar.conversations": "对话",
   "sidebar.settings": "设置",

--- a/desktop/src/renderer/styles/sidebar.css
+++ b/desktop/src/renderer/styles/sidebar.css
@@ -1073,13 +1073,76 @@
   opacity: 0.52;
 }
 
-.sidebar-unread-hint {
-  margin: auto 0 0;
-  padding: 16px 8px 10px;
-  color: var(--ink-muted);
-  font-size: 10px;
+.sidebar-clear-unread-hint {
+  position: fixed;
+  z-index: 2147483000;
+  display: grid;
+  max-width: min(220px, calc(100vw - 16px));
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 6px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 10px;
+  padding: 8px 8px 8px 10px;
+  background: var(--surface-3);
+  box-shadow: var(--shadow-pop);
+  color: var(--ink);
+  pointer-events: auto;
+  animation: sidebar-clear-unread-hint-in 140ms ease-out;
+}
+
+.sidebar-clear-unread-hint-copy {
+  margin: 0;
+  font-size: 12px;
   line-height: 1.4;
-  text-align: center;
+}
+
+.sidebar-clear-unread-hint-dismiss {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border-radius: 6px;
+  padding: 0;
+  background: transparent;
+  color: var(--ink-muted);
+  cursor: pointer;
+  line-height: 0;
+}
+
+.sidebar-clear-unread-hint-dismiss:hover,
+.sidebar-clear-unread-hint-dismiss:focus-visible {
+  background: var(--sidebar-glass-hover);
+  color: var(--ink-strong);
+}
+
+.sidebar-clear-unread-hint-dismiss:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.sidebar-clear-unread-hint-dismiss svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2;
+}
+
+@keyframes sidebar-clear-unread-hint-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-clear-unread-hint {
+    animation: none;
+  }
 }
 
 .collaboration-sidebar-tools {


### PR DESCRIPTION
## Summary
- Show a one-time tip beside the sidebar bell when unread first appears.
- Hide the tip while the sidebar/bell is off-canvas; remember dismissal or a successful hold-to-clear.

## Test plan
- [x] `npm test -- --run src/renderer/AppModeSwitch.test.tsx`
- [ ] Manually verify: first unread shows tip; collapsing sidebar hides tip; dismiss/long-press clears it permanently.