### PR TITLE
feat(desktop): Linux WCO window chrome

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -782,7 +782,11 @@ function syncNativeThemeSource(): void {
 // it follows the stored theme.
 function windowBackgroundColor(): string {
   if (process.platform === "darwin") return DEFAULT_WINDOW_BACKGROUND;
-  return resolvedThemeIsDark() ? DARK_WINDOW_BACKGROUND : DEFAULT_WINDOW_BACKGROUND;
+  if (resolvedThemeIsDark()) return DARK_WINDOW_BACKGROUND;
+  // Linux WCO paints over the page fill; match renderer --paper (#ffffff)
+  // so the control strip does not sit on the warmer #f6f6f4 window fill.
+  if (process.platform === "linux") return "#ffffff";
+  return DEFAULT_WINDOW_BACKGROUND;
 }
 
 // The window-chrome contract per platform: macOS hides the titlebar and
@@ -829,7 +833,8 @@ function nonMacTitleBarOverlay(): Electron.TitleBarOverlay {
   return {
     // Track the themed window fill so the button strip reads as part of
     // the titlebar; symbol colors mirror the --ink text tokens.
-    color: dark ? DARK_WINDOW_BACKGROUND : DEFAULT_WINDOW_BACKGROUND,
+    // On Linux this is --paper white in light theme (see windowBackgroundColor).
+    color: windowBackgroundColor(),
     symbolColor: dark ? "#e4e6e8" : "#1f2328",
     height: WINDOWS_TITLEBAR_OVERLAY_HEIGHT,
   };

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -787,13 +787,24 @@ function windowBackgroundColor(): string {
 
 // The window-chrome contract per platform: macOS hides the titlebar and
 // leaves the traffic lights over the renderer's drag strip (top-left);
-// Windows hides it and lets Chromium draw min/max/close as a controls
-// overlay (top-right — the renderer reserves that corner through the
-// --window-controls-inset-* variables). Anything else keeps the native
-// frame, which needs no in-page reservation at all.
+// Windows and Linux hide it and let Chromium draw min/max/close as a
+// controls overlay (top-right — the renderer reserves that corner through
+// the --window-controls-inset-* variables). Other platforms keep the
+// native frame, which needs no in-page reservation at all.
+//
+// Linux WCO has had DE/Wayland regressions in Electron; set
+// WUU_LINUX_NATIVE_CHROME=1 to force the previous native-frame path.
+function usesWindowControlsOverlay(): boolean {
+  if (process.platform === "win32") return true;
+  if (process.platform === "linux") {
+    return process.env.WUU_LINUX_NATIVE_CHROME !== "1";
+  }
+  return false;
+}
+
 function windowFrameOptions(): Pick<
   BrowserWindowConstructorOptions,
-  "titleBarStyle" | "trafficLightPosition" | "titleBarOverlay"
+  "titleBarStyle" | "trafficLightPosition" | "titleBarOverlay" | "autoHideMenuBar"
 > {
   if (process.platform === "darwin") {
     return {
@@ -801,16 +812,19 @@ function windowFrameOptions(): Pick<
       trafficLightPosition: { x: 18, y: 15 },
     };
   }
-  if (process.platform === "win32") {
+  if (usesWindowControlsOverlay()) {
     return {
       titleBarStyle: "hidden",
-      titleBarOverlay: windowsTitleBarOverlay(),
+      titleBarOverlay: nonMacTitleBarOverlay(),
+      // Linux otherwise shows an always-visible in-window menu strip under
+      // the (now hidden) system titlebar; Alt still reveals the menu.
+      ...(process.platform === "linux" ? { autoHideMenuBar: true } : {}),
     };
   }
   return {};
 }
 
-function windowsTitleBarOverlay(): Electron.TitleBarOverlay {
+function nonMacTitleBarOverlay(): Electron.TitleBarOverlay {
   const dark = resolvedThemeIsDark();
   return {
     // Track the themed window fill so the button strip reads as part of
@@ -824,7 +838,7 @@ function windowsTitleBarOverlay(): Electron.TitleBarOverlay {
 // The theme preference is app-global state owned by the main process.
 // Every themed content window (main + pop-outs) registers here; a theme
 // change — explicit preference or an OS dark-mode flip while on
-// "system" — re-pushes the native chrome (Windows controls overlay,
+// "system" — re-pushes the native chrome (Win/Linux controls overlay,
 // non-macOS window background fill) to all of them, and the new
 // preference is broadcast so each renderer re-applies data-theme.
 // macOS skips both: its vibrancy material and transparent fill are
@@ -841,7 +855,7 @@ function registerThemedChromeWindow(win: BrowserWindow): void {
 function syncThemedWindowChrome(): void {
   if (process.platform === "darwin") return;
   const background = windowBackgroundColor();
-  const overlay = process.platform === "win32" ? windowsTitleBarOverlay() : undefined;
+  const overlay = usesWindowControlsOverlay() ? nonMacTitleBarOverlay() : undefined;
   for (const win of themedChromeWindows) {
     if (win.isDestroyed()) continue;
     // Windows redraws the controls overlay only when told to, and every

--- a/desktop/src/renderer/ChannelView.test.tsx
+++ b/desktop/src/renderer/ChannelView.test.tsx
@@ -1611,7 +1611,8 @@ describe("ChannelView", () => {
     expect(editor.querySelector<HTMLDetailsElement>("details")?.open).toBe(false);
     act(() => editor.querySelector<HTMLButtonElement>('button[aria-label="编辑头像"]')?.click());
     expect(editor.querySelector(".agent-avatar-creator")).not.toBeNull();
-    act(() => editor.querySelector<HTMLButtonElement>('button[aria-label="云朵"]')?.click());
+    // Mascot accessories replaced the old blobatar "cloud" preset.
+    act(() => editor.querySelector<HTMLButtonElement>('button[aria-label="小叶子"]')?.click());
     act(() => editor.querySelector<HTMLButtonElement>('button[aria-label="编辑头像"]')?.click());
     expect(editor.querySelector(".agent-avatar-creator")).toBeNull();
     act(() => setInputValue(editor.querySelector<HTMLTextAreaElement>("textarea")!, "Reviews the interface"));
@@ -1632,7 +1633,7 @@ describe("ChannelView", () => {
       agent_id: "agent-1",
       name: "Reasoner",
       role: "Reviews the interface",
-      avatar_key: expect.stringContaining(":cloud:"),
+      avatar_key: expect.stringMatching(/^mascot-v1:.+:leaf:\d+$/),
       avatar_image: "",
       provider_override: "openai",
       model_override: "gpt-reasoner",

--- a/desktop/src/renderer/i18n/resources/en-US.ts
+++ b/desktop/src/renderer/i18n/resources/en-US.ts
@@ -58,7 +58,7 @@ export const enUS = {
   "agentOnboarding.appearance": "Appearance",
   "agentOnboarding.shape": "Shape",
   "agentOnboarding.shape.round": "Round",
-  "agentOnboarding.shape.rounded-square": "Rounded square",
+  "agentOnboarding.shape.roundedSquare": "Rounded square",
   "agentOnboarding.shape.capsule": "Capsule",
   "agentOnboarding.shape.triangle": "Triangle",
   "agentOnboarding.shape.diamond": "Diamond",

--- a/desktop/src/renderer/i18n/resources/zh-CN.ts
+++ b/desktop/src/renderer/i18n/resources/zh-CN.ts
@@ -56,7 +56,7 @@ export const zhCN = {
   "agentOnboarding.appearance": "外观",
   "agentOnboarding.shape": "形状",
   "agentOnboarding.shape.round": "圆形",
-  "agentOnboarding.shape.rounded-square": "圆角方形",
+  "agentOnboarding.shape.roundedSquare": "圆角方形",
   "agentOnboarding.shape.capsule": "胶囊形",
   "agentOnboarding.shape.triangle": "三角形",
   "agentOnboarding.shape.diamond": "菱形",

--- a/desktop/src/renderer/styles/base.css
+++ b/desktop/src/renderer/styles/base.css
@@ -346,10 +346,11 @@
   --turn-warning-text-strong: #7a4e0d;
 
   /* Top corners the OS window chrome owns: macOS puts the traffic lights
-   * on the left, Windows draws its controls overlay on the right. Strips
-   * that run along the window top consume these through max(<neutral
-   * padding>, var(...)), so each platform only reserves the corner it
-   * actually loses and the other side collapses to the neutral value. */
+   * on the left, Windows/Linux draw the controls overlay on the right.
+   * Strips that run along the window top consume these through
+   * max(<neutral padding>, var(...)), so each platform only reserves the
+   * corner it actually loses and the other side collapses to the neutral
+   * value. */
   --window-controls-inset-left: 86px;
   --window-controls-inset-right: 0px;
   font-feature-settings: "kern", "liga", "calt", "palt";
@@ -372,10 +373,17 @@
   );
 }
 
-/* Linux keeps the native frame — the OS titlebar sits above the page, so
- * neither corner needs an in-page reservation. */
+/* Linux uses the same Window Controls Overlay as Windows when WCO is
+ * enabled (titleBarStyle hidden + titleBarOverlay). Reserve the top-right
+ * overlay; titlebar-area-width is what Chromium leaves of the top strip.
+ * If WUU_LINUX_NATIVE_CHROME=1 forces the native frame, these insets stay
+ * harmless because the OS titlebar sits above the page. */
 :root[data-platform="linux"] {
   --window-controls-inset-left: 0px;
+  --window-controls-inset-right: max(
+    138px,
+    calc(100vw - env(titlebar-area-width, 100vw))
+  );
 }
 
 * {


### PR DESCRIPTION
## Summary
- Linux joins the Windows Window Controls Overlay path (`titleBarStyle: hidden` + `titleBarOverlay`) instead of keeping the native frame.
- Renderer reserves the top-right overlay inset on `data-platform="linux"` the same way as Windows.
- `autoHideMenuBar` on Linux hides the always-visible in-window menu (Alt still reveals it).
- Escape hatch: `WUU_LINUX_NATIVE_CHROME=1` restores the previous native-frame behavior (Electron Linux WCO has had DE/Wayland regressions).

## Test plan
- [x] `npm run typecheck` in `desktop`
- [x] `npm run dev` on Linux: no system titlebar / File menu strip; overlay controls top-right on onboarding
- [ ] Spot-check GNOME and KDE (X11 + Wayland) for overlay button visibility
- [ ] Confirm `WUU_LINUX_NATIVE_CHROME=1` restores native frame + visible menu
- [ ] Confirm macOS / Windows chrome unchanged